### PR TITLE
Update templating to use ids, have a predictable order, and migrate some exercises to new templating system

### DIFF
--- a/exercises/age_word_problems.html
+++ b/exercises/age_word_problems.html
@@ -6,8 +6,6 @@
 </head>
 <body>
 	<div class="exercise">
-	<div class="vars">
-	</div>
 
 	<div class="problems">
 		<div id="solve-older-1">

--- a/exercises/average_word_problems.html
+++ b/exercises/average_word_problems.html
@@ -6,8 +6,6 @@
 </head>
 <body>
 	<div class="exercise">
-	<div class="vars">
-	</div>
 
 	<div class="problems">
 		<div>

--- a/exercises/limits_1.html
+++ b/exercises/limits_1.html
@@ -74,8 +74,8 @@
 					<li><code><var>randRangeNonZero(-3, 3)</var></code></li>
 					<li><code><var>randRangeNonZero(-3, 3)</var></code></li>
 				</ul>
-				<div class="hints">
-					<p class="final">The limit as we approach from the left doesn't match the limit as we approach from the right, so <code>\lim_{x\to<var>a</var>}</code> doesn't exist.</p>
+				<div class="hints" data-apply="appendContents">
+					<p id="final">The limit as we approach from the left doesn't match the limit as we approach from the right, so <code>\lim_{x\to<var>a</var>}</code> doesn't exist.</p>
 				</div>
 			</div>
 			<div>
@@ -181,7 +181,7 @@
 					line([a, 0], [a, r_limtoa]);
 				</div>
 			</div>
-			<p class="final">So <code>\lim_{x\to<var>a</var>} = <var>limtoa</var></code></p>
+			<p id="final">So <code>\lim_{x\to<var>a</var>} = <var>limtoa</var></code></p>
 		</div>
 	</div>
 </body>

--- a/exercises/pythagorean_theorem_1.html
+++ b/exercises/pythagorean_theorem_1.html
@@ -54,11 +54,11 @@
 				<li><code><var>formattedSquareRootOf(floor(AB2 / 1.5))</var></code></li>
 			</ul>
 
-			<div class="hints">
-				<p class="vardef">We want to find <code>c</code>; let <code>a = <var>BC</var></code> and <code>b = <var>AC</var></code>.</p>
-				<p class="solsq">So <code>c^2 = <var>BC</var>^2 + <var>AC</var>^2 = <var>AB2</var></code>.</p>
-				<p class="sol">Then, <code>c = \sqrt{<var>AB2</var>}</code>.</p>
-				<p class="solsim" data-if="squareRootCanSimplify(AB2)">Simplifying the radical gives <code>c = <var>formattedSquareRootOf(AB2)</var>.</code></p>
+			<div class="hints" data-apply="appendContents">
+				<p id="vardef">We want to find <code>c</code>; let <code>a = <var>BC</var></code> and <code>b = <var>AC</var></code>.</p>
+				<p id="solsq">So <code>c^2 = <var>BC</var>^2 + <var>AC</var>^2 = <var>AB2</var></code>.</p>
+				<p id="sol">Then, <code>c = \sqrt{<var>AB2</var>}</code>.</p>
+				<p id="solsim" data-if="squareRootCanSimplify(AB2)">Simplifying the radical gives <code>c = <var>formattedSquareRootOf(AB2)</var>.</code></p>
 			</div>
 		</div>
 
@@ -100,21 +100,21 @@
 				<li><code><var>formattedSquareRootOf(floor(BC2 / 1.5))</var></code></li>
 			</ul>
 
-			<div class="hints">
-				<p class="vardef">We want to find <code><var>a</var></code>; let <code><var>b</var> = <var>AC</var></code> and <code>c = <var>AB</var></code>.</p>
-				<p class="solsq">So <code><var>a</var>^2 = c^2 - <var>b</var>^2 = <var>AB</var>^2 - <var>AC</var>^2 = <var>BC2</var></code>.</p>
-				<p class="sol">Then, <code><var>a</var> = \sqrt{<var>BC2</var>}</code>.</p>
-				<p class="solsim" data-if="squareRootCanSimplify(BC2)">Simplifying the radical gives <code><var>a</var> = <var>formattedSquareRootOf(BC2)</var>.</code></p>
+			<div class="hints" data-apply="appendContents">
+				<p id="vardef">We want to find <code><var>a</var></code>; let <code><var>b</var> = <var>AC</var></code> and <code>c = <var>AB</var></code>.</p>
+				<p id="solsq">So <code><var>a</var>^2 = c^2 - <var>b</var>^2 = <var>AB</var>^2 - <var>AC</var>^2 = <var>BC2</var></code>.</p>
+				<p id="sol">Then, <code><var>a</var> = \sqrt{<var>BC2</var>}</code>.</p>
+				<p id="solsim" data-if="squareRootCanSimplify(BC2)">Simplifying the radical gives <code><var>a</var> = <var>formattedSquareRootOf(BC2)</var>.</code></p>
 			</div>
 		</div>
 	</div>
 
 	<div class="hints">
 		<p>We know <code>a^2 + b^2 = c^2</code>.</p>
