### PR TITLE
Fixes recognizing-percents to show up and misc

### DIFF
--- a/exercises/recognizing_percents.html
+++ b/exercises/recognizing_percents.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-require="math graphie graphie-helpers-arithmetic word-problems">
+<html data-require="math graphie graphie-helpers-arithmetic word-problems graphie-geometry angles">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>Recognizing percents</title>
@@ -31,7 +31,7 @@
 					});
 					var f = squareFractions( BIG_PERCENT, 100, 10, 1.37, 0.25 );
 				</p>
-				<div class="solution"><var>BIG_PERCENT</var></div>
+				<div class="solution" data-forms="percent"><var>BIG_PERCENT</var></div>
 				<div class="hints">
 					<p>The entire grid is 100%.</p>
 					<p>There are 10 lines total, so each line is 10%.</p>
@@ -49,7 +49,7 @@
 					});
 					var f = squareFractions( PERCENT, 100, 10 );
 				</p>
-				<div class="solution"><var>PERCENT</var></div>
+				<div class="solution" data-forms="percent"><var>PERCENT</var></div>
 				<div class="hints">
 					<p>The entire grid is 100%.</p>
 					<p>There are 10 columns and 10 rows, so there are 100 squares total.</p>

--- a/utils/graphie-helpers-arithmetic.js
+++ b/utils/graphie-helpers-arithmetic.js
@@ -703,22 +703,21 @@ function squareFractions( nom, den, perLine, spacing, size ){
 
 	for( y = 0;  y < den/perLine && y * perLine <= nom  ; y++ ){
 		for ( x = 0; x < perLine &&  y * perLine + x < nom   ; x++ ){
-			arr.push( graph.regularPolygon( [ x * spacing * size, y * 2.5 * size ], 4, size, Math.PI/4 ).attr("stroke", "none").attr("fill", "#6495ed"  ).attr("stroke-linecap", "square" ) );
+			arr.push( new RegularPolygon( [ x * spacing * size, y * 2.5 * size ], 4, size, Math.PI/4 ).path.attr("fill", "#6495ed").attr("stroke", "none").attr("stroke-linecap", "square") );
 		}
 	}
 
 	y--;
 	for ( x = x; x < perLine; x++ ){
-		arr.push( graph.regularPolygon( [ x * spacing * size, y * 2.5 * size ], 4, size, Math.PI/4 ).attr("fill", "black" ).attr("stroke", "none").attr("stroke-linecap", "square" ) );
+		arr.push( new RegularPolygon( [ x * spacing * size, y * 2.5 * size ], 4, size, Math.PI/4 ).path.attr("fill", "black" ).attr("stroke", "none").attr("stroke-linecap", "square" ) );
 	}
 
 	y++;
 	for( y = y ;  y < den/perLine; y++ ){
 		for ( x = 0; x < perLine; x++ ){
-			arr.push( graph.regularPolygon( [ x * spacing * size, y * 2.5 * size], 4, size, Math.PI/4 ).attr("fill", "black" ).attr("stroke", "none").attr("stroke-linecap", "square" )  );
+			arr.push( new RegularPolygon( [ x * spacing * size, y * 2.5 * size], 4, size, Math.PI/4 ).path.attr("fill", "black" ).attr("stroke", "none").attr("stroke-linecap", "square" ) );
 		}
 	}
-
 
 	return arr;
 }


### PR DESCRIPTION
This allows the problems 'lines' and 'squares' to show up without error.
I also added data-forms to percent to help with input errors.

[Trello](https://trello.com/card/board/recognizing-percents/4d87e664967a0775082939ab/4e793cc9c9d0fde99221dc9f)

[Sandcastle](http://sandcastle.khanacademy.org/pull/11145/)

[lines problem](http://sandcastle.khanacademy.org/media/castles/eltacodeldiablo:fix-recognizing-percents/exercises/recognizing_percents.html?problem=lines)

[squares problem](http://sandcastle.khanacademy.org/media/castles/eltacodeldiablo:fix-recognizing-percents/exercises/recognizing_percents.html?problem=squares)
