### PR TITLE
Fix #7502 - Add labels to charts

### DIFF
--- a/exercises/slope_of_a_line.html
+++ b/exercises/slope_of_a_line.html
@@ -7,8 +7,8 @@
 	<style type="text/css">
 		.quarter-graph {
 			float: left;
-			padding-bottom: 20px;
-			padding-right: 20px;
+			margin-bottom: 45px;
+			margin-right: 45px;
 		}
 	</style>
 </head>
@@ -146,6 +146,8 @@
 					});
 
 					style({ stroke: COLORS[index].hex });
+					label([0,-6], "\\color{<var>" + COLORS[index].hex + "</var>}" +
+								  "{\\text{" + COLORS[index].name + "}}", "below");
 					plot(function( x ) {
 						return ( x - 1 ) * SLOPES[index].value + B;
 					}, [ -11, 11 ]);


### PR DESCRIPTION
Fix #7502 - Add labels to charts

Additionally, using margin instead of padding looks nicer - we don't have the dashed-lines bounding box being bigger than charts.
