### PR TITLE
Fix complex number polar form answer type problem history; Fix #12066

### DIFF
--- a/exercises/dividing_complex_numbers.html
+++ b/exercises/dividing_complex_numbers.html
@@ -30,7 +30,9 @@
 		<var id="A_IMAG_COLORED">"\\color{" + ORANGE + "}{" + A_IMAG + "}"</var>
 		<var id="B_REAL_COLORED">"\\color{" + BLUE + "}{" + B_REAL + "}"</var>
 		<var id="B_IMAG_COLORED">"\\color{" + BLUE + "}{" + B_IMAG + "}"</var>
-		<var id="CONJUGATE">complexNumber( B_REAL, -B_IMAG )</var>
+		<var id="B_CONJUGATE_IMAG">-B_IMAG</var>
+		<var id="B_CONJUGATE_IMAG_COLORED">"\\color{" + BLUE + "}{" + negParens( B_CONJUGATE_IMAG ) +"}"</var>
+		<var id="CONJUGATE">complexNumber( B_REAL, B_CONJUGATE_IMAG )</var>
 		<var id="CONJUGATE_COLORED">"\\color{" + BLUE + "}{" + CONJUGATE + "}"</var>
 	</div>
 
@@ -87,14 +89,14 @@
 					<code>
 						\qquad \dfrac{(<var>A_REP_COLORED</var>) \cdot (<var>CONJUGATE_COLORED</var>)}
 						{<var>DENOMINATOR</var>} = 
-						\dfrac{(<var>A_REAL_COLORED</var> \cdot \color{<var>BLUE</var>}{<var>negParens( B_REAL )</var>}) + (<var>A_IMAG_COLORED</var> \cdot \color{<var>BLUE</var>}{<var>negParens( B_REAL )</var>i}) + (<var>A_REAL_COLORED</var> \cdot \color{<var>BLUE</var>}{<var>negParens(B_IMAG_COLORED)</var>i}) + (<var>A_IMAG_COLORED</var> \cdot \color{<var>BLUE</var>}{<var>negParens(B_IMAG_COLORED)</var> i^2})}
+						\dfrac{(<var>A_REAL_COLORED</var> \cdot \color{<var>BLUE</var>}{<var>negParens( B_REAL )</var>}) + (<var>A_IMAG_COLORED</var> \cdot \color{<var>BLUE</var>}{<var>negParens( B_REAL )</var>} i) + (<var>A_REAL_COLORED</var> \cdot \color{<var>BLUE</var>}{<var> B_CONJUGATE_IMAG_COLORED </var>}i) + (<var>A_IMAG_COLORED</var> \cdot \color{<var>BLUE</var>}{<var> B_CONJUGATE_IMAG_COLORED </var>} i^2)}
 						{<var>DENOMINATOR</var>}
 					</code>
 					<p>
 						All multiplications are evaluated.
 					</p>
 					<code>
-						\qquad \dfrac{(<var>A_REAL * B_REAL</var>) + (<var>A_IMAG * B_REAL</var>i) + (<var>A_REAL * B_IMAG</var>i) + (<var>A_IMAG * B_IMAG</var> i^2)}
+						\qquad \dfrac{(<var>A_REAL * B_REAL</var>) + (<var>A_IMAG * B_REAL</var>i) + (<var>A_REAL * B_CONJUGATE_IMAG</var>i) + (<var>A_IMAG * B_CONJUGATE_IMAG</var> i^2)}
 						{<var>DENOMINATOR</var>}
 					</code>
 				</div>
@@ -103,7 +105,7 @@
 						Finally, the fraction is simplified.
 					</p>
 					<code>
