### PR TITLE
fix for Issue33: MathJax doesn't work in Safari

### DIFF
--- a/utils/math.js
+++ b/utils/math.js
@@ -385,7 +385,7 @@ scriptWait(function( scriptLoaded ) {
 		"HTML-CSS": {\
 			scale: 88\
 		}\
-	});';
+	});MathJax.Hub.Startup.onload();';
 
 	document.documentElement.appendChild( script );
 });


### PR DESCRIPTION
because loading MathJax dynamically bypasses the onload event, we need to manually tell MathJax to 'start'
