### PR TITLE
measuring angles as radians

### DIFF
--- a/exercises/measuring_angles_2.html
+++ b/exercises/measuring_angles_2.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html data-require="math graphie graphie-helpers">
+	<head>
+		<title>Measuring Angles As A Fraction Of PI</title>
+		<script src="../khan-exercise.js"></script>
+	</head>
+	<body>
+		<div class="exercise">
+			<div class="vars">
+				<var id="ANGLE_ONE">randRange(0, 359)</var>
+				<var id="DIFF">15 * randRange(1, 23)</var>
+			</div>
+
+			<div class="problems">
+				<div>
+					<div class="problem">
+						Measure this angle in as a fraction of <code>\pi</code>.
+					</div>
+					<div class="question">
+						<div class="graphie" id="angle">
+							var ANGLE_TWO = ANGLE_ONE + DIFF;
+							var ANGLE_ONE_R = ANGLE_ONE * PI / 180;
+							var ANGLE_TWO_R = ANGLE_TWO * PI / 180;
+							
+							init({
+								range: [ [-11, 31], [-10, 10] ],
+								scale: 20
+							});
+							path([ [5 * cos( ANGLE_ONE_R ), 5 * sin( ANGLE_ONE_R )], [0, 0], [5 * cos( ANGLE_TWO_R ), 5 * sin( ANGLE_TWO_R )] ]);
+							arc( [0, 0], 1, ANGLE_ONE, ANGLE_TWO );
+
+							graph.protractor = new Protractor( [22, 0], 8 );
+							Khan.scratchpad.disable();
+						</div>
+					</div>
+					<p class="solution" data-type="rational" ><var>(DIFF/180)</var></p>
+				</div>
+			</div>
+
+			<div class="hints">
+				<div>
+					<p>Remember that 15 degrees is the same as <code>\frac{\pi}{12}</code>.  This is the angle that the earth revolves in 1 hour.</p>
+				</div>
+
+				<div>
+					<div class="graphie" data-update="angle" data-if="DIFF > 180">
+						graph.protractor.translate( 0, 0, true );
+						graph.protractor.rotate( 180 - ANGLE_ONE, true );
+						graph.protractor.rotatable( false );
+						graph.protractor.translatable( false );
+					</div>
+					<div class="graphie" data-update="angle" data-else>
+						graph.protractor.translate( 0, 0, true );
+						graph.protractor.rotate( 360 - ANGLE_ONE, true );
+						graph.protractor.rotatable( false );
+						graph.protractor.translatable( false );
+					</div>
+
+					<p>First, align the protractor with the angle.</p>
+					<p data-if="DIFF >180">If the angle is greater than 180 degrees remember it is more than <code>\pi</code>.</p>
+
+				</div>
+				<div>
+					
+					<p>The angle is <code><var>roundTo(2,(DIFF/180)*100)</var></code> percent of <code>\pi</code> or <code><var>roundTo(2,(DIFF/360)*100)</var></code> percent of 2 <code>\pi</code> .</p>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
After a short hipchat discussion regarding "images" yesterday I decided to push this one forward as it does 3 things.  First, it makes use of the "manipulative" created by one of your crack interns (and mentioned by Sal Khan in his video).  Second, it deals with angles greater than 180 degrees but treats them as radians.  Arguably converting kids into "first brained" measurement of angles as radians is very lacking considering almost all "code", including excel and google docs spreadsheets, have radians as default.  Thirdly, it exposes learners to one of the most obvious divisions of a full revolution...one twenty fourth of a revolution or 1/12 th of PI.  The last hint could be improved as all angles selected are to pi/12 increments and so the expected answers are things like 23/12  (for 345 degrees).  Finally, a Pi-protractor would make things better but this would require more image management (essentially editing the protractor png file to have pi/12 increments).
