### PR TITLE
Fix for issue #11624

### DIFF
--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -56,8 +56,26 @@
 				<div class="vars">
 					<var id="ANGLES">randomQuadAngles.isoscelesTrapezoid()</var>
 				</div>
+				<div class="problem">
+					<p>What is the value of the angle marked with "x" ?</p>
+				</div>
+				<div class="question">
+					<div class="graphie">
+						<!-- This is just a copy of the Trapezoid question but with the explicitly shown parallel lines removed -->
+						init({
+							range: [ [-1, 12 ], [ -8, -1 ] ]
+						})
+						var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(0, 1 ) + 0.5, "", 3);
+						q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
+						q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
+
+						q.draw();
+						q.labels = { "angles" : ANG_LABELS, "sides" : jQuery.map( jQuery.map( q.sides, lineLength ), function( x ){ return x.toFixed( 1 ); } ) };
+						q.drawLabels();
+					</div>
+				</div>				
 			</div>
-			<div id="isoscelesTrap2" data-type="trapezoid">
+			<div id="isoscelesTrap2" data-type="isoscelesTrap1">
 				<div class="vars">
 					<var id="ANGLES">randomQuadAngles.isoscelesTrapezoid()</var>
 					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>
@@ -69,7 +87,7 @@
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
-			<div id="parallelogram1" data-type="trapezoid">
+			<div id="parallelogram1" data-type="isoscelesTrap1">
 				<div class="vars">
 					<var id="ANGLES">randomQuadAngles.parallelogram()</var>
 					<var id="SHOWN_POS">( ANSWER_POS + 2 ) % 4</var>
@@ -80,7 +98,7 @@
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
-			<div id="parallelogram2" data-type="trapezoid">
+			<div id="parallelogram2" data-type="isoscelesTrap1">
 				<div class="vars">
 					<var id="ANGLES">randomQuadAngles.parallelogram()</var>
 					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -58,8 +58,26 @@
 				</div>
 				<div class="problem">
 					<p>What is the value of the angle marked with "x" ?</p>
+				</div>			
+			</div>
+			<div id="isoscelesTrap2" data-type="trapezoid">
+				<div class="vars">
+					<var id="ANGLES">randomQuadAngles.isoscelesTrapezoid()</var>
+					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>
 				</div>
