### PR TITLE
Radical exercises almost done

### DIFF
--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html data-require="math math-format">
+<head>
+  <meta charset="UTF-8" />
+  <title>Simplifying radicals 2</title>
+  <script src="../khan-exercise.js"></script>
+</head>
+<body>
+  <div class="exercise">
+  <div class="problems">
+    <div id="already-simplified" data-weight="2">
+      <div class="vars">
+        <var id="NUM, DENOM">shuffle( [ 10, 21, 30, 42, 66, 70, 105, 110, 154, 165, 210], 2 )</var>
+        <var id="NUM_SPLIT">splitRadical(NUM)</var>
+        <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
+        <var id="GCD">getGCD(NUM,DENOM)</var>
+        <var id="TRUE_DENOM">DENOM/GCD === 1 ? "" : DENOM/GCD</var>
+        <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
+        <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+      </div>
+
+      <div class="question">
+        <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
+      </div>
+
+      <div class="solution" data-type="radical"><var>NUM/GCD</var>/<var>DENOM/GCD</var></div>
+
+      <div class="hints">
+        <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> have no perfect-square factors, but <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code> still can be simplified.</p>
+        <p>The largest number that divides both <code><var>NUM</var></code> and <code><var>DENOM</var></code> is <code><var>GCD</var></code>.</p>
+        <p>We see that <code><var>NUM</var></code> = <code><var>NUM/GCD</var>\cdot<var>GCD</var></code>.</p>
+        <p>We also see that <code><var>DENOM</var></code> = <code><var>DENOM/GCD</var>\cdot<var>GCD</var></code>.</p>
+        <p>Since <code>\dfrac{<var>GCD</var>}{<var>GCD</var>}</code> just equals 1, the fraction <code>\dfrac{<var>NUM</var>}{<var>DENOM</var>}</code> ends up simplifying to <code>\dfrac{<var>NUM/GCD</var>}{<var>DENOM/GCD</var>}</code>.</p>
+        <p>Thus, <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \sqrt{\dfrac{<var>NUM/GCD</var>}{<var>TRUE_DENOM</var>}}</code>.</p>
+      </div>
+    </div>
+
+    <div id="both-perfect-squares" data-weight="2">
+      <div class="vars">
+        <var id="NUM, DENOM">shuffle( [ 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225], 2 )</var>
+        <var id="NUM_SPLIT">splitRadical(NUM)</var>
+        <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
+        <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
+        <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+      </div>
+
+      <div class="question">
+        <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
+      </div>
+
+      <div class="solution" data-type="radical"><var>NUM</var>/<var>DENOM</var></div>
+
+      <div class="hints">
+        <p>The numerator <code><var>NUM</var></code> is a perfect square, so it simplifies to <code>\sqrt{<var>NUM</var>} = <var>NUM_COEFFICIENT</var></code>.</p>
+        <p>The denominator <code><var>DENOM</var></code> is a perfect square, so <code>\sqrt{<var>DENOM</var>} = <var>DENOM_COEFFICIENT</var></code>.</p>
+        <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> are perfect squares, so <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = <span data-if="DENOM_SPLIT !== ''">\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}</span><span data-else><var>NUM_COEFFICIENT</span></code>.</p>
+      </div>
+    </div>
+
+    <div id="first-perfect-square_second-not" data-weight="2">
+      <div class="vars">
+        <var id="NUM">randFromArray([9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225])</var>
+        <var id="DENOM">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>
+        <var id="NUM_SPLIT">splitRadical(NUM)</var>
+        <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
+        <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
+        <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+        <var id="DENOM_RADICAL">DENOM_SPLIT[1] === 1 ? "" : DENOM_SPLIT[1]</var>
+      </div>
+
+      <div class="question">
+        <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
+      </div>
+
+      <div class="solution" data-type="radical">\dfrac{<var>NUM</var>}{<var>DENOM</var>}</div>
+
+      <div class="hints">
+        <p>The numerator <code><var>NUM</var></code> is a perfect square, so <code>\sqrt{<var>NUM</var>} = <var>NUM_COEFFICIENT</var></code>.</p>
+        <p>The largest perfect square that divides <code><var>DENOM</var></code> is <code><var>DENOM_COEFFICIENT * DENOM_COEFFICIENT</var></code>.</p>
+        <p>Factoring it out, we have <code><var>DENOM</var> = <var>DENOM_COEFFICIENT</var>^2\cdot <var>DENOM_RADICAL</var></code>.</p>
+        <p>Thus, <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \sqrt{\dfrac{<var>NUM_COEFFICIENT</var}{<var>DENOM_COEFFICIENT</var>}}\sqrt{1/<var>DENOM_RADICAL</var>}</code>.</p>
+      </div>
+    </div>
+
+    <div id="first-not_second-perfect-square" data-weight="2">
+      <div class="vars">
+        <var id="NUM">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>
+        <var id="DENOM">randFromArray([9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225])</var>
+        <var id="NUM_SPLIT">splitRadical(NUM)</var>
+        <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
+        <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
+        <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+        <var id="NUM_RADICAL">NUM_SPLIT[1] === 1 ? "" : NUM_SPLIT[1]</var>
+      </div>
+
+      <div class="question">
+        <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
+      </div>
+
+      <div class="solution" data-type="radical"><var>NUM</var>/<var>DENOM</var></div>
+
+      <div class="hints">
+        <p>The largest perfect square that divides <code><var>NUM</var></code> is <code><var>NUM_COEFFICIENT * NUM_COEFFICIENT</var></code>.</p>
+        <p>Factoring it out, we have <code><var>NUM</var> = <var>NUM_COEFFICIENT</var>^2\cdot <var>NUM_RADICAL</var></code>.</p>
+        <p>The denominator <code><var>DENOM</var></code> is a perfect square, so <code>\sqrt{<var>DENOM</var>} = <var>DENOM_COEFFICIENT</var></code>.</p>
+        <p>Thus, <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{<var>NUM_RADICAL</var>}</code>.</p>
+      </div>
+    </div>
+
+    <div id="not-yet-simple" data-weight="2">
+      <div class="vars">
+        <var id="NUM, DENOM">shuffle( [ 8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216], 2 )</var>
+        <var id="NUM_SPLIT">splitRadical(NUM)</var>
+        <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
+        <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
+        <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+        <var id="NUM_RADICAL">NUM_SPLIT[1] === 1 ? "" : NUM_SPLIT[1]</var>
+        <var id="DENOM_RADICAL">DENOM_SPLIT[1] === 1 ? "" : DENOM_SPLIT[1]</var>
+        <var id="GCD">getGCD(NUM, DENOM)</var>
+      </div>
+
+      <div class="question">
+        <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
+      </div>
+
+      <div class="solution" data-type="radical"><var>NUM</var>/<var>DENOM</var></div>
+
+      <div class="hints">
+        <p>The largest perfect square that divides <code><var>NUM</var></code> is <code><var>NUM_COEFFICIENT * NUM_COEFFICIENT</var></code>.</p>
+        <p>Factoring it out, we have <code><var>NUM</var> = <var>NUM_COEFFICIENT</var>^2\cdot <var>NUM_RADICAL</var></code>.</p>
+        <p>The largest perfect square that divides <code><var>DENOM</var></code> is <code><var>DENOM_COEFFICIENT * DENOM_COEFFICIENT</var></code>.</p>
+        <p>Factoring it out, we have <code><var>DENOM</var> = <var>DENOM_COEFFICIENT</var>^2\cdot <var>DENOM_RADICAL</var></code>.</p>
+        <p>Thus, <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{\dfrac{<var>NUM_RADICAL</var>}{<var>DENOM_RADICAL</var>}}</code>.
+          However, the radical can still be simplified into a whole number.</p>
+        <p>You can use the fact that <code>\dfrac{<var>DENOM_RADICAL</var>}{<var>DENOM_RADICAL</var>}</code> = 1 to your advantage.</p>
+        <p>You can multiply <code>\dfrac{<var>NUM_RADICAL</var>}{<var>DENOM_RADICAL</var>}\cdot\dfrac{<var>DENOM_RADICAL</var>}{<var>DENOM_RADICAL</var>}</code>,
+          which gives you <code>\dfrac{<var>NUM_RADICAL * DENOM_RADICAL</var>}{<var>DENOM_RADICAL * DENOM_RADICAL</var>}</code>.</p>  
+        <p>With this technique, the denominator becomes a perfect square.  You can now take the denominator out of the radical,
+          i.e. <code>\sqrt{\dfrac{<var>NUM_RADICAL * DENOM_RADICAL</var>}{<var>DENOM_RADICAL * DENOM_RADICAL</var>}}=\dfrac{1}{<var>DENOM_RADICAL</var>}\sqrt{<var>NUM_RADICAL * DENOM_RADICAL</var>}</code></p>
+        <p>Therefore, <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} =\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{\dfrac{<var>NUM_RADICAL</var>}{<var>DENOM_RADICAL</var>}}
+          =\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{\dfrac{<var>DENOM_RADICAL</var>}{<var>DENOM_RADICAL</var>}\cdot\dfrac{<var>NUM_RADICAL</var>}{<var>DENOM_RADICAL</var>}}
+          =\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{\dfrac{<var>NUM_RADICAL * DENOM_RADICAL</var>}{<var>DENOM_RADICAL * DENOM_RADICAL</var>}}
+          =\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\cdot\dfrac{1}{<var>DENOM_RADICAL</var>}\sqrt{<var>NUM_RADICAL * DENOM_RADICAL</var>}
+          =\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT * DENOM_RADICAL</var>}\sqrt{<var>NUM_RADICAL * DENOM_RADICAL</var>}</code></p>
+      </div>
+    </div>
+  </div>
+  </div>
+</body>
+</html>

