### PR TITLE
Fix for issue #9865:  Put a tighter range on values for sizeRatio parameter of Quadrilateral function

### DIFF
--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -33,7 +33,7 @@
 						init({
 							range: [ [-1, 12 ], [ -8, -1 ] ]
 						})
-						var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(0, 1 ) + 0.5, "", 3 );
+						var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(5, 10) / 10, "", 3 );
 						q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
 						q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
 


### PR DESCRIPTION
Put a tighter range on values for sizeRatio parameter of Quadrilateral function to fix issue #9865.

Previously sizeRatio had possible values of 0.5 or 1.5; now the range is 0.5, 0.6, ..., 0.9, 1.0.

sizeRatio values at 1.5 were causing this issue.
