### PR TITLE
Markdown the MIT and Creative Commons license links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 Copyright 2011 Khan Academy
 
-The exercise framework is MIT licensed.  
-http://en.wikipedia.org/wiki/MIT_License
+The exercise framework is [MIT licensed](http://en.wikipedia.org/wiki/MIT_License).
 
-The exercises are under a Creative Commons by-nc-sa license.  
-http://en.wikipedia.org/wiki/Creative_Commons_licenses
+The exercises are under a [Creative Commons by-nc-sa license](http://en.wikipedia.org/wiki/Creative_Commons_licenses).
 
 ## Exercise Framework
 


### PR DESCRIPTION
Migrate to Markdown links instead of putting the links under the license text lines.
