### PR TITLE
Call .preventDefault() Instead of Returning false in Event Handlers

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -525,7 +525,9 @@ var Khan = {
 		jQuery( ".summary" ).hide();
 
 		// Watch for a solution submission
-		jQuery("form").submit(function() {
+		jQuery("form").submit(function(ev) {
+			ev.preventDefault();
+			
 			// Figure out if the response was correct
 			if ( Khan.validator() ) {
 				// Show a congratulations message
@@ -540,12 +542,12 @@ var Khan = {
 			} else {
 				jQuery("#oops").show().delay( 1000 ).fadeOut( 2000 );
 			}
-
-			return false;
 		});
 
 		// Watch for when the next button is clicked
-		jQuery("#next").click(function() {
+		jQuery("#next").click(function(ev) {
+			ev.preventDefault();
+			
 			// Erase the old value and hide congrats message
 			jQuery("#congrats").hide();
 
@@ -562,8 +564,6 @@ var Khan = {
 
 			// Generate a new problem
 			Khan.makeProblem();
-
-			return false;
 		});
 
 		// Watch for when the "Get a Hint" button is clicked


### PR DESCRIPTION
Call `.preventDefault()` on the event object instead of returning false. Returning false is the same as calling `.preventDefault()` and `.stopPropagation()`, which prevents other event handlers from being called.
