### PR TITLE
fix to clarify no simplication is needed #9613

### DIFF
--- a/exercises/converting_decimals_to_fractions_2.html
+++ b/exercises/converting_decimals_to_fractions_2.html
@@ -18,7 +18,7 @@ Convert fraction such as 0.3763 to a fraction,  convert fraction such as 12.16 i
 				<var id="NUMERATOR">randRange( 0, 1 ) ? randRange( 100, 999 ) : randRange( 1000, 9999 )</var>
 				<var id="D">( NUMERATOR / 10000 ).toFixed( 4 )</var>
 			</div>
-			<p class="question">Express <code><var>D</var></code> as a fraction.</p>
+			<p class="question">Express <code><var>D</var></code> as a fraction. Simplifying the fraction is optional.</p>
 			<p class="solution" data-type="rational" data-simplify="optional"><var>D</var></p>
 			<div class="hints">
 				<div>
@@ -42,7 +42,7 @@ Convert fraction such as 0.3763 to a fraction,  convert fraction such as 12.16 i
 			</div>
 			<p class="question">Express <code><var>FIXED</var></code> as a mixed number. Reduce to lowest terms.</p>
 
-			<p class="solution" data-type="mixed"><var>W + D</var></p>
+			<p class="solution" data-type="mixed" data-type="rational"><var>W + D</var></p>
 
 			<div class="hints">
 				<div>


### PR DESCRIPTION
[Trello](https://trello.com/card/board/known-bugs/4d87e664967a0775082939ab/4ed4e8bc007a3b41a50e6c8a) - Converting decimals to fractions 2 has two problem types: one that requires simplifying the fraction, one that doesn't. This is confusing.

[Issue](https://github.com/Khan/khan-exercises/issues/9613)
[sandcastle](http://sandcastle.khanacademy.org/pull/11274/)
