### PR TITLE
Prompt if the student enters the negative of the correct answer

### DIFF
--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -2,7 +2,8 @@
 
 var inexactMessages = {
 	unsimplified: "Your answer is almost correct, but it needs to be simplified.",
-	missingPercentSign: "Your answer is almost correct, but it is missing a <code>\\%</code> at the end."
+	missingPercentSign: "Your answer is almost correct, but it is missing a <code>\\%</code> at the end.",
+	wrongSign: "Your answer is almost correct, but have you checked the sign?"
 };
 
 Khan.answerTypes = Khan.answerTypes || {};
@@ -368,7 +369,7 @@ jQuery.extend( Khan.answerTypes, {
 							correct.toLowerCase() === val.toLowerCase() ) {
 						ret = true;
 						return false; // break;
-					} if ( typeof val === "number" &&
+					} else if ( typeof val === "number" &&
 							Math.abs( correctFloat - val ) < options.maxError ) {
 						if ( exact || options.simplify === "optional" ) {
 							ret = true;
@@ -379,6 +380,8 @@ jQuery.extend( Khan.answerTypes, {
 						}
 
 						return false; // break;
+					} else if ( typeof val === "number" && Math.abs( correctFloat + val ) < options.maxError ) {
+						ret = inexactMessages.wrongSign;
 					}
 				}
 			} );


### PR DESCRIPTION
A problem that seems to crop up often in negative number problems is the student enters almost the correct answer, but with the wrong sign (e.g. #11845).

This change presents a message when this happens, similar to the one for unsimplified fractions.

I'm concerned this might not be the best way to fix the problem though. I was thinking perhaps exercises could provide their own "common wrong answers" with appropriate messages?

Also if I've made a mistake it could break every exercise since this in the logic for determining if an answer is correct or not...
