### PR TITLE
Issue #8317 (chain rule 1) - Special derivative simplifications

### DIFF
--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -27,11 +27,11 @@
 				( ( OUTER.f[0] === '^' &amp;&amp; OUTER.f[1] === 'e' &amp;&amp; INNER.f[0] === 'ln' )
 					|| ( OUTER.f[0] === 'ln' &amp;&amp; INNER.f[0] === '^' &amp;&amp; INNER.f[1] == 'e' ) )
 					? [['frac', 'x', 'x'], '1']
-					: false
+					: []
 			</var>
 
 			<var id="DERIVATIVE">
-				DERIVATIVE_SIMPLIFICATIONS === false
+				DERIVATIVE_SIMPLIFICATIONS.length === 0
 					? expr(UNSIMPLIFIED_DERIVATIVE)
 					: expr(DERIVATIVE_SIMPLIFICATIONS[DERIVATIVE_SIMPLIFICATIONS.length - 1])
 			</var>
@@ -85,9 +85,9 @@
 			<p>The derivative of <code><var>OUTER.fText</var></code> with respect to <code><var>INNER.fText</var></code> is <code><var>OUTER.ddxFText</var></code>.</p>
 			<p>The derivative of <code><var>INNER.fText</var></code> with respect to <code>x</code> is <code><var>INNER.ddxFText</var></code>.</p>
 			
-			<p data-if="DERIVATIVE_SIMPLIFICATIONS !== false">The derivative at this point is <code><var>expr(UNSIMPLIFIED_DERIVATIVE)</var></code>, but this expression can be simplified.</p>
+			<p data-if="DERIVATIVE_SIMPLIFICATIONS.length !== 0">The derivative at this point is <code><var>expr(UNSIMPLIFIED_DERIVATIVE)</var></code>, but this expression can be simplified.</p>
 			
-			<div data-if="DERIVATIVE_SIMPLIFICATIONS !== false" data-each="DERIVATIVE_SIMPLIFICATIONS as i, newexpr">
+			<div data-if="DERIVATIVE_SIMPLIFICATIONS.length !== 0" data-each="DERIVATIVE_SIMPLIFICATIONS as i, newexpr">
 				<p><code><var>expr( i === 0 ? UNSIMPLIFIED_DERIVATIVE : DERIVATIVE_SIMPLIFICATIONS[i - 1] )</var></code> can be simplified to <code><var>expr(newexpr)</var></code>.</p>
 			</div>
 

--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -74,6 +74,9 @@
 					<li><code><var>
 						expr(randFromArray(OUTER.wrongs))
 					</var></code></li>
+					<li><code>
+						1
+					</code></li>
 				</ul>
 			</div>
 		</div>

--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -21,19 +21,19 @@
 				<var id="OUTER_WRONG_2">randFromArray( OUTER.wrongs )</var>
 			</div>
 			
-			<var id="UNSIMPLIFIED_DERIVATIVE">expr(['*', OUTER.ddxF, INNER.ddxF])</var>
+			<var id="UNSIMPLIFIED_DERIVATIVE">['*', OUTER.ddxF, INNER.ddxF]</var>
 			
-			<var id="SIMPLIFIES_TO">
+			<var id="DERIVATIVE_SIMPLIFICATIONS">
 				( ( OUTER.f[0] === '^' &amp;&amp; OUTER.f[1] === 'e' &amp;&amp; INNER.f[0] === 'ln' )
 					|| ( OUTER.f[0] === 'ln' &amp;&amp; INNER.f[0] === '^' &amp;&amp; INNER.f[1] == 'e' ) )
-					? '1'
+					? [['frac', 'x', 'x'], '1']
 					: false
 			</var>
 
 			<var id="DERIVATIVE">
-				SIMPLIFIES_TO === false
-					? UNSIMPLIFIED_DERIVATIVE
-					: expr(SIMPLIFIES_TO)
+				DERIVATIVE_SIMPLIFICATIONS === false
+					? expr(UNSIMPLIFIED_DERIVATIVE)
+					: expr(DERIVATIVE_SIMPLIFICATIONS[DERIVATIVE_SIMPLIFICATIONS.length - 1])
 			</var>
 
 			<var id="NOTATION">funcNotation("x")</var>

--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -21,7 +21,13 @@
 				<var id="OUTER_WRONG_2">randFromArray( OUTER.wrongs )</var>
 			</div>
 
-			<var id="DERIVATIVE">expr(["*", OUTER.ddxF, INNER.ddxF])</var>
+			<var id="DERIVATIVE">
+			    ( ( OUTER.f[0] === '^' &amp;&amp; OUTER.f[1] === 'e' &amp;&amp; INNER.f[0] === 'ln' )
+			        || ( OUTER.f[0] === 'ln' &amp;&amp; INNER.f[0] === '^' &amp;&amp; INNER.f[1] == 'e' ) )
+			        ? '1'
+			        : expr(["*", OUTER.ddxF, INNER.ddxF])
+			</var>
+
 			<var id="NOTATION">funcNotation("x")</var>
 		</div>
 

