### PR TITLE
Align vocabulary with high school geometry textbooks

### DIFF
--- a/exercises/congruency_postulates.html
+++ b/exercises/congruency_postulates.html
@@ -48,7 +48,6 @@
 					<strong>Is <em><var>NAME</var></em> a triangle congruency postulate?</strong><br />
 					Answer the question by clicking and dragging the points below to see how many different triangles you can construct.<br />
 					If you can only construct congruent triangles, then the <var>NAME</var> postulate is true. The <var>NAME</var> postulate is not true if you can construct two or more different triangles using the given information.
-<!--					If you believe <var>NAME</var> is not a triangle congruency postulate, prove it by constructing incongruent triangles. Otherwise, construct congruent triangles. -->
 				</p>
 				<div class="question">
 					<em>Your triangle can be anywhere. There is no need to line up the two triangles.</em>

--- a/exercises/congruency_postulates.html
+++ b/exercises/congruency_postulates.html
@@ -74,7 +74,7 @@
 					<div class="instruction">
 						<ul>
 							<li><input type="radio" name="solution" id="r1" value="Yes" /><label for="r1"><span class="value">
-								Yes &mdash; And I've constructed a congruent triangle.
+								Yes &mdash; And I've constructed a congruent triangle, and this is the <strong>ONLY</strong> triangle I can construct with these constraints.
 							</span></label></li>
 							<li><input type="radio" name="solution" id="r2" value="No" /><label for="r2"><span class="value">
 								No &mdash; And I've proven it by constructing an incongruent triangle.

--- a/exercises/congruency_postulates.html
+++ b/exercises/congruency_postulates.html
@@ -46,8 +46,9 @@
 				</div>
 				<p class="problem">
 					<strong>Is <em><var>NAME</var></em> a triangle congruency postulate?</strong><br />
-					Answer the question by clicking and dragging the points below to see what triangles you can construct.<br />
-					If you believe <var>NAME</var> is not a triangle congruency postulate, prove it by constructing incongruent triangles. Otherwise, construct congruent triangles.
+					Answer the question by clicking and dragging the points below to see how many different triangles you can construct.<br />
+					If you can only construct congruent triangles, then the <var>NAME</var> postulate is true. The <var>NAME</var> postulate is not true if you can construct two or more different triangles using the given information.
+<!--					If you believe <var>NAME</var> is not a triangle congruency postulate, prove it by constructing incongruent triangles. Otherwise, construct congruent triangles. -->
 				</p>
 				<div class="question">
 					<em>Your triangle can be anywhere. There is no need to line up the two triangles.</em>
@@ -74,10 +75,10 @@
 					<div class="instruction">
 						<ul>
 							<li><input type="radio" name="solution" id="r1" value="Yes" /><label for="r1"><span class="value">
-								Yes &mdash; And I've constructed a congruent triangle, and this is the <strong>ONLY</strong> triangle I can construct with these constraints.
+								Yes &mdash; And I've constructed a congruent triangle, and this is the <strong>ONLY</strong> triangle I can construct with these conditions.
 							</span></label></li>
 							<li><input type="radio" name="solution" id="r2" value="No" /><label for="r2"><span class="value">
-								No &mdash; And I've proven it by constructing an incongruent triangle.
+								No &mdash; And I've proven it by constructing an incongruent triangle (a counter-example).
 							</span></label></li>
 						</ul>
 					</div>

--- a/exercises/graphing_linear_equations.html
+++ b/exercises/graphing_linear_equations.html
@@ -18,7 +18,7 @@
 				<var id="A">SLOPE_FRAC[0] * -MULT</var>
 				<var id="B">SLOPE_FRAC[1] * MULT</var>
 				<var id="C">SLOPE_FRAC[1] * YINT * MULT</var>
-				<var id="STD_FORM">random() &lt; 0.2</var>
+				<var id="STD_FORM">random() &lt; 0.3</var>
 			</div>
 
 			<p class="question">Graph the following equation:</p>


### PR DESCRIPTION
We have changed some wording in `exercises/congruency_postulates.html` to better reflect wording and vocabulary seen in high school geometry textbooks. We hope this helps address issues similar to: https://github.com/Khan/khan-exercises/issues/7965 where students don't look for a counter example in addition to the congruent triangle.

We have also increased the probability to encounter Standard Form equations in `exercises/graphing_linear_equations.html` from 20% to 30%. In using the practice problems, there have been times when no standard form equations came up. While y-intercept form is more common, it is important for students to be able to graph standard form equations.

Changes made by Brennan Saeta saeta@cs.stanford.edu
On advice of: Linda Saeta lsaeta@cusd.claremont.edu, linda.saeta@gmail.com
- International Baccalaureate Coordinator - Claremont High School
-  IB Math Teacher (HL, SL)
-  AP Statistics Teacher
- General Math Teacher
- Recently completed www.ai-class.org (CS 221, Advanced Track)
- National Board Certified Teacher - Mathematics (2000 - 2010)
