### PR TITLE
New exercise: Derivative intuition

### DIFF
--- a/exercises/derivative_intuition.html
+++ b/exercises/derivative_intuition.html
@@ -19,8 +19,8 @@
 					<var id="DDX">function(x) { return ddxPolynomial(POLYNOMIAL).evalOf(x); }</var>
 					<var id="POINTS">[ -2, -1.5, -1, 0, 1, 1.5, 2 ]</var>
 					<var id="XRANGE">[ -2.5, 2.5 ]</var>
-					<var id="YMIN">min.apply( Math, $.map(POINTS, FNX).concat( $.map(POINTS, DDX )))</var>
-					<var id="YMAX">max.apply( Math, $.map(POINTS, FNX).concat( $.map(POINTS, DDX )))</var>
+					<var id="YMIN">min.apply( Math, jQuery.map(POINTS, FNX).concat( jQuery.map(POINTS, DDX )))</var>
+					<var id="YMAX">max.apply( Math, jQuery.map(POINTS, FNX).concat( jQuery.map(POINTS, DDX )))</var>
 					<var id="YRANGE"> [ floorTo(-1, YMIN - (YMAX-YMIN)*0.05 ), ceilTo(-1, YMAX + (YMAX-YMIN)*0.05) ] </var>
 					<var id="OPTIONS">{}</var>
 				</div>

--- a/exercises/derivative_intuition.html
+++ b/exercises/derivative_intuition.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-require="math math-format polynomials calculus graphie graphie-helpers derivative-intuition">
+<html data-require="math math-format polynomials calculus graphie derivative-intuition">
 <head>
 	<meta charset="UTF-8" />
 	<title>Derivative intuition</title>

