### PR TITLE
Fix for issue #11975: validation of percents

### DIFF
--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -311,9 +311,6 @@ jQuery.extend( Khan.answerTypes, {
 							// Remove space after +, -
 							.replace( /([+-])\s+/g, "$1" )
 
-							// Remove commas
-							.replace( /,\s*/g, "" )
-
 							// Extract integer, numerator and denominator
 							// This matches [+-]?\.; will f
 							.match( /^([+-]?(?:\d+\.?|\d*\.\d+))$/ );


### PR DESCRIPTION
Conversion of decimals such as .89 accepts 8.9% or .89% This occurs only with whole percents, not fractional percents.  see `282e4d4`. Is this change appropriate for all decimals, in particular those that use the euro style numbers? Internationalization seems to be an issue that hasn't been fully address. See issue `#12408`, for example.

http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/converting_decimals_to_percents.html?debug&problem=0&seed=255158388