-		<p class="vardef"></p>
-		<p class="solsq"></p>
-		<p class="sol"></p>
-		<p class="solsim"></p>
+		<p id="vardef"></p>
+		<p id="solsq"></p>
+		<p id="sol"></p>
+		<p id="solsim"></p>
 	</div>
 	</div>
 </body>

--- a/exercises/recognizing_fractions.html
+++ b/exercises/recognizing_fractions.html
@@ -16,15 +16,15 @@
 				<p class="question"><code>\dfrac{<var>NUMERATOR</var>}{<var>DENOMINATOR</var>}</code></p>
 				<p class="problem">What is the fraction's numerator?</p>
 				<p class="solution"><var>NUMERATOR</var></p>
-				<div class="hints">
-				    <p class="answer_hint">Thus, the numerator is <var>NUMERATOR</var>.</p>
+				<div class="hints" data-apply="appendContents">
+				    <p id="answer_hint">Thus, the numerator is <var>NUMERATOR</var>.</p>
 			    </div>
 			</div>
 			<div data-type="original">
 			    <p class="problem">What is the fraction's denominator?</p>
 			    <p class="solution"><var>DENOMINATOR</var></p>
-			    <div class="hints">
-				    <p class="answer_hint">Thus, the denominator is <var>DENOMINATOR</var>.</p>
+			    <div class="hints" data-apply="appendContents">
+				    <p id="answer_hint">Thus, the denominator is <var>DENOMINATOR</var>.</p>
 			    </div>
 		    </div>
 		</div>
@@ -34,7 +34,7 @@
 		    <!-- TODO: Drawing a pie would be great. -->
 		    <p>You can think of this fraction as representing <var>NUMERATOR</var> out of <var>DENOMINATOR</var> slices of pie. In other words, the pie has been cut into <var>DENOMINATOR</var> slices, and we are only considering <var>NUMERATOR</var> of those slices.</p>
             <p>The numerator is the number of slices we care about, and it is written above the fraction line. The denominator is the total number of slices, and it is written below the line.</p>
-            <p class="answer_hint"></p>
+            <p id="answer_hint"></p>
 
 		</div>
 	</div>

--- a/exercises/writing_expressions_1.html
+++ b/exercises/writing_expressions_1.html
@@ -24,39 +24,39 @@
 					<li><code><var>expr(["+", ["*", B, "x"], A])</var></code></li>
 					<li><code><var>expr(["+", ["*", -B, "x"], -A])</var></code></li>
 				</ul>
-				<div class="hints">
-					<p class="hint1">What is <span class="hint_orange">the product of <code><var>A</var></code> and <code>x</code></span>?</p>
-					<p class="hint2">What is <span class="hint_blue">the sum of <code><var>B</var></code></span> and <code class="hint_orange"><var>expr(["*", A, "x"])</var></code>?</p>
+				<div class="hints" data-apply="appendContents">
+					<p id="hint1">What is <span class="hint_orange">the product of <code><var>A</var></code> and <code>x</code></span>?</p>
+					<p id="hint2">What is <span class="hint_blue">the sum of <code><var>B</var></code></span> and <code class="hint_orange"><var>expr(["*", A, "x"])</var></code>?</p>
 				</div>
 			</div>
 			<div data-type="original">
 				<p class="question">Take the quantity <code><var>A</var></code> times <code>x</code>, and then add <code><var>B</var></code>.</p>
-				<div class="hints">
-					<p class="hint1">What is <span class="hint_orange">the quantity of <code><var>A</var></code> times <code>x</code></span>?</p>
-					<p class="hint2">What <span class="hint_blue">does adding <code><var>B</var></code></span> do?</p>
+				<div class="hints" data-apply="appendContents">
+					<p id="hint1">What is <span class="hint_orange">the quantity of <code><var>A</var></code> times <code>x</code></span>?</p>
+					<p id="hint2">What <span class="hint_blue">does adding <code><var>B</var></code></span> do?</p>
 				</div>
 			</div>
 			<div data-type="original">
 				<p class="question"><code><var>B</var></code> plus the product of <code><var>A</var></code> and <code>x</code>.</p>
-				<div class="hints">
-					<p class="hint1">What is <span class="hint_orange">the product of <code><var>A</var></code> and <code>x</code></span>?</p>
-					<p class="hint2">What is <span class="hint_blue"><code><var>B</var></code> plus</span> <code class="hint_orange"><var>expr(["*", A, "x"])</var></code>?</p>
+				<div class="hints" data-apply="appendContents">
+					<p id="hint1">What is <span class="hint_orange">the product of <code><var>A</var></code> and <code>x</code></span>?</p>
+					<p id="hint2">What is <span class="hint_blue"><code><var>B</var></code> plus</span> <code class="hint_orange"><var>expr(["*", A, "x"])</var></code>?</p>
 				</div>
 			</div>
 			<div data-type="original">
 				<p class="question">The sum of <code><var>B</var></code> and the quantity <code><var>A</var></code> times <code>x</code>.</p>
