### PR TITLE
Fix #6150 - wrong math in second hint of dividing decimals 2

### DIFF
--- a/utils/graphie-helpers-arithmetic.js
+++ b/utils/graphie-helpers-arithmetic.js
@@ -634,7 +634,7 @@ function Divider( divisor, dividend, deciDivisor, deciDividend ) {
 				+ "\\times"
 				+ "\\color{#28AE7B}{" + quotient + "}"
 				+ " = "
-				+ "\\color{#FFA500}{" + value + "}", "right" );
+				+ "\\color{#FFA500}{" + ( divisor * quotient ) + "}", "right" );
 			index++;
 			fShowFirstHalf = true;
 		}


### PR DESCRIPTION
Closes #6150. The math is now more correct than it was before. 

Second hint
- was: 54÷14=3 or 14×3=54
- now: 54÷14=3 or 14×3=42

Frankly speaking, I'm not sure if we should write "54÷14=3" at all, but that's a different story.
