### PR TITLE
Fix #3413 - Stray comma confused IE

### DIFF
--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -73,7 +73,7 @@
 						-PI, -5*PI/6, -3*PI/4, -2*PI/3, -PI/2, -PI/3, -PI/4, -PI/6, -PI/12,
 						PI/12, PI/6, PI/4, PI/3, PI/2, 2*PI/3, 3*PI/4, 5*PI/6, PI,
 						7*PI/6, 5*PI/4, 4*PI/3, 3*PI/2, 5*PI/3, 7*PI/4, 11*PI/6, 2*PI,
-						9*PI/4, 7*PI/3, 5*PI/2, 6*PI/2,
+						9*PI/4, 7*PI/3, 5*PI/2, 6*PI/2
 					])</var>
 					<var id="PRETTY_ANGLE">piFraction(ANGLE)</var>
 					<var id="FN">randFromArray( [ "cos", "sin" ] )</var>


### PR DESCRIPTION
An extra comma in the array of angles confused IE into thinking there was a null element at the end of the array.

http://stackoverflow.com/questions/29053/javascript-browser-quirks-array-length
