### PR TITLE
Workaround for IE weirdness

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -982,7 +982,18 @@ var Khan = (function() {
 
 			// Then add rules specific to this exercise.
 			jQuery.each( exercise.data("style"), function( i, styleContents ) {
-				exerciseStyleElem.append( styleContents );
+//				exerciseStyleElem.append( styleContents );
+//
+//			The above (commented) line fails horribly if all of the following conditions are met:
+//				- Internet explorer
+//				- Loading exercise through [dev] appengine, not standalone exercise framework
+//				- Exercise has a <style> tag
+//				- The exercise is loaded through a summative exercise, not on its own
+//
+//			Otherwise (i.e. almost always), the above line works just fine.
+//			But since ( almost always !== always ), this hack appears to work:
+//
+				jQuery( "<style type='text/css'>" + styleContents + "</style>" ).appendTo( "head" );
 			});
 		}
 


### PR DESCRIPTION
The pre-algebra challenge is broken and this fixes it, but I have no idea why. The comments in the code explain the strange behavior I saw.

@spicyj @divad12 @joelburget @marcia @anyoneelsewhounderstandskhanexercise.js Any ideas what's going on?
