### PR TITLE
Fix for #9891: Added examples of correctly formatted answers, using the examples class.

### DIFF
--- a/exercises/completing_the_square_2.html
+++ b/exercises/completing_the_square_2.html
@@ -41,6 +41,9 @@
 				</div>
 				<div class="solution" data-type="multiple">
 					<p><code>x = {}</code><span class="sol"><var>X1</var></span></p>
+					<p class="example"> Answer can be an integer, like <code>6</code></p>
+					<p class="example"> A proper fraction, like <code>1/2</code></p>
+					<p class="example"> Or a decimal, like <code>5.65</code></p>
 				</div>
 			</div>
 			<div id="odds" data-type="original" data-weight="2">


### PR DESCRIPTION
Added examples in the style Khan users are accustomed to.