-						\qquad \dfrac{<var>A_REAL * B_REAL</var> + <var>A_IMAG * B_REAL</var>i + <var>A_REAL * B_IMAG</var>i - <var>A_IMAG * B_IMAG</var>}
+						\qquad \dfrac{<var>A_REAL * B_REAL</var> + <var>A_IMAG * B_REAL</var>i + <var>A_REAL * B_CONJUGATE_IMAG</var>i - <var>A_IMAG * B_CONJUGATE_IMAG</var>}
 						{<var>DENOMINATOR</var>} =
 						\dfrac{<var>REAL_NUMERATOR</var> + <var>IMAG_NUMERATOR</var>i</var>}
 						{<var>DENOMINATOR</var>} =

--- a/exercises/dividing_complex_numbers.html
+++ b/exercises/dividing_complex_numbers.html
@@ -38,12 +38,12 @@
 
 	<div class="problems">
 		<div>
-			<p class="question">Divide the following complex numbers. Round the real and imaginary parts of the result to 2 decimal digits.</p>
+			<p class="question">Divide the following complex numbers. You can round the real and imaginary parts of the result to 2 decimal digits.</p>
 			<p>
 				<code>\qquad \dfrac{<var>A_REP_COLORED</var>}{<var>B_REP_COLORED</var>}</code>
 			</p>
 			<div class="solution" data-type="complexNumberSeparate">
