### PR TITLE
Fix #2268: Special derivatives blank answer choice

### DIFF
--- a/exercises/special_derivatives.html
+++ b/exercises/special_derivatives.html
@@ -22,11 +22,7 @@
 				<p class="solution"><code><var>FUNC.ddxFText</var></code></p>
 
 				<ul class="choices" data-show="5" data-none="true">
-					<li><code><var>WRONG_CHOICES[0]</var></code></li>
-					<li><code><var>WRONG_CHOICES[1]</var></code></li>
-					<li><code><var>WRONG_CHOICES[2]</var></code></li>
-					<li><code><var>WRONG_CHOICES[3]</var></code></li>
-					<li><code><var>WRONG_CHOICES[4]</var></code></li>
+					<li data-each="WRONG_CHOICES as WRONG_CHOICE"><code><var>WRONG_CHOICE</var></code></li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
`generateSpecialFunction()` doesn't always return 5 wrong answers.

In the specific case in bug #2268, the "increment negative exponent" wrong answer wasn't included since the question didn't have any negative exponents. Fix uses `data-each` to consider only the actual number of wrong choices available.
