### PR TITLE
This is a fix for issue #401: Product rule produces extra correct answers

### DIFF
--- a/exercises/product_rule.html
+++ b/exercises/product_rule.html
@@ -22,7 +22,7 @@
 				<p class="solution"><code>\lrsplit{(<var>FUNCN.ddxFText</var>)(<var>FUNCD.fText</var>)}{+\:(<var>FUNCD.ddxFText</var>)(<var>FUNCN.fText</var>)}</code></p>
 
 				<ul class="choices" data-show="5" data-none="true">
-					<li><code>\lrsplit{(<var>FUNCD.fText</var>)(<var>FUNCN.ddxFText</var>)}{+\:(<var>FUNCN.fText</var>)(<var>FUNCD.ddxFText</var>)}</code></li>
+					<li><code>\lrsplit{(<var>FUNCD.fText</var>)(<var>FUNCN.ddxFText</var>)}{-\:(<var>FUNCN.fText</var>)(<var>FUNCD.ddxFText</var>)}</code></li>
 					<li><code>\lrsplit{(<var>FUNCD.fText</var>)(<var>FUNCN.ddxFText</var>)}{-\:(<var>FUNCN.fText</var>)(<var>FUNCD.ddxFText</var>)}</code></li>
 					<li><code>\lrsplit{(<var>FUNCN.fText</var>)(<var>FUNCN.ddxFText</var>)}{+\:(<var>FUNCD.fText</var>)(<var>FUNCD.ddxFText</var>)}</code></li>
 					<li><code>\lrsplit{(<var>FUNCN.fText</var>)(<var>FUNCN.ddxFText</var>)}{+\:(<var>FUNCD.fText</var>)(<var>FUNCD.ddxFText</var>)}</code></li>


### PR DESCRIPTION
This is a fix for issue #401: Product rule produces extra correct answers.

The extra correct answer being generated was switching the order of the solution and nothing else. In order to make this choice invalid I changed the operation to subtraction as opposed to addition.

Alternatively, this could be fixed by changing the choice to be the sum of the product of the two terms and the two terms' derivatives.

You may want to experiment between the two choices once you can view the trends of users. Currently no correct answer will ever have subtraction between the sets of terms. This could make the activity easier to guess the correct answer - if they realize the trick. 
