### PR TITLE
testMode and .local support

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -391,6 +391,9 @@ var Khan = {
 // Load query string params
 Khan.query = Khan.queryString();
 
+// Save testMode state in Khan to share with deps
+Khan.testMode = testMode;
+
 // Seed the random number generator with the user's hash
 randomSeed = testMode && parseFloat( Khan.query.seed ) || userCRC32 || ( new Date().getTime() & 0xffffffff );
 

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -39,6 +39,7 @@ var primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
 	testMode = (window.location.host.indexOf("localhost") === 0 ||
 				window.location.host.indexOf("127.0.0.1") === 0 ||
 				window.location.host.indexOf("192.168") === 0 ||
+				/\.local$/.test(window.location.host) ||
 				window.location.protocol === "file:") &&
 				/\.html$/.test( window.location.pathname ),
 

--- a/utils/tmpl.js
+++ b/utils/tmpl.js
@@ -222,7 +222,7 @@ jQuery.fn.tmplLoad = function() {
 	VARS = {};
 	
 	// Check to see if we're in test mode
-	if ( window.location.host.indexOf("localhost") === 0 || window.location.protocol === "file:" ) {
+	if ( Khan.testMode ) {
 		// Expose the variables if we're in test mode
 		jQuery.tmpl.VARS = VARS;
 	}


### PR DESCRIPTION
This exports `Khan.testMode` so that testMode can be checked in dependencies of `Khan-Exercise.js` (fixing a problem where `?debug` only worked when visiting an exercise page via localhost/file:) and also adds in support for .local domains.
