### PR TITLE
Fix for issue #12472 - Fixed hint displaying incorrect angle

### DIFF
--- a/exercises/angles_1.html
+++ b/exercises/angles_1.html
@@ -326,7 +326,7 @@
 						<code>
 							\color{orange}{\angle{BAC}} =
 								180&deg; - \color{green}{\angle{DAB}} =
-								<var>180 - Tri_Y - Tri_X</var>&deg;
+								<var>180 - Tri_Y - Tri_Z</var>&deg;
 						</code>,
 							because supplementary angles along a line add up to
 							180 degrees.


### PR DESCRIPTION
Fix for #12472 so that the hint for one of the triangle problems displays the correct angle in the hint to match the diagram.

http://sandcastle.khanacademy.org/media/castles/wkvong:fix-angles-1/exercises/angles_1.html
