### PR TITLE
Added support for simplification-optional mixed numbers as answers

### DIFF
--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -297,7 +297,14 @@ jQuery.extend( Khan.answerTypes, {
 
 					return [];
 				},
-				example: "a mixed number, like <code>1\\ 3/4</code>"
+				example: (function() {
+					if ( options.simplify === "required" ) {
+						return "a <em>simplified</em> mixed number, like <code>1\\ 3/4</code>";
+					} else {
+						return "a mixed number, like <code>1\\ 6/8</code>";
+					}
+				})()
+						
 			},
 
 			decimal: {


### PR DESCRIPTION
Changed the description of the answer type "mixed number" to include the word "simplified" and added support for simplification-optional mixed numbers.

Fixes #1169.

Sandcastle: http://sandcastle.khanacademy.org/pull/11731/
