### PR TITLE
Elimination 0.5: Anchored index to control problem type, changed hint colors

### DIFF
--- a/exercises/systems_of_equations_with_elimination_0.5.html
+++ b/exercises/systems_of_equations_with_elimination_0.5.html
@@ -15,7 +15,7 @@
 		<div class="vars">
 			<var id="X">randRange( 1, 10 )</var>
 			<var id="Y" data-ensure="X !== Y">randRange( 1, 10 )</var>
-			<var id="INDEX">randRange( 0, 3 )</var>
+			<var id="INDEX">0</var>
 			<var id="Z1">randRangeWeighted( 1, 3, 1, 0.5 ) * randRangeNonZero( -1, 1 )</var>
 			<var id="Z2" data-ensure="abs( Z2 ) <= 6 && Z2 !== 0">INDEX === 0 ? -1 * Z1 : randRangeWeighted( -4, 4, -1, 0 ) * Z1</var>
 			<var id="Z3">randRange( 2, 6 ) * randRangeNonZero( -1, 1 )</var>
@@ -29,7 +29,7 @@
 					<var id="A1">[ Z1, Z1, Z2, Z5 ][ INDEX ]</var>
 					<var id="B1">Z3</var>
 					<var id="C1">A1 * X + B1 * Y</var>
-					<var id="A2">-A1</var>
+					<var id="A2">[ Z2, Z2, Z1, Z6 ][ INDEX ]</var>
 					<var id="B2">Z4</var>
 					<var id="C2">A2 * X + B2 * Y</var>
 					<var id="MULT1">[ 1, -A2 / A1, 1, A2 &gt; 0 &amp;&amp; A1 &lt; 0 ? A2 : -A2 ][ INDEX ]</var>
@@ -49,7 +49,7 @@
 				<div class="hints">
 					<p>We can eliminate <code>x</code> by adding the equations together when the <code>x</code> coefficients have opposite signs.</p>
 					<div>
-					    <p>Add the equations together. Notice that the terms <code class="hint_green"><var>expr(["*", A1, "x"])</var></code> and <code class="hint_blue"><var>expr(["*", A2, "x"])</var></code> cancel out.</p>
+					    <p>Add the equations together. Notice that the terms <code class="hint_blue"><var>expr(["*", A1, "x"])</var></code> and <code class="hint_green"><var>expr(["*", A2, "x"])</var></code> cancel out.</p>
 					</div>
 					<div>    
 						<p data-if="( B1 * MULT1 + B2 * MULT2 ) !== 1"><code><var>expr(["*", B1 * MULT1 + B2 * MULT2, "y"])</var> = <var>C1 * MULT1 + C2 * MULT2</var></code></p>
@@ -82,7 +82,7 @@
 					<var id="B1">[ Z1, Z1, Z2, Z5 ][ INDEX ]</var>
 					<var id="C1">A1 * X + B1 * Y</var>
 					<var id="A2">Z4</var>
-					<var id="B2">-B1</var>
+					<var id="B2">[ Z2, Z2, Z1, Z6 ][ INDEX ]</var>
 					<var id="C2">A2 * X + B2 * Y</var>
 					<var id="MULT1">[ 1, -B2 / B1, 1, B2 &gt; 0 &amp;&amp; B1 &lt; 0 ? B2 : -B2 ][ INDEX ]</var>
 					<var id="MULT2">[ 1, 1, -B1 / B2, B2 &gt; 0 &amp;&amp; B1 &lt; 0 ? -B1 : B1 ][ INDEX ]</var>
@@ -101,7 +101,7 @@
 				<div class="hints">
 					<p>We can eliminate <code>y</code> by adding the equations together when the <code>y</code> coefficients have opposite signs.</p>
 					<div>
-						<p>Add the equations together. Notice that the terms <code class="hint_green"><var>expr(["*", B1, "y"])</var></code> and <code class="hint_blue"><var>expr(["*", B2, "y"])</var></code> cancel out.</p>
+						<p>Add the equations together. Notice that the terms <code class="hint_blue"><var>expr(["*", B1, "y"])</var></code> and <code class="hint_green"><var>expr(["*", B2, "y"])</var></code> cancel out.</p>
 					</div>
 					<div>	    
 						<p data-if="( A1 * MULT1 + A2 * MULT2 ) !== 1"><code><var>expr(["*", A1 * MULT1 + A2 * MULT2, "x"])</var> = <var>C1 * MULT1 + C2 * MULT2</var></code></p>


### PR DESCRIPTION
In the following problem, the hint shown after the variable is eliminated doesn't match up with the original equations:

http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/systems_of_equations_with_elimination_0.5.html?seed=122&debug

Using the "Index" should fix that. Also, switched blue and green.
