### PR TITLE
Fix #4965: Make sure the labels aren't too close to each other.

### DIFF
--- a/exercises/distance_formula.html
+++ b/exercises/distance_formula.html
@@ -16,11 +16,11 @@
 </head>
 <body>
 	<div class="exercise">
-		<div class="vars" data-ensure="X1 !== X2 || Y1 !== Y2">
-			<var id="X1">randRange( -8, 7 )</var>
-			<var id="X2">randRange( -8, 7 )</var>
-			<var id="Y1">randRange( -8, 8 )</var>
-			<var id="Y2">randRange( -8, 8 )</var>
+		<div class="vars" data-ensure="Y1 !== Y2">
+			<var id="X1">randRangeExclude( -8, 10, [0, 1, 2] )</var>
+			<var id="X2">randRangeExclude( -10, 8, [-1, -2, -3, -4] )</var>
+			<var id="Y1">randRangeExclude( -8, 8, [-1, 0] )</var>
+			<var id="Y2">randRangeExclude( -8, 8, [-1, 0] )</var>
 			<var id="X_DIST">abs( X2 - X1 )</var>
 			<var id="Y_DIST">abs( Y2 - Y1 )</var>
 			<var id="HYP2">X_DIST * X_DIST + Y_DIST * Y_DIST</var>


### PR DESCRIPTION
First, make sure that both points aren't in the same line - this is the simplest solution (the alternative is to ensure that the distance from each other is > 6 when X1 > X2)

Next, as we hardcode that label for x1 shall be on left and x2 on right, we may predict forbidden positions. The first point (label on left) shall not go too far left and shall avoid positions on the right of the Y axis.
Similarly X2 (label on right) shall avoid positions on the left of Y axis (note that, in 3 quater the coordinates take more space due to two minuses, like: -4 -4, so we have to forbid column -4 as well) and close to right border.

On the Y axis, we should just make sure that we don't collide with axis labels - it's enough to avoid line -1.

All that makes the exercise a bit harder (labels from -10, not -8, small numbers are now less probable).