--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -67,7 +67,7 @@
       </div>
     </div>
 
-    <div id="first-perfect-square_second-not" data-weight="20000000000000">
+    <div id="first-perfect-square_second-not" data-weight="2">
       <div class="vars">
         <var id="NUM">randFromArray([9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225])</var>
         <var id="DENOM">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>

--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -42,18 +42,22 @@
         <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
         <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
         <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+        <var id="GCD">getGCD(NUM, DENOM)</var>
       </div>
 
       <div class="question">
         <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
       </div>
 
-      <div class="solution" data-type="radical"><var>NUM</var>/<var>DENOM</var></div>
+      <div class="solution" data-type="radical">
+        <span data-if="GCD > 1"><var>NUM / GCD</var>/<var>DENOM / GCD</var></span>
+        <span data-else><var>NUM</var>/<var>DENOM</var></span>
+      </div>
 
       <div class="hints">
         <p>The numerator <code><var>NUM</var></code> is a perfect square, so it simplifies to <code>\sqrt{<var>NUM</var>} = <var>NUM_COEFFICIENT</var></code>.</p>
         <p>The denominator <code><var>DENOM</var></code> is a perfect square, so <code>\sqrt{<var>DENOM</var>} = <var>DENOM_COEFFICIENT</var></code>.</p>
