### PR TITLE
Explain why certain answers are wrong in Congruency postulates

### DIFF
--- a/exercises/congruency_postulates.html
+++ b/exercises/congruency_postulates.html
@@ -106,12 +106,16 @@
 						interactiveTriangle.update();
 						if ( guess[0] == null ) {
 							return "";
-						} else if ( guess[0] !== ANSWER ) {
-							return false;
 						} else if ( !isTriangle ) {
 							return "Your answer is almost correct, but you haven't constructed a triangle.";
-						} else if ( ANSWER === "No" &amp;&amp; isCongruent ) {
+						} else if ( guess[0] === "Yes" &amp;&amp; !isCongruent ) {
+							return "The triangle you constructed is not congruent. It proves that " + NAME + " is not a congruency postulate.";
+						} else if ( ANSWER === "No" &amp;&amp; guess[0] === "No" &amp;&amp; isCongruent ) {
 							return "Your answer is almost correct, but the two triangles are congruent. Prove your answer by trying to construct an incongruent triangle.";
+						} else if ( ANSWER === "No" &amp;&amp; guess[0] === "Yes") {
+							return "Your answer is almost correct, but there is another incongruent triangle that can be constructed, so " + NAME + " is not a congruency postulate. Try to construct it.";
+						} else if ( guess[0] !== ANSWER ) {
+							return false;
 						} else {
 							return true;
 						}


### PR DESCRIPTION
In Congruency postulates, it might not be crystal clear why your answer isn't accepted if you construct a congruent triangle by an invalid congruency theorem. I added explanation for these cases.
