### PR TITLE
simplifying_radicals_2

### DIFF
--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html data-require="math math-format">
+<head>
+	<meta charset="UTF-8" />
+	<title>Simplifying radicals 2</title>
+	<script src="../khan-exercise.js"></script>
+</head>
+<body>
+	<div class="exercise">
+	<div class="problems">
+		<div id="already-simplified" data-weight="2">
+			<div class="vars">
+				<var id="NUM">randFromArray([30, 42, 66, 70, 105, 110, 154, 165, 210])</var>
+				<var id="NUM2">randFromArray([30, 42, 66, 70, 105, 110, 154, 165, 210])</var>
+			</div>
+
+			<div class="question">
+				<p>Simplify <code>\sqrt{<var>NUM</var>/<var>NUM2</var>}</code>.</p>
+			</div>
+
+			<div class="solution" data-type="radical"><var>NUM</var>/<var>NUM2</var></div>
+
+			<div class="hints">
+				<p>The number <code><var>NUM</var>/<var>NUM2</var></code> has no perfect-square factors, so <code>\sqrt{<var>NUM</var>/<var>NUM2</var>}</code> is already the simplest form.</p>
+			</div>
+		</div>
+
+		<div id="perfect-squares" data-weight="2">
+			<div class="vars">
+				<var id="NUM">randFromArray([9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225])</var>
+				<var id="NUM2">randFromArray([9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225])</var>
+				<var id="SPLIT">splitRadical(NUM)</var>
+				<var id="SPLIT2">splitRadical(NUM2)</var>
+				<var id="COEFFICIENT">SPLIT[0] === 1 ? "" : SPLIT[0]</var>
+				<var id="COEFFICIENT2">SPLIT2[0] === 1 ? "" : SPLIT2[0]</var>
+			</div>
+
+			<div class="question">
+				<p>Simplify <code>\sqrt{<var>NUM</var>/<var>NUM2</var>}</code>.</p>
+			</div>
+
+			<div class="solution" data-type="radical"><var>NUM</var>/<var>NUM2</var></div>
+
+			<div class="hints">
+				<p>The number <code><var>NUM</var>/<var>NUM2</var></code> is a perfect square, so <code>\sqrt{<var>NUM</var>/<var>NUM2</var>} = <var>COEFFICIENT</var>/<var>COEFFICIENT2</var></code>.</p>
+			</div>
+		</div>
+
+		<div id="not-yet-simple" data-weight="6">
+			<div class="vars">
+				<var id="NUM">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>
+				<var id="NUM2">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>
+				<var id="SPLIT">splitRadical(NUM)</var>
+				<var id="SPLIT2">splitRadical(NUM2)</var>
+				<var id="COEFFICIENT">SPLIT[0] === 1 ? "" : SPLIT[0]</var>
+				<var id="COEFFICIENT2">SPLIT2[0] === 1 ? "" : SPLIT2[0]</var>
+				<var id="RADICAL">SPLIT[1] === 1 ? "" : SPLIT[1]</var>
+				<var id="RADICAL2">SPLIT2[1] === 1 ? "" : SPLIT2[1]</var>
+			</div>
+
+			<div class="question">
+				<p>Simplify <code>\sqrt{<var>NUM</var>/<var>NUM2</var>}</code>.</p>
+			</div>
+
+			<div class="solution" data-type="radical"><var>NUM</var>/<var>NUM2</var></div>
+
+			<div class="hints">
+				<p>The largest perfect square that divides <code><var>NUM</var>/<var>NUM2</var></code> is <code><var>COEFFICIENT * COEFFICIENT</var>/<var>COEFFICIENT2 * COEFFICIENT2</var></code>.</p>
+				<p>Factoring it out, we have <code><var>NUM</var>/<var>NUM2</var> = <var>COEFFICIENT</var>^2/<var>COEFFICIENT2</var>^2 \cdot <var>RADICAL</var>/<var>RADICAL2</var></code>.</p>
+				<p>Thus, <code>\sqrt{<var>NUM</var>/<var>NUM2</var>} = <var>COEFFICIENT</var>/<var>COEFFICIENT2</var>\sqrt{<var>RADICAL</var>/<var>RADICAL2</var>}</code>.</p>
+			</div>
+		</div>
+	</div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
You can now simplify fractional radicals.  Since this is all about teaching students a new concept, I'm sure it'd be better to see things like 2/2*sqrt(3/5) instead of sqrt(3/5).  This is my first exercise but it was pretty straightforward so there shouldn't be any problems with it at all.