--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -10,6 +10,13 @@
 		<div class="vars">
 			<var id="INNER">generateFunction("x")</var>
 			<var id="OUTER">new CalcFunctions[randRange(1, CalcFunctions.length - 1)](INNER.f)</var>
+			
+			<var id="PRE_SIMPLIFICATION">
+				( ( OUTER.f[0] === '^' &amp;&amp; OUTER.f[1] === 'e' &amp;&amp; INNER.f[0] === 'ln' )
+					|| ( OUTER.f[0] === 'ln' &amp;&amp; INNER.f[0] === '^' &amp;&amp; INNER.f[1] == 'e' ) )
+					? 'x'
+					: null
+			</var>
 
 			<div data-ensure="expr(INNER_WRONG_1) !== expr(['-', INNER.ddxF]) || expr(OUTER_WRONG_1) !== expr(['-', OUTER.ddxF])">
 				<var id="INNER_WRONG_1">randFromArray( INNER.wrongs )</var>
@@ -95,6 +102,8 @@
 			</div>
 
 			<p>So <code><var>NOTATION.ddxF</var> = <var>DERIVATIVE</var></code>.</p>
+			
+			<p data-if="PRE_SIMPLIFICATION !== null">Interestingly, if we simplify the function before we take the derivative, we can reach the answer more quickly: <code><var>OUTER.fText</var></code> simplifies to <code><var>expr(PRE_SIMPLIFICATION)</var></code>, and <code>\frac{d}{dx}(<var>expr(PRE_SIMPLIFICATION)</var>)</code> is <code><var>DERIVATIVE</var></code>.</p>
 		</div>
 	</div>
 </body>

--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -84,6 +84,12 @@
 
 			<p>The derivative of <code><var>OUTER.fText</var></code> with respect to <code><var>INNER.fText</var></code> is <code><var>OUTER.ddxFText</var></code>.</p>
 			<p>The derivative of <code><var>INNER.fText</var></code> with respect to <code>x</code> is <code><var>INNER.ddxFText</var></code>.</p>
+			
+			<p data-if="DERIVATIVE_SIMPLIFICATIONS !== false">The derivative at this point is <code><var>expr(UNSIMPLIFIED_DERIVATIVE)</var></code>, but this expression can be simplified.</p>
+			
+			<div data-if="DERIVATIVE_SIMPLIFICATIONS !== false" data-each="DERIVATIVE_SIMPLIFICATIONS as i, newexpr">
+				<p><code><var>expr( i === 0 ? UNSIMPLIFIED_DERIVATIVE : DERIVATIVE_SIMPLIFICATIONS[i - 1] )</var></code> can be simplified to <code><var>expr(newexpr)</var></code>.</p>
+			</div>
 
 			<p>So <code><var>NOTATION.ddxF</var> = <var>DERIVATIVE</var></code>.</p>
 		</div>

--- a/exercises/chain_rule_1.html
+++ b/exercises/chain_rule_1.html
@@ -20,12 +20,20 @@
 				<var id="INNER_WRONG_2">randFromArray( INNER.wrongs )</var>
 				<var id="OUTER_WRONG_2">randFromArray( OUTER.wrongs )</var>
 			</div>
+			
+			<var id="UNSIMPLIFIED_DERIVATIVE">expr(['*', OUTER.ddxF, INNER.ddxF])</var>
+			
+			<var id="SIMPLIFIES_TO">
+				( ( OUTER.f[0] === '^' &amp;&amp; OUTER.f[1] === 'e' &amp;&amp; INNER.f[0] === 'ln' )
+					|| ( OUTER.f[0] === 'ln' &amp;&amp; INNER.f[0] === '^' &amp;&amp; INNER.f[1] == 'e' ) )
+					? '1'
+					: false
+			</var>
 
 			<var id="DERIVATIVE">
-			    ( ( OUTER.f[0] === '^' &amp;&amp; OUTER.f[1] === 'e' &amp;&amp; INNER.f[0] === 'ln' )
-			        || ( OUTER.f[0] === 'ln' &amp;&amp; INNER.f[0] === '^' &amp;&amp; INNER.f[1] == 'e' ) )
-			        ? '1'
-			        : expr(["*", OUTER.ddxF, INNER.ddxF])
+				SIMPLIFIES_TO === false
+					? UNSIMPLIFIED_DERIVATIVE
+					: expr(SIMPLIFIES_TO)
 			</var>
 
 			<var id="NOTATION">funcNotation("x")</var>


### PR DESCRIPTION
This fix makes the derivatives of e^(ln x) and ln(e^x) show in their simplified form (1) in the answer list.
