### PR TITLE
Hints update for equivalent fractions 1 & 2

### DIFF
--- a/exercises/equivalent_fractions.html
+++ b/exercises/equivalent_fractions.html
@@ -45,6 +45,12 @@
 				</div>
 				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{<var>C</var>}{<var>D</var>}</code> and so the answer is <code><var>C</var></code>.</p>
 
+				<div>
+					<p>Another way to get the answer is to multiply by <code>\dfrac{<var>M</var>}{<var>M</var>}</code>.</p>
+					<p><code>\dfrac{<var>M</var>}{<var>M</var>} = \dfrac{1}{1} = 1</code> so really we are multiplying by 1.</p>					
+				</div>
+				<p>The final equation is: <code>\dfrac{<var>A</var>}{<var>B</var>} \times \dfrac{<var>M</var>}{<var>M</var>} = \dfrac{<var>C</var>}{<var>D</var>} </code> so our answer is <code><var>C</var></code>.</p>
+
 			</div>
 		</div>
 
@@ -76,8 +82,15 @@
 						rectchart( [C, D - C], ["#e00", "#999"] );
 					</div>
 				</div>
+				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{<var>C</var>}{<var>D</var>}</code> and so the answer is <code><var>D</var></code>.</p>					
 
-				<p><code>\dfrac{<var>A</var>}{<var>B</var>} = \dfrac{<var>C</var>}{<var>D</var>}</code> and so the answer is <code><var>D</var></code>.</p>
+				<div>
+					<p>Another way to get the answer is to multiply by <code>\dfrac{<var>M</var>}{<var>M</var>}</code>.</p>
+					<p><code>\dfrac{<var>M</var>}{<var>M</var>} = \dfrac{1}{1} = 1</code> so really we are multiplying by 1.</p>					
+				</div>
+
+				<p>The final equation is: <code>\dfrac{<var>A</var>}{<var>B</var>} \times \dfrac{<var>M</var>}{<var>M</var>} = \dfrac{<var>C</var>}{<var>D</var>} </code> so our answer is <code><var>D</var></code>.</p>
+
 			</div>
 		</div>
 	</div>

--- a/exercises/equivalent_fractions_2.html
+++ b/exercises/equivalent_fractions_2.html
@@ -26,6 +26,12 @@
 				<p>To get the right numerator <code><var>C</var></code>, the left numerator <code><var>A</var></code> is multiplied by <code><var>M</var></code>.</p>
 				<p>To find the right denominator, multiply the left denominator by <code><var>M</var></code> as well.</p>
 				<p><code><var>B</var> \times <var>M</var> = <var>D</var></code></p>
+				<div>
+					<p>Notice both the numerator and denominator are being multiplied by <code>{<var>M</var>}</code>.</p>
+					<p>We can write that as <code>\dfrac{<var>M</var>}{<var>M</var>}</code>, which is equal to 1 if reduced.
+					<p>So we can solve this problem by multiplying the fraction on the left by one.</p>
+				</div>	
+				<p>The equation becomes: <code>\dfrac{<var>A</var>}{<var>B</var>} \times \dfrac{<var>M</var>}{<var>M</var>} = \dfrac{<var>C</var>}{<var>D</var>} </code> so our answer is <code><var>D</var></code>.</p>						
 			</div>
 		</div>
 
@@ -37,6 +43,12 @@
 				<p>To get the right denominator <code><var>D</var></code>, the left denominator <code><var>B</var></code> is multiplied by <code><var>M</var></code>.</p>
 				<p>To find the right numerator, multiply the left numerator by <code><var>M</var></code> as well.</p>
 				<p><code><var>A</var> \times <var>M</var> = <var>C</var></code></p>
+				<div>
+					<p>Notice both the numerator and denominator are being multiplied by <code>{<var>M</var>}</code>.</p>
+					<p>We can write that as <code>\dfrac{<var>M</var>}{<var>M</var>}</code>, which is equal to 1 if reduced.
+					<p>So we can solve this problem by multiplying the fraction on the left by one.</p>
+				</div>	
+				<p>The equation becomes: <code>\dfrac{<var>A</var>}{<var>B</var>} \times \dfrac{<var>M</var>}{<var>M</var>} = \dfrac{<var>C</var>}{<var>D</var>} </code> so our answer is <code><var>C</var></code>.</p>
 			</div>
 		</div>
 
@@ -48,6 +60,12 @@
 				<p>To get the right numerator <code><var>A</var></code>, the left numerator <code><var>C</var></code> is divided by <code><var>M</var></code>.</p>
 				<p>To find the right denominator, divide the left denominator by <code><var>M</var></code> as well.</p>
 				<p><code><var>D</var> \div <var>M</var> = <var>B</var></code></p>
+				<div>
+					<p>Notice both the numerator and denominator are being divided by <code>{<var>M</var>}</code>.</p>
+					<p>We can write that as <code>\dfrac{<var>M</var>}{<var>M</var>}</code>, which is equal to 1 if reduced.
+					<p>So we can solve this problem by dividing the fraction on the left by one.</p>
+				</div>	
+				<p>The equation becomes: <code>\dfrac{<var>C</var>}{<var>D</var>} \div \dfrac{<var>M</var>}{<var>M</var>} = \dfrac{<var>A</var>}{<var>B</var>} </code> so our answer is <code><var>B</var></code>.</p>
 			</div>
 		</div>
 
@@ -59,6 +77,12 @@
 				<p>To get the right denominator <code><var>B</var></code>, the left denominator <code><var>D</var></code> is divided by <code><var>M</var></code>.</p>
 				<p>To find the right numerator, divide the left numerator by <code><var>M</var></code> as well.</p>
 				<p><code><var>C</var> \div <var>M</var> = <var>A</var></code></p>
+				<div>
+					<p>Notice both the numerator and denominator are being divided by <code>{<var>M</var>}</code>.</p>
+					<p>We can write that as <code>\dfrac{<var>M</var>}{<var>M</var>}</code>, which is equal to 1 if reduced.
+					<p>So we can solve this problem by dividing the fraction on the left by one.</p>
+				</div>	
+				<p>The equation becomes: <code>\dfrac{<var>C</var>}{<var>D</var>} \div \dfrac{<var>M</var>}{<var>M</var>} = \dfrac{<var>A</var>}{<var>B</var>} </code> so our answer is <code><var>A</var></code>.</p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This adds hints to equivalent fractions 1 about how to multiply by M/M.

Also adds hints to equivalent fractions 2 about how to multiply/divide by M/M.

trello request is:
Add to both equivalent fractions 1 and equivalent fractions 2 a couple hints on how we can multiply by X / X because X / X = 1.

I would append these hints to the end, since the graphical hints give a nice intuition.