-        <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> are perfect squares, so <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = <span data-if="DENOM_SPLIT !== ''">\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}</span><span data-else><var>NUM_COEFFICIENT</span></code>.</p>
+        <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> are perfect squares, so <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = <span data-if="DENOM_SPLIT !== ''">\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}</span><span data-else><var>NUM_COEFFICIENT</span><span data-if="GCD > 1">= \dfrac{<var>NUM_COEFFICIENT / sqrt(GCD)</var>}{<var>DENOM_COEFFICIENT / sqrt(GCD)</var>}</span></code>.</p>
       </div>
     </div>
 

--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -73,24 +73,37 @@
         <var id="DENOM">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>
         <var id="NUM_SPLIT">splitRadical(NUM)</var>
         <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
+        <var id="COEFFICIENT_GCD">getGCD(NUM_SPLIT[0], DENOM_SPLIT[0])</var>
         <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
         <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
+        <var id="SIMPLIFIED_NUM_COEFFICIENT">(NUM_SPLIT[0] / COEFFICIENT_GCD) === 1 ? "" : (NUM_SPLIT[0] / COEFFICIENT_GCD)</var>
+        <var id="SIMPLIFIED_DENOM_COEFFICIENT">(DENOM_SPLIT[0] / COEFFICIENT_GCD) === 1 ? "" : (DENOM_SPLIT[0] / COEFFICIENT_GCD)</var>
         <var id="DENOM_RADICAL">DENOM_SPLIT[1] === 1 ? "" : DENOM_SPLIT[1]</var>
-        <var id="GCD">getGCD(NUM, DENOM)</var>
       </div>
 
       <div class="question">
         <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
       </div>
 
