### PR TITLE
Add Exercise -- Python List Elements

### DIFF
--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -28,8 +28,6 @@
 			</div>
 		</div>
 
-
-
 		<div>
 			<div class="question">
 				<p>Given the list a = [<var>MIXEDLIST</var>], what is a[<var>INDEX</var>] ?</p>
@@ -42,17 +40,8 @@
 				<p>Element <var>INDEX</var> of the array [<var>MIXEDLIST</var>] is <var>RESULTMIXED</var></p>
 			</div>
 		</div>
-
-
-
-
-
-
-
-		
 		
 	</div>
-
 
 	</div>
 </body>

--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-require="math word-problems graphie graphie-helpers">
+<html data-require="math word-problems">
 <head>
 	<meta charset="UTF-8" />
 	<title>Python List Elements</title>
@@ -25,7 +25,7 @@
 				<p>Remember that the first element in the list is element 0.
 				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
 				<ol>
-					The elements of the array are:
+					The elements of the list are:
 					<li>a[0] = <var>NUMLIST[0]</var></li>
 					<li>a[1] = <var>NUMLIST[1]</var></li>
 					<li>a[2] = <var>NUMLIST[2]</var></li>
@@ -33,7 +33,7 @@
 					<li>a[4] = <var>NUMLIST[4]</var></li>
 					<li>a[5] = <var>NUMLIST[5]</var></li>						
 				</ol>
-				<p>Element <var>INDEX</var> of the array [<var>NUMLIST</var>] is <var>RESULTNUM</var></p>
+				<p>Element <var>INDEX</var> of the list [<var>NUMLIST</var>] is <var>RESULTNUM</var></p>
 			</div>
 		</div>
 
@@ -47,7 +47,7 @@
 				<p>Remember that the first element in the list is element 0.
 				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
 				<ol>
-					The elements of the array are:
+					The elements of the list are:
 					<li>a[0] = <var>MIXEDLIST[0]</var></li>
 					<li>a[1] = <var>MIXEDLIST[1]</var></li>
 					<li>a[2] = <var>MIXEDLIST[2]</var></li>
@@ -55,7 +55,7 @@
 					<li>a[4] = <var>MIXEDLIST[4]</var></li>
 					<li>a[5] = <var>MIXEDLIST[5]</var></li>
 				</ol>
-				<p>Element <var>INDEX</var> of the array [<var>MIXEDLIST</var>] is <var>RESULTMIXED</var></p>
+				<p>Element <var>INDEX</var> of the list [<var>MIXEDLIST</var>] is <var>RESULTMIXED</var></p>
 			</div>
 		</div>
 		

--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html data-require="math word-problems graphie graphie-helpers">
+<head>
+	<meta charset="UTF-8" />
+	<title>Python List Elements</title>
+	<script src="../khan-exercise.js"></script>
+</head>
+<body>
+	<div class="exercise">
+	<div class="vars">
+		<var id="NUMLIST">[rand(20),rand(20),rand(20),rand(20),rand(20),rand(20)]</var>
+		<var id="MIXEDLIST">[rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1 ) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1 ) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1 ) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1) + '"']</var>
+		<var id="INDEX">rand(6)</var>
+		<var id="RESULTNUM">NUMLIST[INDEX]</var>
+		<var id="RESULTMIXED">MIXEDLIST[INDEX]</var>		
+	</div>
+
+	<div class="problems">
+		<div>
+			<div class="question">
+				<p>Given the list a = [<var>NUMLIST</var>], what is a[<var>INDEX</var>] ?</p>
+			</div>
+			<div class="solution"><var>RESULTNUM</var></div>
+			<div class="hints">
+				<p>Remember that the first element in the list is element 0.
+				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
+				<p>Element <var>INDEX</var> of the array [<var>NUMLIST</var>] is <var>RESULTNUM</var></p>
+			</div>
+		</div>
+
+
+
+		<div>
+			<div class="question">
+				<p>Given the list a = [<var>MIXEDLIST</var>], what is a[<var>INDEX</var>] ?</p>
+			</div>
+			<div class="solution"><var>RESULTMIXED</var></div>
+			<div class="hints">
+				<p>Remember that you must include the quotes if your answer is a string.
+				<p>Remember that the first element in the list is element 0.
+				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
+				<p>Element <var>INDEX</var> of the array [<var>MIXEDLIST</var>] is <var>RESULTMIXED</var></p>
+			</div>
+		</div>
+
+
+
+
+
+
+
+		
+		
+	</div>
+
+
+	</div>
+</body>
+</html>

