### PR TITLE
Fix bug: Limit answer range

### DIFF
--- a/exercises/line_graph_intuition.html
+++ b/exercises/line_graph_intuition.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 	<div class="exercise">
-		<div class="vars" data-ensure="X1 !== X2 && !(M === 1 && B === 0)">
+		<div class="vars" data-ensure="X1 !== X2 && !(M === 1 && B === 0) && abs(M) < 10 && abs(B) < 10">
 			<var id="X1">randRange( -8, 8 )</var>
 			<var id="X2">randRange( -8, 8 )</var>
 			<var id="Y1">randRange( -8, 8 )</var>


### PR DESCRIPTION
The exercise previously could include quite a range of answers (slope of 99 or even greater), and with the current button-style entry method, this would take forever to input. Changed range to -10 < M < 10 and -10 < B < 10 for the slope and y-intercept, respectively.