-      <div class="solution" data-type="radical"><var>NUM</var>/<var>DENOM</var></div>
+      <div class="solution" data-type="radical"><var>NUM / pow(COEFFICIENT_GCD, 2)</var> / <var>DENOM / pow(COEFFICIENT_GCD, 2)</var></div>
 
       <div class="hints">
         <p>The numerator <code><var>NUM</var></code> is a perfect square, so <code>\sqrt{<var>NUM</var>} = <var>NUM_COEFFICIENT</var></code>.</p>
-        <p>The largest perfect square that divides <code><var>DENOM</var></code> is <code><var>DENOM_COEFFICIENT * DENOM_COEFFICIENT</var></code>.</p>
+        <p>The largest perfect square that divides <code><var>DENOM</var></code> is <code><var>pow(DENOM_COEFFICIENT, 2)</var></code>.</p>
         <p>Factoring it out, we have <code><var>DENOM</var> = <var>DENOM_COEFFICIENT</var>^2\cdot <var>DENOM_RADICAL</var></code>.</p>
         <p>Thus,
-          <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{1/<var>DENOM_RADICAL</var>}</code>.
+          <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} =
+            \dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{\dfrac{1}{<var>DENOM_RADICAL</var>}}
+            <span data-if="COEFFICIENT_GCD > 1"> =
+              <span data-if="SIMPLIFIED_DENOM_COEFFICIENT > 1">
+                \dfrac{<var>SIMPLIFIED_NUM_COEFFICIENT</var>}{<var>SIMPLIFIED_DENOM_COEFFICIENT</var>}
+              </span>
+              <span data-else>
+                <var>SIMPLIFIED_NUM_COEFFICIENT</var>
+              </span>
+              \sqrt{\dfrac{1}{<var>DENOM_RADICAL</var>}}
+            </span>
+          </code>.
         </p>
       </div>
     </div>

--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -14,7 +14,7 @@
         <var id="NUM_SPLIT">splitRadical(NUM)</var>
         <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
         <var id="GCD">getGCD(NUM, DENOM)</var>
-        <var id="TRUE_DENOM">DENOM/GCD === 1 ? "" : DENOM / GCD</var>
+        <var id="TRUE_DENOM">DENOM / GCD === 1 ? "" : DENOM / GCD</var>
         <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
         <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
       </div>
@@ -134,7 +134,7 @@
       </div>
     </div>
 
-    <div id="not-yet-simple" data-weight="2">
+    <div id="not-as-simple" data-weight="2">
       <div class="vars">
         <var id="NUM, DENOM">shuffle( [ 8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216], 2 )</var>
         <var id="NUM_SPLIT">splitRadical(NUM)</var>

--- a/exercises/simplifying_radicals_2.html
+++ b/exercises/simplifying_radicals_2.html
@@ -13,8 +13,8 @@
         <var id="NUM, DENOM">shuffle( [ 10, 21, 30, 42, 66, 70, 105, 110, 154, 165, 210], 2 )</var>
         <var id="NUM_SPLIT">splitRadical(NUM)</var>
         <var id="DENOM_SPLIT">splitRadical(DENOM)</var>
-        <var id="GCD">getGCD(NUM,DENOM)</var>
-        <var id="TRUE_DENOM">DENOM/GCD === 1 ? "" : DENOM/GCD</var>
+        <var id="GCD">getGCD(NUM, DENOM)</var>
+        <var id="TRUE_DENOM">DENOM/GCD === 1 ? "" : DENOM / GCD</var>
         <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
         <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
       </div>
@@ -23,7 +23,7 @@
         <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
       </div>
 
-      <div class="solution" data-type="radical"><var>NUM/GCD</var>/<var>DENOM/GCD</var></div>
+      <div class="solution" data-type="radical"><var>NUM / GCD</var>/<var>DENOM / GCD</var></div>
 
       <div class="hints">
         <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> have no perfect-square factors, but <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code> still can be simplified.</p>
@@ -57,11 +57,17 @@
       <div class="hints">
         <p>The numerator <code><var>NUM</var></code> is a perfect square, so it simplifies to <code>\sqrt{<var>NUM</var>} = <var>NUM_COEFFICIENT</var></code>.</p>
         <p>The denominator <code><var>DENOM</var></code> is a perfect square, so <code>\sqrt{<var>DENOM</var>} = <var>DENOM_COEFFICIENT</var></code>.</p>