--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -24,6 +24,15 @@
 			<div class="hints">
 				<p>Remember that the first element in the list is element 0.
 				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
+				<ol>
+					The elements of the array are:
+					<li>a[0] = <var>NUMLIST[0]</var></li>
+					<li>a[1] = <var>NUMLIST[1]</var></li>
+					<li>a[2] = <var>NUMLIST[2]</var></li>
+					<li>a[3] = <var>NUMLIST[3]</var></li>
+					<li>a[4] = <var>NUMLIST[4]</var></li>
+					<li>a[5] = <var>NUMLIST[5]</var></li>						
+				</ol>
 				<p>Element <var>INDEX</var> of the array [<var>NUMLIST</var>] is <var>RESULTNUM</var></p>
 			</div>
 		</div>
@@ -37,6 +46,15 @@
 				<p>Remember that you must include the quotes if your answer is a string.
 				<p>Remember that the first element in the list is element 0.
 				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
+				<ol>
+					The elements of the array are:
+					<li>a[0] = <var>MIXEDLIST[0]</var></li>
+					<li>a[1] = <var>MIXEDLIST[1]</var></li>
+					<li>a[2] = <var>MIXEDLIST[2]</var></li>
+					<li>a[3] = <var>MIXEDLIST[3]</var></li>
+					<li>a[4] = <var>MIXEDLIST[4]</var></li>
+					<li>a[5] = <var>MIXEDLIST[5]</var></li>
+				</ol>
 				<p>Element <var>INDEX</var> of the array [<var>MIXEDLIST</var>] is <var>RESULTMIXED</var></p>
 			</div>
 		</div>

--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -9,7 +9,7 @@
 	<div class="exercise">
 	<div class="vars">
 		<var id="LIST">shuffle( ['"' + fruit(1) + '"','"' + fruit(2) + '"','"' + person(1) + '"',randRange( 0, 20 ),randRange( 0, 20 ),randRange( 0, 20 )], randRange( 3, 6 ) )</var>
-		<var id="RANDOM_INDEX">rand(LIST.length)</var>
+		<var id="RANDOM_INDEX">randRange( 0, LIST.length - 1)</var>
 		<var id="RESULT">LIST[RANDOM_INDEX]</var>
 	</div>
 

--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -8,54 +8,24 @@
 <body>
 	<div class="exercise">
 	<div class="vars">
-		<var id="NUMLIST">[rand(20),rand(20),rand(20),rand(20),rand(20),rand(20)]</var>
-		<var id="MIXEDLIST">[rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1 ) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1 ) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1 ) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1) + '"',rand(2) > 0 ? rand(20) : '"' + person(rand(10) + 1) + '"']</var>
-		<var id="INDEX">rand(6)</var>
-		<var id="RESULTNUM">NUMLIST[INDEX]</var>
-		<var id="RESULTMIXED">MIXEDLIST[INDEX]</var>		
+		<var id="LIST">shuffle( ['"' + fruit(1) + '"','"' + fruit(2) + '"','"' + person(1) + '"',randRange( 0, 20 ),randRange( 0, 20 ),randRange( 0, 20 )], randRange( 3, 6 ) )</var>
+		<var id="RANDOM_INDEX">rand(LIST.length)</var>
+		<var id="RESULT">LIST[RANDOM_INDEX]</var>
 	</div>
 
 	<div class="problems">
 		<div>