--- a/exercises/derivative_intuition.html
+++ b/exercises/derivative_intuition.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html data-require="math math-format polynomials calculus graphie graphie-helpers derivative-intuition">
+<head>
+	<meta charset="UTF-8" />
+	<title>Derivative intuition</title>
+	<script src="../khan-exercise.js"></script>
+</head>
+<body>
+	<div class="exercise">
+
+		<div class="problems">
+			<div id="polynomial" data-weight="4">
+				<div class="vars">
+					<var id="SCENARIO">{}</var>
+					<var id="POLYNOMIAL">new Polynomial( randRange(0, 3), randRange(2, 4) )</var>
+					<var id="FNXTEXT">POLYNOMIAL.text()</var>
+					<var id="DDXTEXT">ddxPolynomial(POLYNOMIAL).text()</var>
+					<var id="FNX">function(x) { return POLYNOMIAL.evalOf(x); }</var>
+					<var id="DDX">function(x) { return ddxPolynomial(POLYNOMIAL).evalOf(x); }</var>
+					<var id="POINTS">[ -2, -1.5, -1, 0, 1, 1.5, 2 ]</var>
+					<var id="XRANGE">[ -2.5, 2.5 ]</var>
+					<var id="YMIN">min.apply( Math, $.map(POINTS, FNX).concat( $.map(POINTS, DDX )))</var>
+					<var id="YMAX">max.apply( Math, $.map(POINTS, FNX).concat( $.map(POINTS, DDX )))</var>
+					<var id="YRANGE"> [ floorTo(-1, YMIN - (YMAX-YMIN)*0.05 ), ceilTo(-1, YMAX + (YMAX-YMIN)*0.05) ] </var>
+					<var id="OPTIONS">{}</var>
+				</div>
+
+				<div class="problem">
+					<div class="graphie" id="ddxplot">
+						initAutoscaledGraph( [ XRANGE,	YRANGE ], OPTIONS );
+
+						style({
+							stroke: "#6495ED",
+							strokeWidth: 3
+						}, function() {
+								plot( function( x ) {
+									return FNX( x );
+								}, XRANGE );
+						});
+
+						initDerivativeIntuition( FNX, DDX, POINTS );
+					</div>
+				</div>
+
+				<div class="question">
+					<p>
+						<code class="hint_blue">f(x) = <var>FNXTEXT</var></code>
+						<span id="ddxspan" style="margin-left: 5em; display: none; opacity:0">
+							<code class="hint_orange">\frac{d}{dx}f(x) = <var>DDXTEXT</var></code>
+						</span>
+					</p>
+					<p>
+						Drag each <span class="hint_orange">orange</span> point up and down
+						to adjust the slope of the corresponding tangent line.</p>
+					<p>
+						The derivative of a function is defined as the slope of a line tangent to the curve at each point.
+						Adjust the slopes of the lines to visually find the	derivative <code>\frac{d}{dx} f(x)</code> at each point.
+					</p>
+				</div>
+
+
+				<div class="solution" data-type="multiple">
+					<table>
+						<tr data-each="POINTS as X">
+							<td class="sol" style="display: none" data-fallback="0"><var>roundTo(2, DDX(X))</var></td>
+							<td style="text-align: right" data-if="OPTIONS.xLabelFormat"><code>\frac{d}{dx} f(<var>OPTIONS.xLabelFormat(X)</var>) = </code></td>
+							<td style="text-align: right" data-else><code>\frac{d}{dx} f(<var>X</var>) = </code></td>
+							<td class="answer-label">0</td>
+						</tr>
+					</table>
+				</div>
+
+				<div class="hints">
+					<div>
+						<p>
+							The orange curve shows the derivative of <code>f(x)</code>. Drag all of the orange points
+							onto the orange curve. Notice how the tangent lines change as you move the orange dots.
+							Pay attention to the relationship between the tangent lines and the blue curve.
+						</p>
+						<div class="graphie" data-update="ddxplot">
+							revealDerivative();
+						</div>
+					</div>
+				</div>
+
+			</div>
+
+
+			<div id="special" data-type="polynomial">
+				<div class="vars">
+					<var id="SCENARIO">randFromArray([
+						{
+							text:    "sin(x)",
+							ddxtext: "cos(x)",
+							fnx:     function(x) { return Math.sin(x) },
+							ddx:     function(x) { return Math.cos(x) },
+							xrange:  [-1.25*Math.PI, 1.25*Math.PI],
+							yrange:  [ -1.25, 1.25 ],
+							points:  [ -1*Math.PI, -3*Math.PI/4, -Math.PI/2, -Math.PI/4, 0, Math.PI/4, Math.PI/2, 3*Math.PI/4, Math.PI ],
+							options: { xLabelFormat: piFraction }
+						}, {
+							text:    "cos(x)",
+							ddxtext: "-sin(x)",
+							fnx:     function(x) { return Math.cos(x) },
+							ddx:     function(x) { return -Math.sin(x) },
+							xrange:  [-1.25*Math.PI, 1.25*Math.PI],
+							yrange:  [ -1.25, 1.25 ],
+							points:  [ -1*Math.PI, -3*Math.PI/4, -Math.PI/2, -Math.PI/4, 0, Math.PI/4, Math.PI/2, 3*Math.PI/4, Math.PI ],
+							options: { xLabelFormat: piFraction }
+						}, {
+							text:    "e^x",
+							ddxtext: "e^x",
+							fnx:     function(x) { return Math.exp(x, Math.E) },
+							ddx:     function(x) { return Math.exp(x, Math.E) },
+							xrange:  [-5, 5],
+							yrange:  [ -5, 15 ],
+							points:  [ -2, -1, 0, 1, 2 ],
+							options: {}
+						}, {
+							text:    "ln(x)",
+							ddxtext: "\\frac{1}{x}",
+							fnx:     function(x) { return Math.log(x) },
+							ddx:     function(x) { return 1/x },
+							xrange:  [.001, 5],
+							yrange:  [ -5, 5 ],
+							points:  [ .25, .5, 1, 2, 3, 4 ],
+							options: { range: [ [ -0.25, 4.75 ], [ -5, 5 ] ] }
+						}
+					])
+					</var>
+
+					<var id="FNXTEXT">SCENARIO.text</var>
+					<var id="DDXTEXT">SCENARIO.ddxtext</var>
+					<var id="FNX">SCENARIO.fnx</var>
+					<var id="DDX">SCENARIO.ddx</var>
+					<var id="XRANGE">SCENARIO.xrange</var>
+					<var id="YRANGE">SCENARIO.yrange</var>
+					<var id="POINTS">SCENARIO.points</var>
+					<var id="OPTIONS">SCENARIO.options || {}</var>
+				</div>
+			</div>
+
+		</div>
+	</div>
+</body>
+</html>

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -28,7 +28,7 @@ jQuery.extend( Khan.answerTypes, {
 			// is empty and the fallback doesn't exist.
 			var val = input.val().length > 0 ?
 				input.val() :
-				fallback ?
+				(typeof fallback !== "undefined") ?
 					fallback + "" :
 					"";
 

--- a/utils/derivative-intuition.js
+++ b/utils/derivative-intuition.js
@@ -9,15 +9,16 @@ jQuery.extend( KhanUtil, {
 	// Wrap graphInit to create a 600x600px graph properly scaled to the given range
 	initAutoscaledGraph: function( range, options ) {
 		var graph = KhanUtil.currentGraph;
+		options = jQuery.extend({
+			xpixels: 600,
+			ypixels: 600,
+			xdivisions: 20,
+			ydivisions: 20,
+			labels: true,
+			unityLabels: true,
+			range: (typeof range === "undefined" ? [ [-10, 10], [-10, 10] ] : range),
+		}, options);
 
-		options = options || {};
-		options.xpixels = options.xpixels || 600;
-		options.ypixels = options.ypixels || 600;
-		options.xdivisions = options.xdivisions || 20;
-		options.ydivisions = options.xdivisions || 20;
-		options.labels = true;
-		options.unityLabels = true,
-		options.range = options.range || (typeof range === "undefined" ? [ [-10, 10], [-10, 10] ] : range);
 		options.scale = [ options.xpixels/(options.range[0][1] - options.range[0][0]),
 		                  options.ypixels/(options.range[1][1] - options.range[1][0]) ];
 		options.gridStep = [ (options.range[0][1] - options.range[0][0])/options.xdivisions,

--- a/utils/derivative-intuition.js
+++ b/utils/derivative-intuition.js
@@ -206,13 +206,12 @@ jQuery.extend( KhanUtil, {
 						jQuery( document ).unbind( "mousemove mouseup" );
 
 						// Snap to the right answer if we're close enough
-						// The "close enough" fudge factor is nominally 1/40th of the range (~half a grid square)
-						// Very large slopes become increasingly impossible to get right, so the fudge factor grows
-						// exponentially (at a 2% rate) to accommodate.
 						var answer = KhanUtil.ddx(KhanUtil.points[index]);
-						var fudge = ((graph.range[1][1] - graph.range[1][0]) / 40) * Math.pow(1.02, Math.abs(answer));
+						var degreesOff = Math.abs(Math.atan(answer * graph.scale[1]/graph.scale[0]) -
+								Math.atan(coordY * graph.scale[1]/graph.scale[0])) * (180/Math.PI);
 
-						if ( Math.abs(answer - coordY) < fudge ) {
+						// How far off you're allowed to be
+						if ( degreesOff < 3 ) {
 							coordY = answer;
 							mouseY = (graph.range[1][1] - coordY) * graph.scale[1];
 						}

--- a/utils/derivative-intuition.js
+++ b/utils/derivative-intuition.js
@@ -1,0 +1,277 @@
+jQuery.extend( KhanUtil, {
+	FN_COLOR: "#6495ED",
+	DDX_COLOR: "#FFA500",
+	TANGENT_COLOR: "#AAA",
+	TANGENT_LINE_LENGTH: 200,
+	TANGENT_GROWTH_FACTOR: 3,
+	TANGENT_SHIFT: 5,
+
+	// Wrap graphInit to create a 600x600px graph properly scaled to the given range
+	initAutoscaledGraph: function( range, options ) {
+		var graph = KhanUtil.currentGraph;
+
+		options = options || {};
+		options.xpixels = options.xpixels || 600;
+		options.ypixels = options.ypixels || 600;
+		options.xdivisions = options.xdivisions || 20;
+		options.ydivisions = options.xdivisions || 20;
+		options.labels = true;
+		options.unityLabels = true,
+		options.range = options.range || (typeof range === "undefined" ? [ [-10, 10], [-10, 10] ] : range);
+		options.scale = [ options.xpixels/(options.range[0][1] - options.range[0][0]),
+		                  options.ypixels/(options.range[1][1] - options.range[1][0]) ];
+		options.gridStep = [ (options.range[0][1] - options.range[0][0])/options.xdivisions,
+		                     (options.range[1][1] - options.range[1][0])/options.ydivisions ];
+
+		// Attach the resulting metrics to the graph for later reference
+		graph.xpixels = options.xpixels;
+		graph.ypixels = options.ypixels;
+		graph.range = options.range;
+		graph.scale = options.scale;
+
+		graph.graphInit(options);
+	},
+
+
+	// start the magic
+	initDerivativeIntuition: function( fnx, ddx, points ) {
+		var graph = KhanUtil.currentGraph;
+
+		KhanUtil.fnx = fnx;
+		KhanUtil.ddx = ddx;
+		KhanUtil.points = points;
+		KhanUtil.highlight = false;
+		KhanUtil.dragging = false;
+		KhanUtil.ddxShown = false;
+
+		// to store the SVG paths
+		graph.tangentLines = [];
+		graph.tangentPoints = [];
+		graph.slopePoints = [];
+		graph.mouseTargets = [];
+
+		// graphie puts text spans on top of the SVG, which looks good, but gets
+		// in the way of mouse events. So we add another SVG element on top
+		// of everything else where we can add invisible shapes with mouse
+		// handlers wherever we want. Is there a better way?
+		graph.mouselayer = Raphael( "ddxplot", graph.xpixels, graph.ypixels );
+		jQuery( graph.mouselayer.canvas ).css( "z-index", 1 );
+
+		// plot all the tangent lines first so they're underneath the tangent/slope points
+		jQuery( points ).each( function ( index, xval ) {
+			KhanUtil.plotTangentLine( index );
+		});
+
+		jQuery( points ).each( function ( index, xval ) {
+			// blue points
+			KhanUtil.plotTangentPoint( index );
+			// orange points and mouse magic
+			KhanUtil.plotSlopePoint( index );
+		});
+
+	},
+
+
+	plotTangentLine: function( index ) {
+		var graph = KhanUtil.currentGraph;
+		var xval = KhanUtil.points[index];
+		var yval = KhanUtil.fnx(xval);
+
+		// Now the fun bit: To make it clear that the tangent line only
+		// touches at a single point, it's shifted a little bit above or
+		// below the curve.
+
+		// The shifted pivot point; defaults to unshifted xval/yval in
+		// case we're dealing with an inflection point.
+		var xshift = xval;
+		var yshift = yval;
+
+		// The slope of a line perpendicular to the tangent line. It is
+		// along this direction that we shift the tangent line.
+		var perpslope = 0;
+
+		// First and second derivative at the point we're dealing with.
+		var ddx1 = KhanUtil.ddx(xval);
+		var ddx2 = (KhanUtil.ddx(xval - 0.001) - KhanUtil.ddx(xval + 0.001)) / 0.002;
+
+		if (ddx1 != 0) {
+			// We want to shift *visually* perpendicular to the tangent line,
+			// so if the graph has different x and y scales, perpslope isn't
+			// quite as simple as (-1/slope)
+			perpslope = (-1 / (ddx1 * (graph.scale[1] / graph.scale[0]))) / (graph.scale[1] / graph.scale[0]);
+
+			// Second derivative tells us if the curve is concave up or down, thus which way to
+			// shift the tangent line to "get away" from the curve. If perpslope is negative,
+			// everything is reversed.
+			if ((ddx2 > 0 && perpslope > 0) || (ddx2 < 0 && perpslope < 0)) {
+				// atan(perpslope) is the direction to shift; cos() of that gives the x component; the rest of the mess normalizes for different x- and y-scales
+				xshift = xval + Math.cos(Math.atan(perpslope * (graph.scale[1] / graph.scale[0]))) * KhanUtil.TANGENT_SHIFT / (2 * graph.scale[0]);
+				yshift = perpslope * (xshift - xval) + yval;
+			} else if ((ddx2 < 0 && perpslope > 0) || (ddx2 > 0 && perpslope < 0)) {
+				xshift = xval - Math.cos(Math.atan(perpslope * (graph.scale[1] / graph.scale[0]))) * KhanUtil.TANGENT_SHIFT / (2 * graph.scale[0]);
+				yshift = perpslope * (xshift - xval) + yval;
+			}
+		} else {
+			// Slope is 0, so perpslope is undefined. Just shift up or down based on concavity
+			if (ddx2 < 0) {
+				yshift = yval - ( KhanUtil.TANGENT_SHIFT / (2 * graph.scale[1]) );
+			} else if (ddx2 > 0) {
+				yshift = yval + ( KhanUtil.TANGENT_SHIFT / (2 * graph.scale[1]) );
+			}
+		}
+
+		// at last the slightly nudged line is ready to draw
+		graph.style({
+			stroke: KhanUtil.TANGENT_COLOR,
+			strokeWidth: 2
+		}, function() {
+			graph.tangentLines[index] = graph.line(
+					[ xshift - KhanUtil.TANGENT_LINE_LENGTH / (2 * graph.scale[0]), yshift ],
+					[ xshift + KhanUtil.TANGENT_LINE_LENGTH / (2 * graph.scale[0]), yshift ] );
+		});
+	},
+
+
+	plotTangentPoint: function( index ) {
+		var graph = KhanUtil.currentGraph;
+		var xval = KhanUtil.points[index];
+
+		graph.style({
+			fill: KhanUtil.FN_COLOR,
+			stroke: KhanUtil.FN_COLOR,
+		}, function() {
+			graph.tangentPoints[index] = graph.ellipse( [ xval, KhanUtil.fnx(xval) ], [ 4 / graph.scale[0], 4 / graph.scale[1] ] );
+		});
+	},
+
+
+	plotSlopePoint: function( index ) {
+		var graph = KhanUtil.currentGraph;
+		var xval = KhanUtil.points[index];
+
+		graph.style({
+			fill: KhanUtil.DDX_COLOR,
+			stroke: KhanUtil.DDX_COLOR,
+		}, function() {
+			graph.slopePoints[index] = graph.ellipse( [ xval, 0 ], [ 4 / graph.scale[0], 4 / graph.scale[1] ] );
+		});
+
+		// the invisible shape in front of each point that gets mouse events
+		graph.mouseTargets[index] = graph.mouselayer.circle(
+				(xval - graph.range[0][0]) * graph.scale[0],
+				(graph.range[1][1] - 0) * graph.scale[1], 15 );
+		graph.mouseTargets[index].attr({fill: "#000", "opacity": 0.0});
+
+		jQuery( graph.mouseTargets[index][0] ).css( "cursor", "move" );
+		jQuery( graph.mouseTargets[index][0] ).bind("mousedown mouseenter mouseleave", function( event ) {
+			var graph = KhanUtil.currentGraph;
+			if ( event.type === "mouseenter" ) {
+				KhanUtil.highlight = true;
+				if ( !KhanUtil.dragging ) {
+					graph.slopePoints[index].animate({ scale: 2 }, 50 );
+					graph.tangentLines[index].animate({ "stroke": KhanUtil.DDX_COLOR }, 100 );
+				}
+
+			} else if ( event.type === "mouseleave" ) {
+				KhanUtil.highlight = false;
+				if ( !KhanUtil.dragging ) {
+					graph.slopePoints[index].animate({ scale: 1 }, 50 );
+					graph.tangentLines[index].animate({ "stroke": KhanUtil.TANGENT_COLOR }, 100 );
+				}
+
+			} else if ( event.type === "mousedown" && event.which === 1 ) {
+				event.preventDefault();
+				graph.tangentLines[index].toFront();
+				graph.tangentPoints[index].toFront();
+				graph.slopePoints[index].toFront();
+				graph.tangentLines[index].animate( { scale: KhanUtil.TANGENT_GROWTH_FACTOR }, 200 );
+
+				jQuery( document ).bind("mousemove mouseup", function( event ) {
+					event.preventDefault();
+					KhanUtil.dragging = true;
+
+					// mouseY is in pixels relative to the SVG; coordY is the scaled y-coordinate value
+					var mouseY = event.pageY - jQuery( "#ddxplot" ).offset().top;
+					mouseY = Math.max(10, Math.min(graph.ypixels-10, mouseY));
+					var coordY = graph.range[1][1] - mouseY / graph.scale[1];
+
+					if ( event.type === "mousemove" ) {
+						jQuery( jQuery( "div#solution :text" )[index]).val( KhanUtil.roundTo(2, coordY) );
+						jQuery( jQuery( "div#solution .answer-label" )[index]).text( KhanUtil.roundTo(2, coordY) );
+						graph.tangentLines[index].rotate(-Math.atan(coordY * (graph.scale[1] / graph.scale[0])) * (180 / Math.PI), true);
+						graph.slopePoints[index].attr( "cy", mouseY );
+						graph.mouseTargets[index].attr( "cy", mouseY );
+
+					} else if ( event.type === "mouseup" ) {
+						jQuery( document ).unbind( "mousemove mouseup" );
+
+						// Snap to the right answer if we're close enough
+						// The "close enough" fudge factor is nominally 1/40th of the range (~half a grid square)
+						// Very large slopes become increasingly impossible to get right, so the fudge factor grows
+						// exponentially (at a 2% rate) to accommodate.
+						var answer = KhanUtil.ddx(KhanUtil.points[index]);
+						var fudge = ((graph.range[1][1] - graph.range[1][0]) / 40) * Math.pow(1.02, Math.abs(answer));
+
+						if ( Math.abs(answer - coordY) < fudge ) {
+							coordY = answer;
+							mouseY = (graph.range[1][1] - coordY) * graph.scale[1];
+						}
+
+						jQuery( jQuery( "div#solution :text" )[index]).val( KhanUtil.roundTo(2, coordY) );
+						jQuery( jQuery( "div#solution .answer-label" )[index]).text( KhanUtil.roundTo(2, coordY) );
+						graph.tangentLines[index].rotate(-Math.atan(coordY * (graph.scale[1] / graph.scale[0])) * (180 / Math.PI), true);
+						graph.slopePoints[index].attr( "cy", mouseY );
+						graph.mouseTargets[index].attr( "cy", mouseY );
+
+						KhanUtil.dragging = false;
+
+						graph.tangentLines[index].animate( { scale: 1 }, 200 );
+						if (!KhanUtil.highlight) {
+							graph.slopePoints[index].animate({ scale: 1 }, 200 );
+							graph.tangentLines[index].animate({ "stroke": KhanUtil.TANGENT_COLOR }, 100 );
+						}
+
+						// If all the points are in the right place, reveal the derivative function
+						var answers = jQuery.map(jQuery( "div#solution .answer-label" ), function(x) {
+							return parseFloat(jQuery(x).text());
+						});
+						var correct = jQuery.map(KhanUtil.points, function(x) {
+							return KhanUtil.roundTo(2, KhanUtil.ddx(x));
+						});
+						if (answers.join() === correct.join()) {
+							KhanUtil.revealDerivative(400);
+						}
+					}
+				});
+			}
+		});
+
+	},
+
+
+	// Shows the derivative plot and equation
+	// Called when all the points are in the right place or as a hint
+	revealDerivative: function( duration ) {
+		if ( !KhanUtil.ddxShown ) {
+			var graph = KhanUtil.currentGraph;
+			var ddxplot;
+			duration = duration || 0;
+			graph.style({
+				stroke: KhanUtil.DDX_COLOR,
+				strokeWidth: 1,
+				opacity: 0,
+			}, function() {
+				ddxplot = graph.plot( function( x ) {
+					return KhanUtil.ddx( x );
+				}, KhanUtil.tmpl.getVAR( "XRANGE" ) );
+			});
+
+			jQuery( "span#ddxspan" ).show();  // for IE
+			jQuery( "span#ddxspan" ).fadeTo(duration, 1);
+
+			ddxplot.animate( { opacity: 1 }, duration );
+			KhanUtil.ddxShown = true;
+		}
+	},
+
+});

--- a/utils/derivative-intuition.js
+++ b/utils/derivative-intuition.js
@@ -196,8 +196,8 @@ jQuery.extend( KhanUtil, {
 					var coordY = graph.range[1][1] - mouseY / graph.scale[1];
 
 					if ( event.type === "mousemove" ) {
-						jQuery( jQuery( "div#solution :text" )[index]).val( KhanUtil.roundTo(2, coordY) );
-						jQuery( jQuery( "div#solution .answer-label" )[index]).text( KhanUtil.roundTo(2, coordY) );
+						jQuery( jQuery( "div#solutionarea :text" )[index]).val( KhanUtil.roundTo(2, coordY) );
+						jQuery( jQuery( "div#solutionarea .answer-label" )[index]).text( KhanUtil.roundTo(2, coordY) );
 						graph.tangentLines[index].rotate(-Math.atan(coordY * (graph.scale[1] / graph.scale[0])) * (180 / Math.PI), true);
 						graph.slopePoints[index].attr( "cy", mouseY );
 						graph.mouseTargets[index].attr( "cy", mouseY );
@@ -217,8 +217,8 @@ jQuery.extend( KhanUtil, {
 							mouseY = (graph.range[1][1] - coordY) * graph.scale[1];
 						}
 
-						jQuery( jQuery( "div#solution :text" )[index]).val( KhanUtil.roundTo(2, coordY) );
-						jQuery( jQuery( "div#solution .answer-label" )[index]).text( KhanUtil.roundTo(2, coordY) );
+						jQuery( jQuery( "div#solutionarea :text" )[index]).val( KhanUtil.roundTo(2, coordY) );
+						jQuery( jQuery( "div#solutionarea .answer-label" )[index]).text( KhanUtil.roundTo(2, coordY) );
 						graph.tangentLines[index].rotate(-Math.atan(coordY * (graph.scale[1] / graph.scale[0])) * (180 / Math.PI), true);
 						graph.slopePoints[index].attr( "cy", mouseY );
 						graph.mouseTargets[index].attr( "cy", mouseY );
@@ -232,7 +232,7 @@ jQuery.extend( KhanUtil, {
 						}
 
 						// If all the points are in the right place, reveal the derivative function
-						var answers = jQuery.map(jQuery( "div#solution .answer-label" ), function(x) {
+						var answers = jQuery.map(jQuery( "div#solutionarea .answer-label" ), function(x) {
 							return parseFloat(jQuery(x).text());
 						});
 						var correct = jQuery.map(KhanUtil.points, function(x) {

--- a/utils/graphie.js
+++ b/utils/graphie.js
@@ -463,7 +463,9 @@
 				// allow symmetric ranges to be specified by the absolute values 
 				if ( prop === "range" ) {
 					if ( val.constructor === Array ) {
-						options[ prop ] = [ [ -val[0], val[0] ], [ -val[1], val[1] ] ];
+						if ( val[0].constructor !== Array ) {  // but don't mandate symmetric ranges
+							options[ prop ] = [ [ -val[0], val[0] ], [ -val[1], val[1] ] ];
+						}
 					} else if ( typeof val === "number" ) {
 						options[ prop ] = [ [ -val, val ], [ -val, val ] ];
 					}


### PR DESCRIPTION
Cleaned up pull request to account for the recent change of `#solution` to `#solutionarea`
- Adds Derivative intuition exercise
- Also fixes an issue where specifying `data-fallback="0"` didn't work.
- Also changes `graphie.graphInit()` to actually accept a non-symmetric range such as `[ [a, b], [c, d] ]` as it claims to in the comments.
