### PR TITLE
Fix exercise: Slope of a line #7465

### DIFF
--- a/exercises/slope_of_a_line.html
+++ b/exercises/slope_of_a_line.html
@@ -174,7 +174,7 @@
 				<var id="SLOPES">[
 					{ value: M_INIT, display: M_INIT },
 					{ value: 0, display: 0 },
-					{ value: Number.POSITIVE_INFINITY, display: "undefined" },
+					{ value: 99999, display: "undefined" },
 					{ value: 1 / M_INIT, display: "\\dfrac{1}{" + M_INIT + "}" }
 					]</var>
 				<var id="WHICH">randRange( 1, 2 )</var>

--- a/exercises/slope_of_a_line.html
+++ b/exercises/slope_of_a_line.html
@@ -147,7 +147,7 @@
 
 					style({ stroke: COLORS[index].hex });
 					plot(function( x ) {
-						return x * SLOPES[index].value + B;
+						return ( x - 1 ) * SLOPES[index].value + B;
 					}, [ -11, 11 ]);
 				</div>
 			</div>


### PR DESCRIPTION
The green line wasn't showing up when its slope had a value of positive infinity, so I changed it to a large positive number instead. It's a little hard to see since it coincides with the y-axis, but I guess its ok. Also, let me know if it's not kosher to just change it to a big number like that, and if there's a better solution.

Edit: Gave it a little space off the y-axis.

Fixes: https://github.com/Khan/khan-exercises/issues/7465
