### PR TITLE
Substitution rewind, added abs() to data-ensure to handle special cases

### DIFF
--- a/exercises/systems_of_equations_with_substitution.html
+++ b/exercises/systems_of_equations_with_substitution.html
@@ -14,16 +14,16 @@
 	<div class="exercise">
 		<div class="vars">
 			<var id="X">randRangeNonZero( -10, 10 )</var>
-			<var id="Y" data-ensure="X !== Y">randRangeNonZero( -10, 10 )</var>
+			<var id="Y" data-ensure="abs( X ) !== abs( Y )">randRangeNonZero( -10, 10 )</var>
 		</div>
 		<div class="problems">
 			<div id="substitution-y">
 				<div class="vars">
-					<var id="A1">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
-					<var id="B1">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
+					<var id="A1" data-ensure="( abs( A1 * X ) - abs( 6 * Y ) ) < 13">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
+					<var id="B1" data-ensure="abs( A1 * X + B1 * Y ) < 13">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
 					<var id="C1">A1 * X + B1 * Y</var>
 					<var id="B2">1</var>
-					<var id="A2" data-ensure="abs( A2 * X + B2 * Y ) !== 0 && ( A1 * B2 ) !== ( A2 * B1 )">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
+					<var id="A2" data-ensure="abs( A2 * X + B2 * Y ) < 13 && abs( A2 * X + B2 * Y ) !== 0 && ( A1 * B2 ) !== ( A2 * B1 )">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
 					<var id="C2">A2 * X + B2 * Y</var>
 					<var id="SIGN_1">B1 * C2 &gt; 0 ? "-" : "+"</var>
 					<var id="SIGN_2">A1 * X &gt; 0 ? "-" : "+"</var>
@@ -70,11 +70,11 @@
 			</div>
 			<div id="substitution-x">
 				<div class="vars">
-					<var id="A1">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
-					<var id="B1">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
+					<var id="A1" data-ensure="( abs( A1 * X ) - abs( 6 * Y ) ) < 13">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
+					<var id="B1" data-ensure="abs( A1 * X + B1 * Y ) < 13">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
 					<var id="C1">A1 * X + B1 * Y</var>
 					<var id="A2">1</var>
-					<var id="B2" data-ensure="abs( A2 * X + B2 * Y ) !== 0 && ( A1 * B2 ) !== ( A2 * B1 )">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
+					<var id="B2" data-ensure="abs( A2 * X + B2 * Y ) < 13 && abs( A2 * X + B2 * Y ) !== 0 && ( A1 * B2 ) !== ( A2 * B1 )">randRange( 1, 6 ) * randRangeNonZero( -1, 1 )</var>
 					<var id="C2">A2 * X + B2 * Y</var>
 					<var id="SIGN_1">A1 * C2 &gt; 0 ? "-" : "+"</var>
 					<var id="SIGN_2">B1 * Y &gt; 0 ? "-" : "+"</var>


### PR DESCRIPTION
Added the data-ensures back to keep numbers small, and I think I handled the cases that were causing problems as well by making sure abs( X ) !== abs( Y )

I tried the bad seeds that were in the issues, and they work now.
