### PR TITLE
handle one-off plurals efficiently / problem-specific hints

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -361,11 +361,17 @@ function makeProblem() {
 		// Clone the hints and add them into their area
 		var hints = exercise.children(".hints").clone();
 		
-		// Extract any problem-specific hints
-		problem.find(".hints").remove().children().each(function() {
-			// Replace the hint placeholders
-			hints.find("." + this.className).replaceWith( this );
-		});
+		// Extract any problem-specific hints.  If there are no global hints,
+		// use the problem-specific ones in their entirety.
+		if ( hints.length ) {
+			problem.find(".hints").remove().children().each(function() {
+				// Replace the hint placeholders
+				hints.find("." + this.className).replaceWith( this );
+			});
+		} else {
+			hints = problem.find(".hints").appendTo(exercise);
+		}
+			
 		
 		hints
 			// Hide all the hints

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -172,15 +172,20 @@ function initRandom() {
 		// - plural(NUMBER, singular, plural): 
 		//		- return "NUMBER word"
 		plural: (function() {
+			var one_offs = {
+				quiz: 'quizzes'
+			};
+
 			var pluralizeWord = function(word) {
 				// determine if our word is all caps.  If so, we'll need to
 				// re-capitalize at the end
 				var isUpperCase = (word.toUpperCase() == word);
+				var one_off = one_offs[ word.toLowerCase() ];
 
-				if ( /[^aeiou]y/i.test( word ) ) {
+				if ( one_off ) {
+					word = one_off;
+				} else if ( /[^aeiou]y/i.test( word ) ) {
 					word = word.replace(/y$/i, "ies");
-				} else if ( word == "quiz" ) {
-					word += "zes";
 				} else if ( /[sxz]$/i.test( word ) || /[bcfhjlmnqsvwxyz]h/.test( word ) ) {
 					word += "es";
 				} else {


### PR DESCRIPTION
just a small tweak to make it easy to handle one-off pluralizations.

Edit:
Still learning the pull-request system. This pull-request now also includes a second change... I wanted to offer a completely different hintset for each problem. Now, if you don't specify a global hint section, but do specify problem-specific sections, it does a wholesale substitution (no need to futz with class names).