-        <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> are perfect squares, so <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = <span data-if="DENOM_SPLIT !== ''">\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}</span><span data-else><var>NUM_COEFFICIENT</span><span data-if="GCD > 1">= \dfrac{<var>NUM_COEFFICIENT / sqrt(GCD)</var>}{<var>DENOM_COEFFICIENT / sqrt(GCD)</var>}</span></code>.</p>
+        <p>Both numbers <code><var>NUM</var></code> and <code><var>DENOM</var></code> are perfect squares, so
+          <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} =
+            <span data-if="DENOM_SPLIT !== ''">\dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}</span>
+            <span data-else><var>NUM_COEFFICIENT</span>
+            <span data-if="GCD > 1"> = \dfrac{<var>NUM_COEFFICIENT / sqrt(GCD)</var>}{<var>DENOM_COEFFICIENT / sqrt(GCD)</var>}</span>
+          </code>.
+        </p>
       </div>
     </div>
 
-    <div id="first-perfect-square_second-not" data-weight="2">
+    <div id="first-perfect-square_second-not" data-weight="20000000000000">
       <div class="vars">
         <var id="NUM">randFromArray([9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225])</var>
         <var id="DENOM">randFromArray([8, 12, 18, 20, 24, 27, 28, 32, 40, 44, 45, 48, 50, 54, 56, 60, 63, 72, 75, 80, 88, 90, 98, 99, 120, 125, 128, 140, 150, 160, 175, 180, 200, 216])</var>
@@ -70,19 +76,22 @@
         <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
         <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
         <var id="DENOM_RADICAL">DENOM_SPLIT[1] === 1 ? "" : DENOM_SPLIT[1]</var>
+        <var id="GCD">getGCD(NUM, DENOM)</var>
       </div>
 
       <div class="question">
         <p>Simplify <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}}</code>.</p>
       </div>
 
-      <div class="solution" data-type="radical">\dfrac{<var>NUM</var>}{<var>DENOM</var>}</div>
+      <div class="solution" data-type="radical"><var>NUM</var>/<var>DENOM</var></div>
 
       <div class="hints">
         <p>The numerator <code><var>NUM</var></code> is a perfect square, so <code>\sqrt{<var>NUM</var>} = <var>NUM_COEFFICIENT</var></code>.</p>
         <p>The largest perfect square that divides <code><var>DENOM</var></code> is <code><var>DENOM_COEFFICIENT * DENOM_COEFFICIENT</var></code>.</p>
         <p>Factoring it out, we have <code><var>DENOM</var> = <var>DENOM_COEFFICIENT</var>^2\cdot <var>DENOM_RADICAL</var></code>.</p>
-        <p>Thus, <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \sqrt{\dfrac{<var>NUM_COEFFICIENT</var}{<var>DENOM_COEFFICIENT</var>}}\sqrt{1/<var>DENOM_RADICAL</var>}</code>.</p>
+        <p>Thus,
+          <code>\sqrt{\dfrac{<var>NUM</var>}{<var>DENOM</var>}} = \dfrac{<var>NUM_COEFFICIENT</var>}{<var>DENOM_COEFFICIENT</var>}\sqrt{1/<var>DENOM_RADICAL</var>}</code>.
+        </p>
       </div>
     </div>
 
@@ -95,6 +104,7 @@
         <var id="NUM_COEFFICIENT">NUM_SPLIT[0] === 1 ? "" : NUM_SPLIT[0]</var>
         <var id="DENOM_COEFFICIENT">DENOM_SPLIT[0] === 1 ? "" : DENOM_SPLIT[0]</var>
         <var id="NUM_RADICAL">NUM_SPLIT[1] === 1 ? "" : NUM_SPLIT[1]</var>
+        <var id="GCD">getGCD(NUM, DENOM)</var>
       </div>
 
       <div class="question">


### PR DESCRIPTION
I was working on https://trello.com/card/simplifying-radicals-2/4d87e664967a0775082939ab/224, but I haven't had time to discover why for the answers that have a mixed notation, you could answer with just the initial fraction without regard to the value inside the radical.
