### PR TITLE
Remind students about the hint system when they get a problem wrong repeatedly

### DIFF
--- a/css/khan-exercise.css
+++ b/css/khan-exercise.css
@@ -98,6 +98,27 @@ var, div.graphie { white-space: pre; }
   text-shadow: 0 -1px 0 #B55C00;
 }
 
+#hint-reminder {
+  display: none;
+}
+#hint-reminder-body {
+  border: 1px solid black;
+  margin-top: 12px;
+  padding: 7px;
+  background-color: #FD8;
+}
+
+#hint-reminder-pointing-tip {
+  display: block;
+  width: 1px;
+  border-left: 15px solid #EEE;
+  border-right: 15px solid #EEE;
+  border-bottom: 12px solid #FD8;
+  margin-bottom: -12px;
+  z-index: 100;
+  margin-top: 4px;
+}
+
 .user-activity {
   margin: 5px;
   padding: 2px 5px;

--- a/exercises/khan-exercise.html
+++ b/exercises/khan-exercise.html
@@ -82,6 +82,12 @@
 				<div id="get-hint-button-container">
 					<input id="hint" type="button" class="simple-button action-gradient orange" value="I'd like a hint" name="hint"/>
 				</div>
+				<div id='hint-reminder'>
+					<div id='hint-reminder-pointing-tip'></div>
+					<div id='hint-reminder-body'>
+						Stuck? Why not get a hint? It will explain the problem in detail and show you how to solve it.
+					</div>
+				</div>
 				<span id="hint-remainder"></span>
 			</div>
 			<div class="info-box related-video-box" style="display:none;">

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1486,9 +1486,16 @@ function prepareSite() {
 		if ( pass === true ) {
 			jQuery("#happy").show();
 			jQuery("#sad").hide();
+			jQuery("#hint-reminder").hide();
 		} else {
 			jQuery("#happy").hide();
 			jQuery("#sad").show();
+
+			//at this point attempts hasn't been incremented, so this
+			//can be read as attempts >= 2
+			if (attempts >= 1 && hints.length > 0) {
+			    jQuery("#hint-reminder").show();
+			}
 
 			// Is this a message to be shown?
 			if ( typeof pass === "string" ) {
@@ -1604,6 +1611,7 @@ function prepareSite() {
 
 	// Watch for when the "Get a Hint" button is clicked
 	jQuery( "#hint" ).click(function() {
+	jQuery("#hint-reminder").hide();
 
 		if ( user && attempts === 0 ) {
 			var hintApproved = window.localStorage[ "hintApproved:" + user ];


### PR DESCRIPTION
Something I've been seeing a lot in the bug reports are students who have submitted a wrong answer twice or more (surprisingly often it's the _same_ wrong answer). The student is often very frustrated at this point, either because they are convinced that they are correct, or because they're having trouble figuring out where they went wrong.

In these cases I think it would be good to draw the students' attention to the hint system.

This commit is very ugly and I'm not attached to this implementation at all, I just want to get an idea of whether the khan folks think something like this would be valuable.
