### PR TITLE
Update exercise - Made answer format for Logarithms 2 clearer and more stable; standardised question format

### DIFF
--- a/exercises/logarithms_2.html
+++ b/exercises/logarithms_2.html
@@ -18,9 +18,9 @@
 				<p class="problem">Rewrite the following in the form log(c).</p>
 				<p class="question"><code>\log(<var>A</var>) + \log(<var>B</var>)</code></p>
 				<p class="solution" data-type="multiple">
-          log(
-          <span class="sol"><var>C</var></span>
-          )</p>
+                                   log(
+                                   <span class="sol"><var>C</var></span>
+                                   )</p>
 
 				<div class="hints">
 					<p>Use the rule: <code>\log(a) + \log(b) = \log(a \cdot b)</code>.</p>
@@ -33,9 +33,9 @@
 				<p class="problem">Rewrite the following in the form log(c).</p>
 				<p class="question"><code>\log(<var>C</var>) - \log(<var>A</var>)</code></p>
 				<p class="solution" data-type="multiple">
-          log(
-          <span class="sol"><var>B</var></span>
-          )</p>
+                                   log(
+                                   <span class="sol"><var>B</var></span>
+                                   )</p>
 				<div class="hints">
 					<p>Use the rule: <code>\log(a) - \log(b) = \log(\frac{a}{b})</code>.</p>
 					<p><code>\log(<var>C</var>) - \log(<var>A</var>) = \log(\frac{<var>C</var>}{<var>A</var>})</code></p>
@@ -47,9 +47,9 @@
 				<p class="problem">Rewrite the following in the form log(c).</p>
 				<p class="question"><code><var>A</var>\log(<var>B</var>)</code></p>
 				<p class="solution" data-type="multiple">
-          log(
-          <span class="sol"><var>pow( B, A )</var></span>
-          )</p>
+                                   log(
+                                   <span class="sol"><var>pow( B, A )</var></span>
+                                   )</p>
 				<div class="hints">
 					<p>Use the rule: <code>n \cdot \log(a) = \log(a^{n})</code>.</p>
 					<p><code><var>A</var>\log(<var>B</var>) = \log(<var>B</var>^{<var>A</var>})</code></p>

--- a/exercises/logarithms_2.html
+++ b/exercises/logarithms_2.html
@@ -17,7 +17,11 @@
 			<div>
 				<p class="problem">Rewrite the following in the form log(c).</p>
 				<p class="question"><code>\log(<var>A</var>) + \log(<var>B</var>)</code></p>
-				<p class="solution" data-type="regex">^(log\(|)<var>C</var>(\)|)$</p>
+				<p class="solution" data-type="multiple">
+          log(
+          <span class="sol"><var>C</var></span>
+          )</p>
+
 				<div class="hints">
 					<p>Use the rule: <code>\log(a) + \log(b) = \log(a \cdot b)</code>.</p>
 					<p><code>\log(<var>A</var>) + \log(<var>B</var>) = \log(<var>A</var> \cdot <var>B</var>)</code></p>
@@ -26,9 +30,12 @@
 			</div>
 
 			<div>
-				<p class="problem">Rewrite in the form log(c).</p>
+				<p class="problem">Rewrite the following in the form log(c).</p>
 				<p class="question"><code>\log(<var>C</var>) - \log(<var>A</var>)</code></p>
-				<p class="solution" data-type="regex">^(log\(|)<var>B</var>(\)|)$</p>
+				<p class="solution" data-type="multiple">
+          log(
+          <span class="sol"><var>B</var></span>
+          )</p>
 				<div class="hints">
 					<p>Use the rule: <code>\log(a) - \log(b) = \log(\frac{a}{b})</code>.</p>
 					<p><code>\log(<var>C</var>) - \log(<var>A</var>) = \log(\frac{<var>C</var>}{<var>A</var>})</code></p>
@@ -37,9 +44,12 @@
 			</div>
 
 			<div>
-				<p class="problem">Rewrite in the form log(c).</p>
+				<p class="problem">Rewrite the following in the form log(c).</p>
 				<p class="question"><code><var>A</var>\log(<var>B</var>)</code></p>
-				<p class="solution" data-type="regex">^(log\(|)<var>pow( B, A )</var>(\)|)$</p>
+				<p class="solution" data-type="multiple">
+          log(
+          <span class="sol"><var>pow( B, A )</var></span>
+          )</p>
 				<div class="hints">
 					<p>Use the rule: <code>n \cdot \log(a) = \log(a^{n})</code>.</p>
 					<p><code><var>A</var>\log(<var>B</var>) = \log(<var>B</var>^{<var>A</var>})</code></p>


### PR DESCRIPTION
In Logarithms 2, the question asks the user to rewrite the equation in the form "log(c)". The answer field accepts either of log(c) or c as correct. Note that log(c ) or log (c) or log( c) are considered incorrect due to the spacing, so I considered this answer format more unstable. 

This commit writes "log(" and ")" around the answer field to make clear what is required: "c". This shouldn't impact users' learning of log rules.

Also standardised the language in the question to "Rewrite the following in the form log(c)". The subtraction and power parts of the exercise were phrased differently.