-				[ <var>ANSWER_REAL</var>, <var>ANSWER_IMAG</var> ]
+				[ <var>ANSWER_REAL_UNROUNDED</var>, <var>ANSWER_IMAG_UNROUNDED</var> ]
 			</div>
 			<div class="hints">
 				<p>

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -951,12 +951,12 @@ jQuery.extend( Khan.answerTypes, {
 		var solutionArray = [];
 
 		var realArea = jQuery( '<p />' ).html('Real part: ');
-		var realControl = jQuery( '<span />' ).html( correct[0] );
-		var realValidator = Khan.answerTypes["decimal"]( realArea, realControl, 0 );
+		var realControl = jQuery( '<span data-inexact data-max-error="0.01" />' ).html( correct[0] );
+		var realValidator = Khan.answerTypes["number"]( realArea, realControl, 0 );
 
 		var imagArea = jQuery( '<p />' ).html('Imaginary part: ');
-		var imagControl = jQuery( '<span />' ).html( correct[1] );
-		var imagValidator = Khan.answerTypes["decimal"]( imagArea, imagControl, 0 );
+		var imagControl = jQuery( '<span data-inexact data-max-error="0.01" />' ).html( correct[1] );
+		var imagValidator = Khan.answerTypes["number"]( imagArea, imagControl, 0 );
 
 		var area = jQuery( '<div />' );
 		area.append( realArea ).append( imagArea ).tmpl();

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -995,10 +995,10 @@ jQuery.extend( Khan.answerTypes, {
 	// (see The complex plane for an example)
 	// The solution argument is expected to be [ angle, magnitude ]
 	complexNumberPolarForm: function ( solutionarea, solution ) {
+		var isTimeline = !( solutionarea.attr( "id" ) === "solutionarea" || solutionarea.parent().attr( "id" ) === "solutionarea" );
 		solutionarea = jQuery( solutionarea );
 		
 		var json = typeof solution === "object" ? jQuery( solution ).text() : solution;
-		// TODO: is there a better way than eval?
 		var correct = eval( json );
 		var table = jQuery( '<table />' );
 		var row = jQuery( '<tr />' );
@@ -1022,6 +1022,11 @@ jQuery.extend( Khan.answerTypes, {
 		table.append(row);
 
 		var numberLabel = jQuery( '<p id="number-label" style="margin: 8px 0 2px 0" />' );
+		var guessCorrect = false;
+
+		var validator = function( guess ) {
+			return ( guess[0] === correct[0] ) && ( guess[1] === correct[1] );
+		};
 
 		solutionarea.append(table, numberLabel);
 		redrawComplexPolarForm();
@@ -1029,12 +1034,27 @@ jQuery.extend( Khan.answerTypes, {
 		var ret = function() {
 			var cplx = KhanUtil.currentGraph.graph.currComplexPolar;
 			ret.guess = [ cplx.getAngleNumerator(), cplx.getRadius() ];
-			return ( ret.guess[0] === correct[0] ) && ( ret.guess[1] === correct[1] );
+
+			if ( isTimeline ) {
+				return guessCorrect;
+			} else {
+				return validator( ret.guess );
+			}
 		};
 
 		ret.showGuess = function( guess ) {
-			var cplx = KhanUtil.currentGraph.graph.currComplexPolar;
-			cplx.update( guess[0], guess[1] );
+			if ( typeof guess === "undefined" ) {
+				guess = [ 0, 1 ]; // magic: this is the default position of the complex number polar form dot
+			}
+			if ( isTimeline ) {
+				guessCorrect = validator( guess );
+				jQuery( solutionarea ).empty();
+				jQuery( solutionarea ).append( guessCorrect === true ? "Answer correct" : "Answer incorrect" );
+			} else {
+				var cplx = KhanUtil.currentGraph.graph.currComplexPolar;
+				cplx.update( guess[0], guess[1] );
+				redrawComplexPolarForm();
+			}
 		};
 
 		ret.solution = solution;

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1044,17 +1044,22 @@ jQuery.extend( Khan.answerTypes, {
 
 		ret.showGuess = function( guess ) {
 			if ( typeof guess === "undefined" ) {
-				guess = [ 0, 1 ]; // magic: this is the default position of the complex number polar form dot
+				guess = [ 0, 1 ]; // magic: default complex polar form value
 			}
 			if ( isTimeline ) {
 				guessCorrect = validator( guess );
 				jQuery( solutionarea ).empty();
 				jQuery( solutionarea ).append( guessCorrect === true ? "Answer correct" : "Answer incorrect" );
 			} else {
-				var cplx = KhanUtil.currentGraph.graph.currComplexPolar;
-				cplx.update( guess[0], guess[1] );
-				redrawComplexPolarForm();
+				redrawComplexPolarForm( guess[0], guess[1] );
 			}
+		};
+
+		ret.showCustomGuess = function( guess ) {
+			var code = "(function() { var guess = " + ( JSON.stringify( guess ) || "[]" ) + ";" + 
+				"graph.currComplexPolar.update( guess[0], guess[1] );" +
+				"})()";
+			KhanUtil.tmpl.getVAR( code, KhanUtil.currentGraph );
 		};
 
 		ret.solution = solution;

--- a/utils/graphie-helpers.js
+++ b/utils/graphie-helpers.js
@@ -500,7 +500,7 @@ function ComplexPolarForm( angleDenominator, maxRadius, euler ) {
 
 	this.update = function ( newAngle, newRadius ) {
 		angle = newAngle;
-		while (angle < 0) angle += denominator;
+		while ( angle < 0 ) angle += denominator;
 		angle %= denominator;
 
 		radius = Math.max( 1, Math.min( newRadius, maximumRadius ) ); // keep between 0 and maximumRadius...
@@ -538,10 +538,11 @@ function ComplexPolarForm( angleDenominator, maxRadius, euler ) {
 
 	this.plot = function () {
 		var graph = KhanUtil.currentGraph;
-		raphaelObjects.push( graph.circle( [ this.getRealPart(), this.getImaginaryPart() ], 1/4, {
+		var circle = graph.circle( [ this.getRealPart(), this.getImaginaryPart() ], 1/4, {
 			fill: KhanUtil.ORANGE,
 			stroke: "none"
-		}));
+		});
+		raphaelObjects.push( circle );
 	}
 
 	this.redraw = function () {

--- a/utils/graphie-helpers.js
+++ b/utils/graphie-helpers.js
@@ -495,7 +495,7 @@ function ComplexPolarForm( angleDenominator, maxRadius, euler ) {
 	var denominator = angleDenominator;
 	var maximumRadius = maxRadius;
 	var angle = 0, radius = 1;
-	var raphaelObjects = [];
+	var circle;
 	var useEulerForm = euler;
 
 	this.update = function ( newAngle, newRadius ) {
@@ -514,6 +514,10 @@ function ComplexPolarForm( angleDenominator, maxRadius, euler ) {
 
 	this.getAngleNumerator = function () {
 		return angle;
+	}
+
+	this.getAngleDenominator = function () {
+		return denominator;
 	}
 
 	this.getAngle = function () {
@@ -537,19 +541,16 @@ function ComplexPolarForm( angleDenominator, maxRadius, euler ) {
 	}
 
 	this.plot = function () {
-		var graph = KhanUtil.currentGraph;
-		var circle = graph.circle( [ this.getRealPart(), this.getImaginaryPart() ], 1/4, {
+		circle = KhanUtil.currentGraph.circle( [ this.getRealPart(), this.getImaginaryPart() ], 1/4, {
 			fill: KhanUtil.ORANGE,
 			stroke: "none"
 		});
-		raphaelObjects.push( circle );
-	}
-
+	},
+	
 	this.redraw = function () {
-		jQuery.each( raphaelObjects, function( i, el ) {
-			el.remove();
-		});
-		raphaelObjects = [];
+		if ( circle ) {
+			circle.remove();
+		}
 		this.plot();
 	}
 }
@@ -559,14 +560,20 @@ function updateComplexPolarForm( deltaAngle, deltaRadius ) {
 	redrawComplexPolarForm();
 }
 
-function redrawComplexPolarForm() {
+function redrawComplexPolarForm( angle, radius ) {
 	var graph = KhanUtil.currentGraph;
 	var storage = graph.graph;
 	var point = storage.currComplexPolar;
 	point.redraw();
 
-	var radius = point.getRadius();
-	var angle = point.getAngle();
+	if ( typeof radius === "undefined" ) {
+		radius = point.getRadius();
+	}
+	if ( typeof angle === "undefined" ) {
+		angle = point.getAngleNumerator();
+	}
+
+	angle *= 2 * Math.PI / point.getAngleDenominator();
 
 	var equation = KhanUtil.polarForm( radius, angle, point.getUseEulerForm() );
 

--- a/utils/math-format.js
+++ b/utils/math-format.js
@@ -499,11 +499,17 @@ jQuery.extend(KhanUtil, {
 		} 
 		if ( imag != 0 ) {
 			if ( imag / imagDenominator > 0 ) {
-				ret += " + " + KhanUtil.fraction( imag, imagDenominator, false, true ) + " i";
+				if ( real != 0 ) {
+					ret += " + ";
+				}
+				ret += KhanUtil.fraction( imag, imagDenominator, false, true ) + " i";
 			} else {
 				imag = Math.abs( imag );
 				imagDenominator = Math.abs( imagDenominator );
-				ret += " - " + KhanUtil.fraction( imag, imagDenominator, false, true ) + " i";
+				if ( real != 0 ) {
+					ret += " - ";
+				}
+				ret += KhanUtil.fraction( imag, imagDenominator, false, true ) + " i";
 			}
 		}
 		return ret;

--- a/utils/math-format.js
+++ b/utils/math-format.js
@@ -506,9 +506,7 @@ jQuery.extend(KhanUtil, {
 			} else {
 				imag = Math.abs( imag );
 				imagDenominator = Math.abs( imagDenominator );
-				if ( real != 0 ) {
-					ret += " - ";
-				}
+				ret += " - ";
 				ret += KhanUtil.fraction( imag, imagDenominator, false, true ) + " i";
 			}
 		}


### PR DESCRIPTION
- My earlier complex number exercises introduced a new answer type - complexNumberPolarForm. It didn't work well with problem history. This should fix the problem.
- Fixes #12066 - +/- issues in Dividing complex numbers hints.
- Rounding the answer is also made optional in Dividing complex numbers, plus other number forms (like fractions) are now accepted.
- Fixes rendering a complex number with real part 0 and real part 10 as "+10i".
