### PR TITLE
Fix #2474, Adding vectors - Non-recognition of multiplicitive identity

### DIFF
--- a/exercises/adding_vectors.html
+++ b/exercises/adding_vectors.html
@@ -48,7 +48,7 @@
 			</div>
 
 			<div class="solution" data-type="multiple">
-				<p><span class="sol"><var>AX + BX</var></span> <code>\hat\imath + {}</code><span class="sol"><var>AY + BY</var></span> <code>\hat\jmath</code></p>
+				<p><span class="sol" data-type="decimal" data-fallback="1"><var>AX + BX</var></span> <code>\hat\imath + {}</code><span class="sol" data-type="decimal" data-fallback="1"><var>AY + BY</var></span> <code>\hat\jmath</code></p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Use `data-fallback="1"` to treat a blank coefficient as equal to 1.
Also added `data-type="decimal"` rather than the default of `text` in case someone decides to type 1.0 or whatever.

I'm really impressed by your framework. Nice job guys!
