### PR TITLE
don't give equal numbers in Comparing improper fracs and mixed nums

### DIFF
--- a/exercises/comparing_improper_fractions_and_mixed_numbers.html
+++ b/exercises/comparing_improper_fractions_and_mixed_numbers.html
@@ -10,7 +10,7 @@
 	<div class="exercise">
 		<div class="problems">
 			<div id="same-whole">
-				<div class="vars" data-ensure="M_DENOM !== I_DENOM && abs( ( WHOLE + M_NUM / M_DENOM ) -  ( I_NUM / I_DENOM ) ) > 0.001">
+				<div class="vars" data-ensure="M_DENOM !== I_DENOM && abs( ( WHOLE + M_NUM / M_DENOM ) -  ( I_NUM / I_DENOM ) ) > 0.001 && ( M_AS_I * F1 ) !== ( I_NUM * F2 )">
 					<var id="WHOLE">randRange( 1, 5 )</var>
 					<var id="WHOLE_2">WHOLE</var>
 
@@ -36,15 +36,15 @@
 					<var id="M_AS_I">M_DENOM_REDUCED*WHOLE+M_NUM_REDUCED</var>
 
 					<var id="SOLUTION">(function() {
-						if ( (M_AS_I*F1) > (I_NUM*F2) ) {
+						if ( (M_AS_I*F1) &gt; (I_NUM*F2) ) {
 							return "&gt;";
 						} else {
 							return "&lt;";
 						}
 					})()</var>
-					<var id="MORE">M_DENOM > I_DENOM ? "more" : "fewer"</var>
-					<var id="SMALLER">M_DENOM > I_DENOM ? "smaller" : "bigger"</var>
-					<var id="LESS">M_DENOM > I_DENOM ? "less" : "more"</var>
+					<var id="MORE">M_DENOM &gt; I_DENOM ? "more" : "fewer"</var>
+					<var id="SMALLER">M_DENOM &gt; I_DENOM ? "smaller" : "bigger"</var>
+					<var id="LESS">M_DENOM &gt; I_DENOM ? "less" : "more"</var>
 					<var id="BIGGER">SMALLER === "smaller" ? "bigger" : "smaller"</var>
 				</div>
 
@@ -78,7 +78,7 @@
 				</div>
 			</div>
 			<div id="different-whole">
-				<div class="vars" data-ensure="M_DENOM !== I_DENOM && abs( ( WHOLE + M_NUM / M_DENOM ) -  ( I_NUM / I_DENOM ) ) > 0.001">
+				<div class="vars" data-ensure="M_DENOM !== I_DENOM && abs( ( WHOLE + M_NUM / M_DENOM ) -  ( I_NUM / I_DENOM ) ) > 0.001 && ( M_AS_I * F1 ) !== ( I_NUM * F2 )">
 					<var id="WHOLE">randRange( 1, 5 )</var>
 					<var id="WHOLE_2">randRange( 1, 5 )</var>
 
@@ -104,15 +104,15 @@
 					<var id="M_AS_I">M_DENOM_REDUCED*WHOLE+M_NUM_REDUCED</var>
 
 					<var id="SOLUTION">(function() {
-						if ( (M_AS_I*F1) > (I_NUM*F2) ) {
+						if ( (M_AS_I*F1) &gt; (I_NUM*F2) ) {
 							return "&gt;";
 						} else {
 							return "&lt;";
 						}
 					})()</var>
-					<var id="MORE">M_DENOM > I_DENOM ? "more" : "fewer"</var>
-					<var id="SMALLER">M_DENOM > I_DENOM ? "smaller" : "bigger"</var>
-					<var id="LESS">M_DENOM > I_DENOM ? "less" : "more"</var>
+					<var id="MORE">M_DENOM &gt; I_DENOM ? "more" : "fewer"</var>
+					<var id="SMALLER">M_DENOM &gt; I_DENOM ? "smaller" : "bigger"</var>
+					<var id="LESS">M_DENOM &gt; I_DENOM ? "less" : "more"</var>
 					<var id="BIGGER">SMALLER === "smaller" ? "bigger" : "smaller"</var>
 				</div>
 


### PR DESCRIPTION
Comparing improper fractions and mixed numbers gave equal numbers to compare, but didn't offer the right answer. The related issues are #11229, #11208, #11204, #11202, #11198, #11196. I added a data-ensure so this shouldn't happen anymore. (Plus there were some <>'s in the tags interpreted as JavaScript.)