-			<div class="question">
-				<p>Given the list a = [<var>NUMLIST</var>], what is a[<var>INDEX</var>] ?</p>
-			</div>
-			<div class="solution" data-type="text"><var>RESULTNUM</var></div>
+			<p class="question">Given the list a = [<var>LIST</var>], what is a[<var>RANDOM_INDEX</var>] ?</p>
+			<div class="solution" data-type="text"><var>RESULT</var></div>
 			<div class="hints">
-				<p>Remember that the first element in the list is element 0.
-				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
+				<p>Remember that you must include the quotes if your answer is a string.</p>
+				<p>Remember that the first element in the list is element 0.</p>
+				<p>Start from the beginning of the list and count to element number <var>RANDOM_INDEX</var>.</p>
 				<ol>
 					The elements of the list are:
-					<li>a[0] = <var>NUMLIST[0]</var></li>
-					<li>a[1] = <var>NUMLIST[1]</var></li>
-					<li>a[2] = <var>NUMLIST[2]</var></li>
-					<li>a[3] = <var>NUMLIST[3]</var></li>
-					<li>a[4] = <var>NUMLIST[4]</var></li>
-					<li>a[5] = <var>NUMLIST[5]</var></li>						
+					<li data-each="LIST as index, num">a[<var>index</var>] = <var>num</var></li>
 				</ol>
-				<p>Element <var>INDEX</var> of the list [<var>NUMLIST</var>] is <var>RESULTNUM</var></p>
-			</div>
-		</div>
-
-		<div>
-			<div class="question">
-				<p>Given the list a = [<var>MIXEDLIST</var>], what is a[<var>INDEX</var>] ?</p>
-			</div>
-			<div class="solution" data-type="text"><var>RESULTMIXED</var></div>
-			<div class="hints">
-				<p>Remember that you must include the quotes if your answer is a string.
-				<p>Remember that the first element in the list is element 0.
-				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
-				<ol>
-					The elements of the list are:
-					<li>a[0] = <var>MIXEDLIST[0]</var></li>
-					<li>a[1] = <var>MIXEDLIST[1]</var></li>
-					<li>a[2] = <var>MIXEDLIST[2]</var></li>
-					<li>a[3] = <var>MIXEDLIST[3]</var></li>
-					<li>a[4] = <var>MIXEDLIST[4]</var></li>
-					<li>a[5] = <var>MIXEDLIST[5]</var></li>
-				</ol>
-				<p>Element <var>INDEX</var> of the list [<var>MIXEDLIST</var>] is <var>RESULTMIXED</var></p>
+				<p>Element <var>RANDOM_INDEX</var> of the list [<var>LIST</var>] is <var>RESULT</var></p>
 			</div>
 		</div>
 		

--- a/exercises/python_list.html
+++ b/exercises/python_list.html
@@ -20,7 +20,7 @@
 			<div class="question">
 				<p>Given the list a = [<var>NUMLIST</var>], what is a[<var>INDEX</var>] ?</p>
 			</div>
-			<div class="solution"><var>RESULTNUM</var></div>
+			<div class="solution" data-type="text"><var>RESULTNUM</var></div>
 			<div class="hints">
 				<p>Remember that the first element in the list is element 0.
 				<p>Start from the beginning of the list and count to element number <var>INDEX</var>.</p>
@@ -41,7 +41,7 @@
 			<div class="question">
 				<p>Given the list a = [<var>MIXEDLIST</var>], what is a[<var>INDEX</var>] ?</p>
 			</div>
-			<div class="solution"><var>RESULTMIXED</var></div>
+			<div class="solution" data-type="text"><var>RESULTMIXED</var></div>
 			<div class="hints">
 				<p>Remember that you must include the quotes if your answer is a string.
 				<p>Remember that the first element in the list is element 0.


### PR DESCRIPTION
Added Python list element exercise for MIT Founder's Journey class. Contains two questions, both require users to answer with the appropriate list item. One question has only numbers, while the other has a mix of numbers and strings. Its a bit messy because I don't know how to dynamically generate lists, so all the lists are of the same size.