-				<div class="question">
+
+				<div class="hints">
+					<p>This figure is an isosceles trapezoid.</p>
+					<p>The angles of bases of an isosceles trapezoid are equal.</p>
+					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
+				</div>
+			</div>
+			<div id="parallelogram1" data-type="trapezoid">		
+				<div class="vars">
+					<var id="ANGLES">randomQuadAngles.parallelogram()</var>
+					<var id="SHOWN_POS">( ANSWER_POS + 2 ) % 4</var>
+				</div>
+				<div class="question">				
 					<div class="graphie">
 						<!-- This is just a copy of the Trapezoid question but with the explicitly shown parallel lines removed -->
 						init({
@@ -72,25 +90,7 @@
 						q.draw();
 						q.labels = { "angles" : ANG_LABELS, "sides" : jQuery.map( jQuery.map( q.sides, lineLength ), function( x ){ return x.toFixed( 1 ); } ) };
 						q.drawLabels();
-					</div>
-				</div>				
-			</div>
-			<div id="isoscelesTrap2" data-type="isoscelesTrap1">
-				<div class="vars">
-					<var id="ANGLES">randomQuadAngles.isoscelesTrapezoid()</var>
-					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>
-				</div>
-
-				<div class="hints">
-					<p>This figure is an isosceles trapezoid.</p>
-					<p>The angles of bases of an isosceles trapezoid are equal.</p>
-					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
-				</div>
-			</div>
-			<div id="parallelogram1" data-type="isoscelesTrap1">
-				<div class="vars">
-					<var id="ANGLES">randomQuadAngles.parallelogram()</var>
-					<var id="SHOWN_POS">( ANSWER_POS + 2 ) % 4</var>
+					</div>		
 				</div>
 				<div class="hints">
 					<p>This quadrilateral is a parallelogram.</p>
@@ -98,7 +98,7 @@
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
-			<div id="parallelogram2" data-type="isoscelesTrap1">
+			<div id="parallelogram2" data-type="parallelogram1">
 				<div class="vars">
 					<var id="ANGLES">randomQuadAngles.parallelogram()</var>
 					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -27,7 +27,6 @@
 				</div>
 				<div class="problem">
 					<p>What is the value of the angle marked with "x" ?</p>
-					<p>The top and bottom sides are parallel.</p>
 				</div>
 				<div class="question">
 					<div class="graphie">
@@ -45,6 +44,7 @@
 				</div>
 				<div class="solution"><var>ANGLES[ ANSWER_POS ]</var></div>
 				<div class="hints">
+					<p>The top and bottom sides are parallel.</p>				
 					<p>This figure is a trapezoid.</p>
 					<p>The angles of a trapezoid side are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -26,7 +26,7 @@
 					</var>
 				</div>
 				<div class="problem">
-					<p>What is the value of the angle marked with "x" ?</p>
+					<p>What is the value of the angle marked with <code>x</code> ?</p>
 				</div>
 				<div class="question">
 					<div class="graphie">
@@ -45,7 +45,7 @@
 				<div class="solution"><var>ANGLES[ ANSWER_POS ]</var></div>
 				<div class="hints">
 					<p>The top and bottom sides are parallel.</p>				
-					<p>This figure is a trapezoid, because a pair of opposite sides are parallel.</p>
+					<p>Therefore this figure is a trapezoid.</p>
 					<p>The angles of a trapezoid side are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>
 					<p><code>x = 180 - <var>ANGLES[ SHOWN_POS ]</var></code></p>
@@ -55,10 +55,7 @@
 			<div id="isoscelesTrap1" data-type="trapezoid">
 				<div class="vars">
 					<var id="ANGLES">randomQuadAngles.isoscelesTrapezoid()</var>
-				</div>
-				<div class="problem">
-					<p>What is the value of the angle marked with "x" ?</p>
-				</div>			
+				</div>		
 			</div>
 			<div id="isoscelesTrap2" data-type="trapezoid">
 				<div class="vars">
@@ -68,10 +65,10 @@
 
 				<div class="hints">
 					<p>The top and bottom sides are parallel.</p>
-					<p>The sides that are not parallel have equal length.
-					<p>This figure is an isosceles trapezoid, because a pair of opposite sides are parallel and the other pair have equal length.</p>
+					<p>The sides that are not parallel have equal length.</p>
+					<p>Therefore this figure is an isosceles trapezoid.</p>
 					<p>The angles of bases of an isosceles trapezoid are equal.</p>
-					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
+					<p>Therefore, the angle <code>x</code> is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
 			<div id="parallelogram1" data-type="trapezoid">		
@@ -96,9 +93,9 @@
 				</div>
 				<div class="hints">
 					<p>Each pair of opposite sides have equal length.</p>
-					<p>This quadrilateral is a parallelogram, because each pair of opposite sides have equal length.</p>
+					<p>Therefore this figure is a parallelogram.</p>
 					<p>Opposite angles of a parallelogram are equal.</p>
-					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
+					<p>Therefore, the angle <code>x</code> is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
 			<div id="parallelogram2" data-type="parallelogram1">
@@ -108,8 +105,8 @@
 				</div>
 				<div class="hints">
 					<p>Each pair of opposite sides have equal length.</p>
-					<p>This quadrilateral is a parallelogram, because each pair of opposite sides have equal length.</p>
-					<p>Adjacent angles of a parallelogram are supplementary.</p>
+					<p>Therefore this figure is a parallelogram.</p>
+					<p>Consecutive angles of a parallelogram are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>
 					<p><code>x = 180 - <var>ANGLES[ SHOWN_POS ]</var></code></p>
 					<p><code>x =  <var>ANGLES[ ANSWER_POS ]</var></code></p>
@@ -135,9 +132,9 @@
 				</div>
 				<div class="hints">
 					<p>All the sides have equal length.</p>
-					<p>This quadrilateral is a rhombus, because all the sides have equal length</p>
+					<p>Therefore this figure is a rhombus.</p>
 					<p>Opposite angles of a rhombus are equal.</p>
-					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
+					<p>Therefore, the angle <code>x</code> is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
 			<div id="rhombus2" data-type="rhombus1">
@@ -147,8 +144,8 @@
 				</div>
 				<div class="hints">
 					<p>All the sides have equal length.</p>
-					<p>This quadrilateral is a rhombus, because all the sides have equal length.</p>
-					<p>Adjacent angles of a rhombus are supplementary.</p>
+					<p>Therefore this figure is a rhombus.</p>
+					<p>Consecutive angles of a rhombus are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>
 					<p><code>x = 180 - <var>ANGLES[ SHOWN_POS ]</var></code></p>
 					<p><code>x =  <var>ANGLES[ ANSWER_POS ]</var></code></p>
@@ -162,9 +159,9 @@
 				</div>
 				<div class="hints">
 					<p>This quadrilateral has two pairs of adjacent sides of equal length.</p>
-					<p>This is a kite, because it has two pairs of adjacent sides of equal length.</p>
+					<p>Therefore this figure is a kite.</p>
 					<p>Angles between the non-equal sides of a kite are equal.</p>
-					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
+					<p>Therefore, the angle <code>x</code> is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
 			</div>
 		</div>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -45,7 +45,7 @@
 				<div class="solution"><var>ANGLES[ ANSWER_POS ]</var></div>
 				<div class="hints">
 					<p>The top and bottom sides are parallel.</p>				
-					<p>This figure is a trapezoid.</p>
+					<p>This figure is a trapezoid, because a pair of opposite sides are parallel.</p>
 					<p>The angles of a trapezoid side are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>
 					<p><code>x = 180 - <var>ANGLES[ SHOWN_POS ]</var></code></p>
@@ -67,7 +67,9 @@
 				</div>
 
 				<div class="hints">
-					<p>This figure is an isosceles trapezoid.</p>
+					<p>The top and bottom sides are parallel.</p>
+					<p>The sides that are not parallel have equal length.
+					<p>This figure is an isosceles trapezoid, because a pair of opposite sides are parallel and the other pair have equal length.</p>
 					<p>The angles of bases of an isosceles trapezoid are equal.</p>
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
@@ -93,7 +95,8 @@
 					</div>		
 				</div>
 				<div class="hints">
-					<p>This quadrilateral is a parallelogram.</p>
+					<p>Each pair of opposite sides have equal length.</p>
+					<p>This quadrilateral is a parallelogram, because each pair of opposite sides have equal length.</p>
 					<p>Opposite angles of a parallelogram are equal.</p>
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
@@ -104,7 +107,8 @@
 					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>
 				</div>
 				<div class="hints">
-					<p>This quadrilateral is a parallelogram.</p>
+					<p>Each pair of opposite sides have equal length.</p>
+					<p>This quadrilateral is a parallelogram, because each pair of opposite sides have equal length.</p>
 					<p>Adjacent angles of a parallelogram are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>
 					<p><code>x = 180 - <var>ANGLES[ SHOWN_POS ]</var></code></p>
@@ -130,7 +134,8 @@
 					</div>
 				</div>
 				<div class="hints">
-					<p>This quadrilateral is a rhombus, because it has all sides equal.</p>
+					<p>All the sides have equal length.</p>
+					<p>This quadrilateral is a rhombus, because all the sides have equal length</p>
 					<p>Opposite angles of a rhombus are equal.</p>
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>
@@ -141,7 +146,8 @@
 					<var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>
 				</div>
 				<div class="hints">
-					<p>This quadrilateral is a rhombus, because it has all sides equal.</p>
+					<p>All the sides have equal length.</p>
+					<p>This quadrilateral is a rhombus, because all the sides have equal length.</p>
 					<p>Adjacent angles of a rhombus are supplementary.</p>
 					<p><code><var>ANGLES[ SHOWN_POS ]</var> + x = 180</code></p>
 					<p><code>x = 180 - <var>ANGLES[ SHOWN_POS ]</var></code></p>
@@ -155,7 +161,8 @@
 					<var id="SHOWN_POS">( ANSWER_POS + 2 ) % 4</var>
 				</div>
 				<div class="hints">
-					<p>This quadrilateral is a kite, because it has two pairs of adjacent sides equal.</p>
+					<p>This quadrilateral has two pairs of adjacent sides of equal length.</p>
+					<p>This is a kite, because it has two pairs of adjacent sides of equal length.</p>
 					<p>Angles between the non-equal sides of a kite are equal.</p>
 					<p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
 				</div>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -26,14 +26,15 @@
 					</var>
 				</div>
 				<div class="problem">
-					What is the value of the angle marked with "x" ?
+					<p>What is the value of the angle marked with "x" ?</p>
+					<p>The top and bottom sides are parallel.</p>
 				</div>
 				<div class="question">
 					<div class="graphie">
 						init({
 							range: [ [-1, 12 ], [ -8, -1 ] ]
 						})
-						var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(0, 1 ) + 0.5, "", 3 );
+						var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(0, 1 ) + 0.5, "", 3, [ 0, 2 ] );
 						q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
 						q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
 

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -363,7 +363,8 @@ function Triangle( center, angles, scale, labels, points ){
 	this.draw = function(){
 		this.set = KhanUtil.currentGraph.raphael.set();
 		this.set.push( KhanUtil.currentGraph.path( this.points.concat( [ this.points[ 0 ] ] ) ) );
-		return this.set;
+			
+		return this.set;		
 	}
 
 	this.color = "black";
@@ -496,7 +497,7 @@ function Triangle( center, angles, scale, labels, points ){
 	}
 
 }
