### PR TITLE
Triangle inequality fixes

### DIFF
--- a/exercises/triangle_inequality_theorem.html
+++ b/exercises/triangle_inequality_theorem.html
@@ -92,7 +92,7 @@
 				</ul>
 				<div class="hints">
 					<p>Triangle inequality theorem states that a side must be smaller than the sum of the other two sides.</p>
-					<p>Lets check for all three sides:</p>
+					<p>Let's check for all three sides:</p>
 					<div data-each="MAIN[ 1 ] as i, v">
 						<p><code><var>MAIN[ 1 ][ i ]</var> + <var>MAIN[ 1 ][ ( i + 1 ) % 3 ]</var> = <var>( parseFloat( MAIN[ 1 ][ i ] ) + parseFloat( MAIN[ 1 ][ ( i + 1 ) % 3  ] ) ).toFixed( 1 )</var></code></p>
 						<p><code><var>MAIN[ 1 ][ ( i + 2 ) % 3 ]</var></code> is <span data-if="parseFloat( MAIN[ 1 ][ ( i + 2 ) % 3 ] ) >= ( parseFloat( MAIN[ 1 ][ i ] ) + parseFloat( MAIN[ 1 ][ ( i + 1 ) % 3  ] ) ) ">not</span> smaller than <code><var>( parseFloat( MAIN[ 1 ][ i ] ) + parseFloat( MAIN[ 1 ][ ( i + 1 ) % 3  ] ) ).toFixed( 1 )</var></code> so the theorem <span data-if="parseFloat( MAIN[ 1 ][ ( i + 2 ) % 3 ] ) >= ( parseFloat( MAIN[ 1 ][ i ] ) + parseFloat( MAIN[ 1 ][ ( i + 1 ) % 3  ] ) )">does not hold</span><span data-else>holds</span>.</p>

--- a/exercises/triangle_inequality_theorem.html
+++ b/exercises/triangle_inequality_theorem.html
@@ -41,7 +41,7 @@
 						init({
 							range: [ [ -1, 10 ], [ -7.5, 1 ] ]
 						})
-						var tr = new Triangle( [ 3, -6.5 ],  MAIN[ 0 ], 5, { "c" : HIDDEN !== 2 ?  MAIN[ 1 ][ 2 ] : "x"  ,  "a" : HIDDEN !== 0 ?  MAIN[ 1 ][ 0 ] : "x"  , "b" : HIDDEN !== 1 ?  MAIN[ 1 ][ 1 ] : "x"  } );
+						var tr = new Triangle( [ 3, -6.5 ],  MAIN[ 0 ], 5, { "sides" : [ HIDDEN !== 2 ?  MAIN[ 1 ][ 2 ] : "x", HIDDEN !== 0 ?  MAIN[ 1 ][ 0 ] : "x", HIDDEN !== 1 ?  MAIN[ 1 ][ 1 ] : "x" ] } );
 						tr.boxOut( [ [ [ -1, -10 ], [ -1, 10 ] ] ], [ 1, 0 ] );
 						tr.boxOut( [ [ [ 10, -10 ], [ 10, 10 ] ] ], [ -1, 0 ] );
 						tr.draw();
@@ -78,7 +78,7 @@
 							var sideValue = ( parseFloat( MAIN[ 1 ][ ( side + 1 ) % 3 ] ) + parseFloat( MAIN[ 1 ][ ( side + 2 ) % 3 ] ) + randRange( 1, 3 ) ).toFixed( 1 );
 							MAIN[ 1 ][ side ] = sideValue;
 						}
-						var tr = new Triangle( [ 3, -6.9 ],  MAIN[ 0 ], 5, { "c" : MAIN[ 1 ][ 2 ],  "a" : MAIN[ 1 ][ 0 ] , "b" : MAIN[ 1 ][ 1 ] } );
+						var tr = new Triangle( [ 3, -6.9 ],  MAIN[ 0 ], 5, { "sides" : [ MAIN[ 1 ][ 2 ], MAIN[ 1 ][ 0 ], MAIN[ 1 ][ 1 ] ] } );
 						tr.boxOut( [ [ [ -1, -10 ], [ -1, 10 ] ] ], [ 1, 0 ] );
 						tr.boxOut( [ [ [ 10, -10 ], [ 10, 10 ] ] ], [ -1, 0 ] );
 						tr.draw();


### PR DESCRIPTION
Hi all,

I'm fixing https://github.com/Khan/khan-exercises/issues/6861. The old Triangle "a", "b", "c" labeling method seemed to place labels incorrectly, and that part of the code was marked //DEPRECATED, so I changed it to use the new sides:[] argument. 

The number placement looks a lot better (tested in Chrome, FF, IE8).

Seeing as this is my first Pull Request ever, please let me know if I could do anything better next time!

Thanks,
~Charlie
