### PR TITLE
1825 fix recognizing conic sections

### DIFF
--- a/exercises/recognizing_conic_sections.html
+++ b/exercises/recognizing_conic_sections.html
@@ -52,7 +52,7 @@
 				</div>
 
 				<div id="ellipse" data-type="parabola">
-					<div class="vars">
+					<div class="vars" data-ensure="A+1 > B || B+1 > A">
 						<var id="A">randRangeNonZero( -70, 70 ) / 10</var>
 						<var id="B">randRangeNonZero( -70, 70 ) / 10</var>
 						<var id="C">randRangeNonZero( -30, 30 ) / 10</var>


### PR DESCRIPTION
one-line data-ensure fix to assure that ellipses are significantly different from circles.  There is still some nuance but ellipses are different enough from circles to be differentiated by the user.  Help could probably be changed to let users know that circles are in fact ellipses where the major and minor axes are equal.
