### PR TITLE
Count and report data-ensure var recomputations

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1706,6 +1706,21 @@ var Khan = (function() {
 				links.append("Original exercise: " + exercise.data( "name" ));
 			}
 
+			if ( jQuery.tmpl.DATA_ENSURE_LOOPS !== undefined && jQuery.tmpl.DATA_ENSURE_LOOPS > 0 ) {
+				var dataEnsureInfo = jQuery( "<p>" );
+				dataEnsureInfo.append("Data-ensure loops: " + jQuery.tmpl.DATA_ENSURE_LOOPS);
+				if ( jQuery.tmpl.DATA_ENSURE_LOOPS > 15 ) {
+					dataEnsureInfo.css( "background-color", "yellow" );
+				}
+				if ( jQuery.tmpl.DATA_ENSURE_LOOPS > 30 ) {
+					dataEnsureInfo.css( "background-color", "orange" );
+				}
+				if ( jQuery.tmpl.DATA_ENSURE_LOOPS > 50 ) {
+					dataEnsureInfo.css( "background-color", "red" );
+				}
+				dataEnsureInfo.appendTo( debugWrap );
+			}
+
 			if ( typeof jQuery.tmpl.VARS !== "undefined" ) {
 				var varInfo = jQuery( "<p>" );
 

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1706,7 +1706,7 @@ var Khan = (function() {
 				links.append("Original exercise: " + exercise.data( "name" ));
 			}
 
-			if ( jQuery.tmpl.DATA_ENSURE_LOOPS !== undefined && jQuery.tmpl.DATA_ENSURE_LOOPS > 0 ) {
+			if ( jQuery.tmpl.DATA_ENSURE_LOOPS > 0 ) {
 				var dataEnsureInfo = jQuery( "<p>" );
 				dataEnsureInfo.append("Data-ensure loops: " + jQuery.tmpl.DATA_ENSURE_LOOPS);
 				if ( jQuery.tmpl.DATA_ENSURE_LOOPS > 15 ) {

--- a/utils/tmpl.js
+++ b/utils/tmpl.js
@@ -4,6 +4,8 @@
 var VARS = {};
 
 jQuery.tmpl = {
+	DATA_ENSURE_LOOPS: 0,
+
 	// Processors that act based on element attributes
 	attr: {
 		"data-ensure": function( elem, ensure ) {
@@ -11,7 +13,11 @@ jQuery.tmpl = {
 			return function( elem ) {
 				// Return a boolean corresponding to the ensure's value
 				// False means all templating will be run again, so new values will be chosen
-				return !!(ensure && jQuery.tmpl.getVAR( ensure ));
+				var result = !!(ensure && jQuery.tmpl.getVAR( ensure ));
+				if ( !result ) {
+					++jQuery.tmpl.DATA_ENSURE_LOOPS;
+				}
+				return result;
 			};
 		},
 
@@ -249,6 +255,7 @@ if ( typeof KhanUtil !== "undefined" ) {
 // Reinitialize VARS for each problem
 jQuery.fn.tmplLoad = function( problem, info ) {
 	VARS = {};
+	jQuery.tmpl.DATA_ENSURE_LOOPS = 0;
 
 	// Check to see if we're in test mode
 	if ( info.testMode ) {


### PR DESCRIPTION
Adds a counter that is displayed in debug mode showing how many times your `data-ensure`s failed:

![debug](http://i.imgur.com/U2SWl.png)
