### PR TITLE
Firefox workaround

### DIFF
--- a/utils/interactive.js
+++ b/utils/interactive.js
@@ -39,6 +39,10 @@ jQuery.extend( KhanUtil, {
 		// the cryptic references to scale, range, xpixels, ypixels, etc.
 		graph.xpixels = graph.raphael.canvas.offsetWidth;
 		graph.ypixels = graph.raphael.canvas.offsetHeight;
+		if (typeof graph.xpixels === "undefined") {
+			graph.xpixels = graph.raphael.width;
+			graph.ypixels = graph.raphael.height;
+		}
 		graph.scale = [ graph.scalePoint([ 1, 1 ])[0] - graph.scalePoint([ 0, 0 ])[0], graph.scalePoint([ 0, 0 ])[1] - graph.scalePoint([ 1, 1 ])[1] ];
 		xmin = 0 - (graph.scalePoint([0, 0])[0] / graph.scale[0]);
 		xmax = (graph.xpixels / graph.scale[0]) + xmin;


### PR DESCRIPTION
This should work around the firefox issue... I tested it in FF, Chrome and IE.

I really just need to better integrate with graphie rather than separately try to tease out all of the metrics from within `interactive`. I figured starting this way would be lower impact, though now I'm not so sure...