-				<div class="hints">
-					<p class="hint1">What is <span class="hint_orange">the quantity <code><var>A</var></code> times <code>x</code></span>?</p>
-					<p class="hint2">What is <span class="hint_blue">the sum of <code><var>B</var></code></span> and <code class="hint_orange"><var>expr(["*", A, "x"])</var></code>?</p>
+				<div class="hints" data-apply="appendContents">
+					<p id="hint1">What is <span class="hint_orange">the quantity <code><var>A</var></code> times <code>x</code></span>?</p>
+					<p id="hint2">What is <span class="hint_blue">the sum of <code><var>B</var></code></span> and <code class="hint_orange"><var>expr(["*", A, "x"])</var></code>?</p>
 				</div>
 			</div>
 		</div>
 	
 		<div class="hints">
 			<p>Let's break this problem into smaller and easier pieces.</p>
-			<p class="hint1"></p>
+			<p id="hint1"></p>
 			<p><code><var>A</var> \times x = \color{orange}{<var>expr(["*", A, "x"])</var>}</code></p>
-			<p class="hint2"></p>
+			<p id="hint2"></p>
 			<p><code class="hint_orange"><var>A</var>x</code><code class="hint_blue">{} + <var>B</var></code></p>
 			<p>So, the original phrase can be written as <code><var>expr(["+", ["*", A, "x"], B])</var></code></p>
 		</div>

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -120,7 +120,7 @@ var Khan = {
 			// Apply templating
 			var children = problem
 				// vars and hints blocks append their contents to the parent
-				.find( ".vars, .hints" ).tmplApply( { attribute: "class", defaultApply: "appendContents" } ).end()
+				.find( ".vars" ).tmplApply( { attribute: "class", defaultApply: "appendContents" } ).end()
 
 				// Individual variables override other variables with the name name
 				.find( ".vars [id]" ).tmplApply().end()

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -120,19 +120,19 @@ var Khan = {
 			// Apply templating
 			var children = problem
 				// vars and hints blocks append their contents to the parent
-				.find( ".vars, .hints" ).tmplApply( { defaultApply: "appendContents" } ).end()
+				.find( ".vars, .hints" ).tmplApply( { attribute: "class", defaultApply: "appendContents" } ).end()
 
 				// Individual variables override other variables with the name name
-				.find( ".vars [id]" ).tmplApply( { attribute: "id" } ).end()
+				.find( ".vars [id]" ).tmplApply().end()
 
 				// We also look at the main blocks within the problem itself to override
-				.children( "[class]" ).tmplApply();
+				.children( "[class]" ).tmplApply( { attribute: "class" } );
 
 			// Finally we do any inheritance to the individual child blocks (such as problem, question, etc.)
 			children.each(function () {
 				// Apply while adding problem.children() to include
 				// template definitions within problem scope
-				jQuery( this ).find( "[class]" ).add( children ).tmplApply();
+				jQuery( this ).find( "[id]" ).add( children ).tmplApply();
 			});
 
 			// Run the "Load" method of any modules

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -135,6 +135,9 @@ var Khan = {
 				jQuery( this ).find( "[id]" ).add( children ).tmplApply();
 			});
 
+			// Remove and store hints to delay running modules on it
+			var hints = problem.children( ".hints" ).remove();
+
 			// Run the "Load" method of any modules
 			problem.runModules( "Load" );
 
@@ -186,7 +189,7 @@ var Khan = {
 			jQuery("#workarea").append( problem );
 
 			// Add the hints into the page
-			problem.find(".hints")
+			hints
 				// Hide all the hints
 				.children().hide().end()
 

--- a/utils/template-inheritance.js
+++ b/utils/template-inheritance.js
@@ -2,9 +2,9 @@ jQuery.fn.extend({
 	tmplApply: function( options ) {
 		options = options || {};
 		
-		// Get the attribute which we'll be checking
-		// defaults to "class", "id" is also sometimes used
-		var attribute = options.attribute || "class",
+		// Get the attribute which we'll be checking, defaults to "id"
+		// but "class" is sometimes used
+		var attribute = options.attribute || "id",
 		
 			// Figure out the way in which the application will occur
 			defaultApply = options.defaultApply || "replace",


### PR DESCRIPTION
I can break these up to separate pull requests if you'd like. But most of these commits depend on each other.

These commits should address issues #78, #79, and #80

This change includes:
- Using ids instead of classes for "inheritance"[1](except for the problem-level things like hints, question, etc).
- Defaulting to replace for hints (as this is the more frequent use case)
- Convert 6 exercises to use new templating. Hopefully that catches most of the broken ones, let me know if there are others.
- Delay hint runModules - prevents it from trying to do things too early like graph updates

This change does not include:
- Limiting content manipulation to only apply when inheriting - This seems less of an issue now that we're using ids. Having multiple items with the same id in the same context seems generally well known to be a "bad thing".
- Merging attributes like data-ensure - This isn't currently needed in any exercises, but I can see it being useful in the future.

[1] "Inheritance" is probably the wrong word for this. It's more along the lines of "convenient/inline manipulation of elements". The actual "inheritance" part just creates a single document out of the inheritance path - and then we apply these element manipulation bits.
