### PR TITLE
Fix for #9500 (Exponent rules - Correct answer considered wrong)

### DIFF
--- a/exercises/exponent_rules.html
+++ b/exercises/exponent_rules.html
@@ -70,7 +70,7 @@
 			</div>
 
 			<div id="combined">
-				<div class="vars" data-ensure="BASE1 !== BASE2">
+				<div class="vars" data-ensure="getGCD(BASE1,BASE2)===1">
 					<var id="BASE1">randRange(3, 9)</var>
 					<var id="BASE2">randRange(3, 9)</var>
 

--- a/utils/convert-values.js
+++ b/utils/convert-values.js
@@ -23,7 +23,7 @@ jQuery.extend( KhanUtil, {
 			return 1;
 		}
 		else if( angle == 30 ){
-			return "\\frac{2}{\\sqrt 3}";
+			return "\\frac{2 \\sqrt 3}{3}";
 		}
 		else if( angle == 45 ){
 			return '\\sqrt 2';
@@ -68,7 +68,7 @@ tan: {name: "tan", print: function( angle ){
 		return 0;
 	}
 	else if( angle == 30 ){
-		return "\\frac{1}{\\sqrt 3}";
+		return "\\frac{\\sqrt 3}{3}";
 	}
 	else if( angle == 45 ){
 		return '1';


### PR DESCRIPTION
For the <div id="combined"> problem, I changed data-ensure="BASE1 !== BASE2" to data-ensure="getGCD(BASE1,BASE2)===1". This will keep any problems like (3^10*9^(-3))^3 from coming up. (There are infinitely many correct answers there, since integer powers of 3 and 9 have common factors). If BASE1 and BASE2 have no common factors, then this cannot happen.