-function Quadrilateral( center, angles, sideRatio, labels, size ){
+function Quadrilateral( center, angles, sideRatio, labels, size, parallelSides ){
 
 	this.sideRatio = sideRatio;
 	this.angles = angles;
@@ -512,6 +513,7 @@ function Quadrilateral( center, angles, sideRatio, labels, size ){
 	this.sines = $.map( this.radAngles, Math.sin );
 	this.labels = labels || {};
 	this.sides = [];
+	this.parallelSides = parallelSides || [];
 
 	this.generatePoints = function(){
 		var once = false;
@@ -557,6 +559,31 @@ function Quadrilateral( center, angles, sideRatio, labels, size ){
 
 	area = 0.5 *  vectorProduct( [ this.points[ 0 ], this.points[ 2 ] ], [ this.points[ 3 ], this.points[ 1 ] ] );
 
+	this.draw = function(){
+		this.set = KhanUtil.currentGraph.raphael.set();
+		this.set.push( KhanUtil.currentGraph.path( this.points.concat( [ this.points[ 0 ] ] ) ) );
+	
+		// This currently only works properly for sides close to vertical or horizontal.
+		// Could be expanded to correctly rotate the marks for any line orientation
+		// Also only supports a single set of parallel lines
+		var numParallelSides = this.parallelSides.length;
+		for (var i=0; i < numParallelSides; i++)
+		{
+			var line = this.sides[this.parallelSides[i]];		
+			var gradient = (line[ 0 ][ 1 ] - line[ 1 ][ 1 ]) / (line[ 0 ][ 0 ] - line[ 1 ][ 0 ]);
+			if (gradient < 0.5 && gradient > -0.5) // Horizontal
+			{
+				var midPoint = lineMidpoint(line);
+				this.set.push(KhanUtil.currentGraph.path([ [ midPoint[ 0 ]-0.1,midPoint[ 1 ]-0.15 ], midPoint, [midPoint[ 0 ]-0.1,midPoint[ 1 ]+0.15 ] ] ));				
+			}
+			else // Vertical
+			{
+				var midPoint = lineMidpoint(line);
+				this.set.push(KhanUtil.currentGraph.path([ [ midPoint[ 0 ]-0.15,midPoint[ 1 ]-0.1 ], midPoint, [midPoint[ 0 ]+0.15,midPoint[ 1 ]-0.1 ] ] ));				
+			}
+		}		
+		return this.set;		
+	}
 }
 
 
@@ -695,7 +722,7 @@ function newParallelogram( center ){
 
 function newTrapezoid( center ){
 	var center = center || [ 0, 0 ];
-	return  new Quadrilateral( center, randomQuadAngles.trapezoid(),  KhanUtil.randFromArray( [ 0.2, 0.5, 0.7, 1.5 ] ) , "", 3 );
+	return new Quadrilateral( center, randomQuadAngles.trapezoid(),  KhanUtil.randFromArray( [ 0.2, 0.5, 0.7, 1.5 ] ) , "", 3 );
 }
 
 function newKite( center ) {


### PR DESCRIPTION
#11624
#6156
#2803
#11242
#10842

Plus others probably...

quadrilateral_angles assumed that some quadrilaterals were trapezoids without proving it. This annotates the sides as being parallel and adds a note saying as much to the question. It does not do this for isosceles quadrilaterals or parallelograms since working this out from the information given is a good part of the question.

It doesn't do this terribly generically however. For a given quadrilateral only a single set of lines can be marked as parallel and it will only look right is the lines are nearly vertical or nearly horizontal. I believe it is still an improvement however.

Sandcastle: http://sandcastle.khanacademy.org/pull/11724/
