### PR TITLE
Extract Script Regex Doesn't Handle type="text/javascript"

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -728,7 +728,7 @@ Khan.loadScripts( [ { src: "https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/j
 			}
 
 			// Extract scripts with no src
-			var rscript = /<(?:)script\b[^s>]*(?:(?!src=)s[^s>])*>([^<]*(?:(?!<\/script>)<[^<]*)*)<\/script>/gi;
+			var rscript = /<(?:)script\b(?:(?!src=).)*?>([^<]*(?:(?!<\/script>)<[^<]*)*)<\/script>/gi;
 			while ( ( match = rscript.exec( data ) ) != null ) {
 				jQuery.globalEval( match[1] );
 			}


### PR DESCRIPTION
Some exercises, such as `even_and_odd_functions.html`, have a script tag that has the `type="..."` attribute. The regex in the `loadExercise` function isn't permissive enough and ignores those script tags. Thus, the exercise won't run with `ReferenceErrors` that are logged to the console.

I updated the regex to use a non-greedy regex selector (*?) as talked about [on stackoverflow](http://stackoverflow.com/questions/3788496/php-regex-find-inline-javascript-in-html-document/3788525#3788525).
