### PR TITLE
Fix #2439, Graphing inequalities - Incorrect "correct" answer

### DIFF
--- a/exercises/graphing_inequalities.html
+++ b/exercises/graphing_inequalities.html
@@ -43,8 +43,18 @@
 			<div data-ensure="sqrt( pow( POINT_1[0] - POINT_2[0], 2 ) + pow( POINT_1[1] - POINT_2[1], 2 ) ) > 4">
 				<var id="POINT_1">[ randRangeExclude( -9, 9, [ -3, -2, -1, 0 ] ), randRangeExclude( -9, 9, [ -1, -2 ] ) ]</var>
 				<var id="POINT_2">[ randRangeExclude( -9, 9, [ -3, -2, -1, 0 ] ), randRangeExclude( -9, 9, [ -1, -2 ] ) ]</var>
-				<var id="POINT_1_SOLUTION">POINT_1[1] > M * POINT_1[0] + B !== LESS_THAN || ( INCLUSIVE && M * POINT_1[0] + B === POINT_1[1] )</var>
-				<var id="POINT_2_SOLUTION">POINT_2[1] > M * POINT_2[0] + B !== LESS_THAN || ( INCLUSIVE && M * POINT_2[0] + B === POINT_2[1] )</var>
+				<var id="POINT_1_SOLUTION">
+					  (((COMP == "&lt;") && (Y_COEF * POINT_1[1] + X_COEF * POINT_1[0] <  RIGHT_INT))
+					|| ((COMP == "&le;") && (Y_COEF * POINT_1[1] + X_COEF * POINT_1[0] <= RIGHT_INT))
+					|| ((COMP == "&gt;") && (Y_COEF * POINT_1[1] + X_COEF * POINT_1[0] >  RIGHT_INT))
+					|| ((COMP == "&ge;") && (Y_COEF * POINT_1[1] + X_COEF * POINT_1[0] >= RIGHT_INT)))
+				</var>
+				<var id="POINT_2_SOLUTION">
+					  (((COMP == "&lt;") && (Y_COEF * POINT_2[1] + X_COEF * POINT_2[0] <  RIGHT_INT))
+					|| ((COMP == "&le;") && (Y_COEF * POINT_2[1] + X_COEF * POINT_2[0] <= RIGHT_INT))
+					|| ((COMP == "&gt;") && (Y_COEF * POINT_2[1] + X_COEF * POINT_2[0] >  RIGHT_INT))
+					|| ((COMP == "&ge;") && (Y_COEF * POINT_2[1] + X_COEF * POINT_2[0] >= RIGHT_INT)))
+				</var>
 			</div>
 		</div>
 


### PR DESCRIPTION
The exercise is computing the slope and y-intercept in order to properly draw the graph and explain the procedure in the hints. It then uses this computed slope and intercept to determine the correct answers.

The problem is that if the slope is a fraction that can't be precisely represented by a floating point decimal, it may incorrectly determine the point is not on the line due to rounding error, leading to an incorrect answer.

This fix modifies the way the correct answer is computed. Rather than solving via the computed y=mx+b form, the points are simply plugged into the original inequality and tested directly.
