### PR TITLE
Clarify what is being asked for in equivalent fractions 2

### DIFF
--- a/exercises/equivalent_fractions.html
+++ b/exercises/equivalent_fractions.html
@@ -20,7 +20,10 @@
 			<div class="question">
 				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{?}{<var>D</var>}</code></p>
 			</div>
-			<div class="solution" data-forms="integer"><var>C</var></div>
+			<div class="solution" data-type="multiple">
+				<code>? = </code> <span class="sol"><var>C</var></span>
+				<div class="example">an integer, like <code>6</code></div>
+			</div>
 			<div class="hints">
 				<div>
 					<p>The fraction on the left represents <var>A</var> out of <var>B</var> slices of a rectangular <var>pizza( 1 )</var>.</p>
@@ -52,7 +55,10 @@
 			<div class="question">
 				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{<var>C</var>}{?}</code></p>
 			</div>
-			<div class="solution" data-forms="integer"><var>D</var></div>
+			<div class="solution" data-type="multiple">
+				<code>? = </code> <span class="sol"><var>D</var></span>
+				<div class="example">an integer, like <code>6</code></div>
+			</div>
 			<div class="hints">
 				<div>
 					<p>The fraction on the left represents <var>A</var> out of <var>B</var> slices of a rectangular <var>pizza( 1 )</var>.</p>

--- a/exercises/equivalent_fractions_2.html
+++ b/exercises/equivalent_fractions_2.html
@@ -21,7 +21,10 @@
 			<div class="question">
 				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{<var>C</var>}{?}</code></p>
 			</div>
-			<div class="solution"><var>D</var></div>
+			<div class="solution" data-type="multiple">
+				<code>? = </code> <span class="sol"><var>D</var></span>
+				<div class="example">an integer, like <code>6</code></div>
+			</div>
 			<div class="hints">
 				<p>To get the right numerator <code><var>C</var></code>, the left numerator <code><var>A</var></code> is multiplied by <code><var>M</var></code>.</p>
 				<p>To find the right denominator, multiply the left denominator by <code><var>M</var></code> as well.</p>
@@ -33,7 +36,10 @@
 			<div class="question">
 				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{?}{<var>D</var>}</code></p>
 			</div>
-			<div class="solution"><var>C</var></div>
+			<div class="solution" data-type="multiple">
+				<code>? = </code> <span class="sol"><var>C</var></span>
+				<div class="example">an integer, like <code>6</code></div>
+			</div>
 			<div class="hints">
 				<p>To get the right denominator <code><var>D</var></code>, the left denominator <code><var>B</var></code> is multiplied by <code><var>M</var></code>.</p>
 				<p>To find the right numerator, multiply the left numerator by <code><var>M</var></code> as well.</p>
@@ -45,7 +51,10 @@
 			<div class="question">
 				<p><code>\dfrac{<var>C</var>}{<var>D</var>} = \dfrac{<var>A</var>}{?}</code></p>
 			</div>
-			<div class="solution"><var>B</var></div>
+			<div class="solution" data-type="multiple">
+				<code>? = </code> <span class="sol"><var>B</var></span>
+				<div class="example">an integer, like <code>6</code></div>
+			</div>
 			<div class="hints">
 				<p>To get the right numerator <code><var>A</var></code>, the left numerator <code><var>C</var></code> is divided by <code><var>M</var></code>.</p>
 				<p>To find the right denominator, divide the left denominator by <code><var>M</var></code> as well.</p>
@@ -57,7 +66,10 @@
 			<div class="question">
 				<p><code>\dfrac{<var>C</var>}{<var>D</var>} = \dfrac{?}{<var>B</var>}</code></p>
 			</div>
-			<div class="solution"><var>A</var></div>
+			<div class="solution" data-type="multiple">
+				<code>? = </code> <span class="sol"><var>A</var></span>
+				<div class="example">an integer, like <code>6</code></div>
+			</div>
 			<div class="hints">
 				<p>To get the right denominator <code><var>B</var></code>, the left denominator <code><var>D</var></code> is divided by <code><var>M</var></code>.</p>
 				<p>To find the right numerator, divide the left numerator by <code><var>M</var></code> as well.</p>


### PR DESCRIPTION
I've seen a number of issues pop up related to this; the most recent #2956. I think the confusion is legitimate both because a lot of people are confused and also the "acceptable answer format" help suggests that you can enter fractions.

At a minimum `data-forms="integer"` should be used so the help isn't wrong. This pull request goes one better and puts "? = " in front of the input box to make it even more clear what is expected.

Or... :) An even better solution would involve my "set" answer type from #2644. It would allow the exercise to accept either form so the exercise judges knowledge of fractions rather than knowledge of how to format the answer correctly.
