### PR TITLE
Fixed possibility of 0/0 in fraction excersizes

### DIFF
--- a/exercises/division_1.html
+++ b/exercises/division_1.html
@@ -7,7 +7,7 @@
 <body>
 	<div class="exercise">
 		<div class="vars">
-			<var id="DIVISOR">rand(10)</var>
+			<var id="DIVISOR">randRange(1,10)</var>
 			<var id="DIVIDEND">randRange(1,9)*DIVISOR</var>
 		</div>
 


### PR DESCRIPTION
It was previously possible (and happened to me) that 0/0 appeared as a question in division_1.html, leaving no valid answer (if 0/0 is wanted as a question, there should be an 'undefined' radio button or something).

This fix ensures the denominator is never zero.
