### PR TITLE
Fix #8115 - localStorage LRU abstraction - quota problems

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -59,7 +59,9 @@ function LocalStorageLRU( lru_name, limit, upgrade_fun ) {
 
     // No index present yet and we're given upgrade_fun. Create index.
     with_lru( function( lru_idx ) {
-	if ( typeof window.localStorage[ lru_idx_key_name ] === 'undefined' && upgrade_fun ) {
+	// localStorage for unknown value returns undefined in all
+	// browsers and null in ff.
+	if ( !window.localStorage[ lru_idx_key_name ] && upgrade_fun ) {
 	    var order = {}; // key --> date
 	    for ( var i = 0; i < window.localStorage.length; i++ ) {
 		var k = window.localStorage.key( i );

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -131,9 +131,9 @@ var Khan = (function() {
 	// Wrapper on top of localStorage to store exercises
 	localStorageExercises = new LocalStorageLRU( "exercises", 40,
 						     function ( key, value ) {
-							 if ( !/^exercise/.test( key ) ) return null;
-							 var data = JSON.parse( value );
-							 return data.last_done || data.first_done || '1970-01-01T00:00:00Z';
+							     if ( !/^exercise/.test( key ) ) return null;
+							     var data = JSON.parse( value );
+							     return data.last_done || data.first_done || '1970-01-01T00:00:00Z';
 						     } ),
 
 	// The current problem and its corresponding exercise
@@ -2517,7 +2517,7 @@ var Khan = (function() {
 			// Cache the data locally
 			if ( user != null ) {
 				localStorageExercises.set( "exercise:" + user + ":" + exerciseName,
-							  JSON.stringify( data ) );
+							   JSON.stringify( data ) );
 			}
 
 		// If no data is provided then we're just updating the UI

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -35,15 +35,24 @@
 */
 
 
-// window.localStorage is cool. But, it has a limited storage. In
-// order to avoid QUOTA_EXCEEDED_ERR exception we should make sure
-// that we don't store too much data. The solution to this is quite
-// simple: let's create a simple LRU structure. All the items are
-// stored in localStorage as usual and we add another item xxx_lru_idx,
-// which is an array of keys, ordered by the time of last use. Keys
-// recently used will be closer to the end of the lru_idx. When the
-// size of the index is exceeded - we just remove items at the
+// window.localStorage is cool, but it has a limited storage. In order
+// to avoid QUOTA_EXCEEDED_ERR exception we should make sure that we
+// don't store too much data. The solution to this is quite simple:
+// let's use a simple abstract LRU structure. The items are stored in
+// localStorage as usual and we add another index xxx_lru_idx, which
+// is an array of keys, ordered by the time of last use. Keys recently
+// used will be closer to the end of that list. When the size of the
+// list gets above threshold - we will remove items from the
 // beginning.
+//
+// The constructor takes:
+//   lru_name - prefix name, in order to enable multiple LRU lists
+//   limit - maximum size of index (ie: max number of elements for this LRU)
+//   upgrade_fun - If the index isn't present yet, we iterate over all the
+//        keys in localStorage and try to create one. This function is called
+//        for every found key. It should return null if the key doesn't belong
+//        to our bucket or a value which will be used to sort items and get
+//        proper initial ordering.
 function LocalStorageLRU( lru_name, limit, upgrade_fun ) {
     var lru_idx_key_name = lru_name + '_lru_idx';
 

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -66,10 +66,11 @@ function LocalStorageLRU( lru_name, limit, upgrade_fun ) {
 	    for ( var i = 0; i < window.localStorage.length; i++ ) {
 		var k = window.localStorage.key( i );
 		var d = upgrade_fun( k, window.localStorage[ k ] );
-		if ( d ) { order[ k ] = d; }
+		if ( d !== null ) { order[ k ] = d; }
 	    }
 	    lru_idx = []
 	    for(k in order) lru_idx.push(k);
+	    lru_idx.sort( function ( k1, k2 ) {return order[ k1 ] < order[ k2 ] ? -1 : 1;} );
 	}
 	return lru_idx;
     } );
@@ -207,9 +208,9 @@ var Khan = (function() {
 	// Wrapper on top of localStorage to store exercises
 	localStorageExercises = new LocalStorageLRU( "exercises", 40,
 						     function ( key, value ) {
-							 if ( !/^exercise/.test( key ) ) return false;
+							 if ( !/^exercise/.test( key ) ) return null;
 							 var data = JSON.parse( value );
-							 return data.last_done || data.first_done || '0';
+							 return data.last_done || data.first_done || '1970-01-01T00:00:00Z';
 						     } ),
 
 	// The current problem and its corresponding exercise

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -34,7 +34,6 @@
 
 */
 
-
 var Khan = (function() {
 	function warn( message, showClose ) {
 		jQuery(function() {

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -80,7 +80,8 @@ function LocalStorageLRU( lru_name, limit, upgrade_fun ) {
 		lru_idx.push( key );
 		while ( lru_idx.length > limit ) {
 		    var k = lru_idx.shift();
-		    delete window.localStorage[ k ];
+		    if (k in window.localStorage)
+			delete window.localStorage[ k ];
 		}
 		return lru_idx;
 	    } );
@@ -100,7 +101,8 @@ function LocalStorageLRU( lru_name, limit, upgrade_fun ) {
 	    with_lru( function( lru_idx ) {
 		return _.without( lru_idx, key );
 	    } );
-	    delete window.localStorage[ key ];
+	    if (key in window.localStorage)
+		delete window.localStorage[ key ];
 	}
     }
     return lru;

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -68,8 +68,8 @@ function LocalStorageLRU( lru_name, limit, upgrade_fun ) {
 		var d = upgrade_fun( k, window.localStorage[ k ] );
 		if ( d ) { order[ k ] = d; }
 	    }
-	    lru_idx = Object.keys( order );
-	    lru_idx.sort( function ( k1, k2 ) {return order[ k1 ] > order[ k2 ];} );
+	    lru_idx = []
+	    for(k in order) lru_idx.push(k);
 	}
 	return lru_idx;
     } );


### PR DESCRIPTION
As discussed in #8115 - it's possible to exceed the quota on `window.localStorage`.

Proposed solution is to wrap all the sets/gets to exercises localStorage data in a simple LRU abstraction. By keeping ordered index we will know which items weren't used for a while and we'll be able to remove the oldest ones when the threshold is reached.

 1) I arbitrarily set the threshold to 40 entries.

 2) The code uses `underscore` library. I assume that it's loaded at the time when `handleSubmit`, `updateData` or `getData` will be called.

 3) Actually, it may make sense to pull the LRU abstraction to another file. Suggestions welcome. (beware LRU is actually initiated quite early on, before other dependencies are loaded)

 4) I've written few tests for the LRU abstraction code, see: 3795e409f93166f1713f9cd00b5a1c9e65d56ffe (not part of this pull request). The tests run successfully on recent Firefox, Chrome, Opera, Safari and IE8.

 5) Beware, that sandcastle version of `khan-exercises` doesn't use localStorage at all - I'm not able to test if my pull request actually works (although, as mentioned before, the LRU abstraction was tested separately). Further verification may be required.
