### PR TITLE
Changed \\mathbb{R} to \\\\mathbb{R}. Apparently there is two layers that

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -23,7 +23,7 @@ var Khan = {
 				TeX: {\
 					extensions: ["AMSmath.js","AMSsymbols.js","noErrors.js","noUndefined.js"],\
 					Macros: {\
-						RR: "\\mathbb{R}"\
+						RR: "\\\\mathbb{R}"\
 					}\
 				},\
 				"HTML-CSS": { scale: 93 }\


### PR DESCRIPTION
Changed \mathbb{R} to \\mathbb{R}. Apparently there is two layers that need the backslash to be escaped.
