### PR TITLE
Fix for issue #13876: decimals on the number line 2

### DIFF
--- a/exercises/decimals_on_the_number_line_2.html
+++ b/exercises/decimals_on_the_number_line_2.html
@@ -16,7 +16,7 @@
 
 		<var id="SOLUTION">roundTo(1, randRangeNonZero(-19, 19) / 10)</var>
 		<var id="SOLUTION_DECIMAL">roundTo(1, SOLUTION % 1)</var>
-		<var id="SOLUTION_WHOLE">SOLUTION - SOLUTION_DECIMAL</var>
+		<var id="SOLUTION_WHOLE">parseInt( ( SOLUTION ).toString(), 10 )</var>
 
 	</div>
 	<div class="problems">


### PR DESCRIPTION
Issue #13876
Hints may display "1.4 = 0.9999999999999999 + 0.4". The whole number variable in this exercise does not always display properly. This may be due to floating point error.

http://sandcastle.khanacademy.org/media/castles/clkirby1:decimalNumberLine2/exercises/decimals_on_the_number_line_2.html
