### PR TITLE
More sophisticated template inheritance, fixes issue #2

### DIFF
--- a/utils/math.js
+++ b/utils/math.js
@@ -237,11 +237,11 @@ jQuery.fn.extend({
 			this.children().filter( jQuery.tmplFilter );
 			return;
 		
-		// If we're in an exercise then we only want the main var block
+		// If we're in an exercise, then reset VARS
 		} else if ( this.is(".exercise") ) {
-			vars = this.children(".vars");
 			VARS = {};
-		
+			return;
+
 		// Otherwise we're in a problem
 		} else {
 			vars = this.find(".vars");
@@ -328,7 +328,7 @@ jQuery.extend({
 		
 		return true;
 	},
-	
+
 	getVAR: function( elem ) {
 		// If it's a list, grab a random one out of it
 		if ( elem.nodeName && elem.nodeName.toLowerCase() === "ul" ) {

--- a/utils/template-inheritance.js
+++ b/utils/template-inheritance.js
@@ -1,0 +1,83 @@
+jQuery.fn.extend({
+	tmplApply: function( options ) {
+		options = options || {};
+		var attribute = options.attribute || "class",
+			defaultApply = options.defaultApply || "replace";
+
+		var parent = {};
+		jQuery( this ).each( function () {
+			var name = jQuery( this ).attr( attribute );
+
+			if ( name ) {
+				if ( name in parent ) {
+					var apply = jQuery.tmplApplyMethods[ jQuery( this ).data( "apply" ) || defaultApply ];
+
+					apply.call( parent[ name ], this );
+
+					jQuery( this ).removeAttr( "data-apply" );
+				} else {
+					parent[ name ] = this;
+				}
+			}
+		} );
+		return this;
+	}
+});
+
+jQuery.extend({
+	// These methods should be called with context being the parent
+	// and first argument being the child.
+	tmplApplyMethods: {
+		// Removes both the parent and the child
+		remove: function() {
+			jQuery( this ).remove();
+			jquery( elem ).remove();
+		},
+		// Replaces the parent with the child
+		replace: function( elem ) {
+			jQuery( this ).replaceWith( elem );
+		},
+		// Replaces the parent with the child's content. Useful when
+		// needed to replace an element without introducing additional
+		// wrappers.
+		splice: function( elem ) {
+			jQuery( this ).replaceWith( jQuery( elem ).contents() );
+		},
+		// Appends the child element to the parent element
+		append: function( elem ) {
+			jQuery( this ).append( elem );
+		},
+		// Appends the child element's contents to the parent element.
+		appendContents: function( elem ) {
+			jQuery( this ).append( jQuery( elem ).contents() );
+			jQuery( elem ).remove();
+		},
+		// Prepends the child element to the parent.
+		prepend: function( elem ) {
+			jQuery( this ).prepend( elem );
+		},
+		// Prepends the child element's contents to the parent element.
+		prependContents: function( elem ) {
+			jQuery( this ).prepend( jQuery( elem ).contents() );
+			jQuery( elem ).remove();
+		},
+		// Insert child before the parent.
+		before: function( elem ) {
+			jQuery( this ).before( elem );
+		},
+		// Insert child's contents before the parent.
+		beforeContents: function( elem ) {
+			jQuery( this ).before( jQuery( elem ).contents() );
+			jQuery( elem ).remove();
+		},
+		// Insert child after the parent.
+		after: function( elem ) {
+			jQuery( this ).after( elem );
+		},
+		// Insert child's contents after the parent.
+		afterContents: function( elem ) {
+			jQuery( this ).after( jQuery( elem ).contents() );
+			jQuery( elem ).remove();
+		}
+	},
+});


### PR DESCRIPTION
Re: Issue #2 - Add Inheritance for Problems/Questions

Adds more sophisticated template inheritance as described in the wiki under [Template Inheritance](/Khan/khan-exercises/wiki/Template-Inheritance).
- The current vars behavior is preserved. 
- The hints behavior is mostly preserved - problem hints no longer just replace, but will also append.
- Inheritance can now be multiple levels deep
- Templating is namespaced to the problem top level (.question, .solution, .hints, .vars). When templating exists outside of a namespace, it will be applied to the first section with a match.

Possibly confusing things I can see with this (but I think are exceptions to general use case):
- Using a mix of un-namespaced templating as well as a namespaced data-apply="appendContent" can be confusing because un-namespaced templating is always executed after all namespaced templates.
- There are no multiple parents.
