### PR TITLE
if no global hints, use problem specific hints in their entirety

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -298,12 +298,21 @@ function makeProblem() {
 
 		// Clone the hints and add them into their area
 		var hints = exercise.children(".hints").clone();
-		
-		// Extract any problem-specific hints
-		problem.find(".hints").remove().children().each(function() {
-			// Replace the hint placeholders
-			hints.find("." + this.className).replaceWith( this );
-		});
+		var problemHints = problem.find(".hints");
+ 
+		if ( !hints.length || hints.is(":empty") ) {
+			
+			// there is no global hints section (or it's empty).  Just grab
+			// the problem-specific hints section in its entirety
+			hints = problemHints;
+		} else {
+			
+			// Extract any problem-specific hints
+			problem.find(".hints").remove().children().each(function() {
+				// Replace the hint placeholders
+				hints.find("." + this.className).replaceWith( this );
+			});
+		}
 		
 		hints
 			// Hide all the hints


### PR DESCRIPTION
There are some problems that simply need their own set of hints.  If no `hints` section exists (or is empty), just use the problem-specific hint section (no classname-based substitution).
