### PR TITLE
Added new initial hint to Slope of Line Exercise

### DIFF
--- a/exercises/slope_of_a_line.html
+++ b/exercises/slope_of_a_line.html
@@ -48,6 +48,7 @@
 	</div>
 
 	<div class="hints">
+		<p>Picture an airplane moving from left to right.  If the the airplane is taking off <code>\color{<var>BLUE</var>}{/}</code> the slope is positive.  If it's landing <code>\color{<var>GREEN</var>}{\backslash}</code> the slope is negative.  When the plane has reached cruising altitude  <code>\color{<var>ORANGE</var>}{-}</code> the slope is 0.</code></p>
 		<div data-if="!GRAPH_IN_QUESTION" class="graphie" id="slope">
 			graphInit({
 				range: 10,


### PR DESCRIPTION
"Convey in the slope of a line exercise the idea of rise over run (or some reasonable hill analogy) and not just some math expression."

Added a new hint with an airplane reference.
