### PR TITLE
Fixes graphical issue in Fractions cut and copy

### DIFF
--- a/utils/slice-clone.js
+++ b/utils/slice-clone.js
@@ -44,6 +44,7 @@ jQuery.extend( KhanUtil, {
 		for ( var id in KhanUtil.times ) {
 			times = KhanUtil.times[ id ];
 			KhanUtil.currentGraph = jQuery( "#problemarea" ).find( "#" + id ).data( "graphie" );
+			KhanUtil.currentGraph.raphael.clear();
 			KhanUtil.currentGraph.init({ range: [ [ 0, 1 ], [ 0, 1 ] ],scale: [ 600 / pieces * times, 25 ] });
 			rectchart( [ times, 0 ], ["#e00", "#999" ] );
 			jQuery( "#" + id + "_answer input" ).val( KhanUtil.roundTo(3, times / pieces) );


### PR DESCRIPTION
Added a single line to call clear on Raphael paper objects when they
update. This prevents graphical issues in IE9 and prevents build-up of svg paths in the HTML document in all browsers as the user interacts with the rectangular slicing.
