### PR TITLE
Fix issue #12090 - plot vertical lines correctly in Distance between point and line

### DIFF
--- a/exercises/distance_between_point_and_line.html
+++ b/exercises/distance_between_point_and_line.html
@@ -188,9 +188,7 @@
 								axisArrows: "<->"
 							});
 
-							plot(function( x ) {
-								return ( M1 * ( x - B1 ) );
-							}, [-10, 10], {
+							line( [ B1, -10 ], [ B1, 10 ], {
 								stroke: BLUE
 							});
 


### PR DESCRIPTION
Distance between point and line used graphie.plot() to render vertical lines (as `y = ax + b` with huge A's), which (probably) caused some sort of overflow, so graphie actually plotted several lines scattered over the whole graph. This fixes the bug by plotting vertical lines using graphie.line().
