### PR TITLE
Fix couple floating point precision issues

### DIFF
--- a/exercises/dividing_decimals_2.html
+++ b/exercises/dividing_decimals_2.html
@@ -24,7 +24,7 @@
 					graph.divider.show();
 					DUMMY = Array( graph.divider.getNumHints() );
 				</div>
-				<div class="solution" data-type="decimal"><var>QUOTIENT  / pow( 10, QUOTIENT_DECIMAL )</var></div>
+				<div class="solution" data-type="decimal"><var>Math.round(QUOTIENT / pow( 10, QUOTIENT_DECIMAL ))</var></div>
 			</div>
 		</div>
 		<div class="hints">

--- a/exercises/rounding_whole_numbers.html
+++ b/exercises/rounding_whole_numbers.html
@@ -15,7 +15,7 @@
 				<var id="NUM">+DIGITS.join( "" )</var>
 				<var id="PLACE">randFromArray([ -2, -3 ])</var>
 				<var id="TPLACE">placesLeftOfDecimal[ -PLACE ]</var>
-				<var id="ROUNDED">roundTo( PLACE, NUM )</var>
+				<var id="ROUNDED">Math.round(roundTo( PLACE, NUM ))</var>
 			</div>
 
 			<p class="question">Round <code><var>commafy( NUM )</var></code> to the nearest <var>TPLACE</var>.</p>


### PR DESCRIPTION
The root cause of exercises not accepting correct answers is due to
floating point precision on some platforms.

For issue 5198, the issue is due to the solution calculated is actually
4599.999999999. This only repros on the specific Firefox version on Mac.
The same version on Windows doesn't repro. The dividing decimals 2
exercise expects the answer to be integers so fixing the issue by
calling Math.round().

For issue 4865, the issue is likely due to the same thing. The answer
must be an integer, so also fixing the issue by calling Math.round().
