### PR TITLE
Add exercise-- Rounding whole numbers

### DIFF
--- a/exercises/rounding_whole_numbers.html
+++ b/exercises/rounding_whole_numbers.html
@@ -62,6 +62,7 @@
 		<div>
 			<p>2nd way:  Consider which end of the number line is closer to <var>NUM</var> - this end is circled in blue.</p>
 			<p data-if="DIGITS[ N_DIGITS + PLACE ] == 5">(by the "round half up" convention, numbers are rounded up when we look at the <code>5</code> to round)</p>
+		</div>
 		<div class="graphie"> 
 			init({
 				range: [ [ -0.05 *pow( 10, -PLACE ) , 1.3*pow( 10, -PLACE ) ], [-1.5, 1] ],

--- a/exercises/rounding_whole_numbers.html
+++ b/exercises/rounding_whole_numbers.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html data-require="math math-format graphie graphie-helpers">
+<head>
+	<meta charset="UTF-8" />
+	<title>Rounding whole numbers</title>
+	<script src="../khan-exercise.js"></script>
+</head>
+
+<body>
+<div class="exercise">
+
+	<div class="problems">
+		<div id="original" data-weight="4">
+			<div class="vars">
+				<var id="N_DIGITS">randRange( 2, 4 )</var>
+				<var id="PLACE">randRange( max( -N_DIGITS, -3) , -1 )</var>
+				<var id="DIGITS">shuffle( [1, 2, 3, 4, 5, 6, 7, 8, 9], N_DIGITS )</var>
+				<var id="NUM">+DIGITS.join( "" )</var>
+				<var id="TPLACE">placesLeftOfDecimal[ -PLACE ]</var>
+				<var id="ROUNDED">roundTo( PLACE, NUM )</var>
+			</div>
+
+			<p class="question">Round <code><var>commafy( NUM )</var></code> to the nearest <var>TPLACE</var>.</p>
+			<div class="solution" data-forms="integer, decimal"><var>ROUNDED</var></div>
+
+		</div>
+		
+		<div id="five" data-weight="1">
+			<div class="vars">
+				<var id="PLACE">randRange( -3 , -1 )</var>
+				<var id="N_DIGITS">randRange( 1, 4 + PLACE ) - PLACE</var>
+				<var id="DIGITS">(function() {
+					var array = shuffle( [1, 2, 3, 4, 5, 6, 7, 8, 9], N_DIGITS + PLACE );
+					array.push(5);
+				
+					var i = 1; 
+					while ( i < -PLACE ) {
+						array.push(0);
+						i++;
+					}
+					
+					return array;
+				})()</var>
+				<var id="NUM">+DIGITS.join( "" )</var>
+				<var id="TPLACE">placesLeftOfDecimal[ -PLACE ]</var>
+				<var id="ROUNDED">roundTo( PLACE, NUM )</var>
+				
+				
+			</div>
+
+			<p class="question">Round <code><var>commafy( NUM )</var></code> to the nearest <var>TPLACE</var>.</p>
+			<div class="solution" data-forms="integer, decimal"><var>ROUNDED</var></div>
+
+		</div>
+	</div>
+
+	<div class="hints">
+		<p>There are two ways to think about this problem.</p>
+		<p>1st way: Look at the <var>placesLeftOfDecimal[ -1 - PLACE ]</var>s digit <code><var>DIGITS[ N_DIGITS + PLACE ]</var></code> to see whether to round up or down.</p>
+		<p data-if="DIGITS[ N_DIGITS + PLACE ] >= 5">Because it is <span data-if="DIGITS[ N_DIGITS + PLACE ] > 5">more than</span><span data-else>equal to</span> <code>5</code>, we round up, giving <code><var>ROUNDED</var></code>.</p>
+		<p data-else>Because it is less than <code>5</code>, we round down, giving <code><var>commafy( ROUNDED )</var></code>.</p>
+		<div>
+			<p>2nd way:  Consider which end of the number line is closer to <var>NUM</var> - this end is circled in blue.</p>
+			<p data-if="DIGITS[ N_DIGITS + PLACE ] == 5">(by the "round half up" convention, numbers are rounded up when we look at the <code>5</code> to round)</p>
+		<div class="graphie"> 
+			init({
+				range: [ [ -0.05 *pow( 10, -PLACE ) , 1.3*pow( 10, -PLACE ) ], [-1.5, 1] ],
+				scale: [ 600 * pow( 10, PLACE ), 40 ]
+			});
+			numberLine( floorTo( PLACE , NUM ), ceilTo( PLACE , NUM ) +  pow( 10, -( PLACE+2 ))  , round( pow( 10, -(PLACE + 1 ))) );
+			style({ stroke: "#FFA500", fill: "#FFA500", strokeWidth: 3.5, arrows: "->" });
+			ellipse( [  10 * pow( 10, -( PLACE+1 )) * (NUM -  floorTo( PLACE , NUM   ))/pow( 10,- (PLACE) ), 0 ], [pow( 10, -PLACE ) / 100, 0.15]);
+			label( [  10 * pow(10, -( PLACE+1 )) * ( NUM -  floorTo( PLACE , NUM ))/pow( 10,- (PLACE) )], NUM, "below");
+			style({ stroke: "#0000FF", "fill": "none", strokeWidth: 3.5, arrows: "->" });
+			<span data-if="DIGITS[ N_DIGITS + PLACE ] >= 5">ellipse( [ pow( 10, -PLACE ), -0.55 ], [pow( 10, - PLACE - 0.5 ) / 8, 0.35] );</span>
+			<span data-else>ellipse( [ 0, -0.55 ], [pow( 10, - PLACE - 0.5 ) / 8, 0.35] );</span>
+
+		</div>
+	</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
weight = 4 for regular numbers

weight = 1 for #s ending in 5 (getting people to learn the round half up rule while looking at the visual of the number line)

weights can be shifted (e.g. 9 and 1) but I think that learning the round half up rule should be a part of this exercise.  We can leave the other rounding exercise alone in terms of this rule

(but I will add the nice blue circles)
