### PR TITLE
Updated the unit_circle exercise to use custom answer type for setting the angle in timeline.

### DIFF
--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -28,13 +28,15 @@
 
 				<div class="solution" data-type="multiple">
 					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
+
 					<div class="sol" data-type="custom">
 						<div class="instruction"></div>
-						<div class="guess"> [ angle ] </div>
+						<div class="guess"> angle </div>
+
 						<div class="validator-function">
 							// Convert guess to an angle between 0 and 2*PI for comparison
-							var revolutions = floor(guess[0] / (2 * PI));
-							var modified_guess = guess[0] - revolutions*2*PI;
+							var revolutions = floor(guess / (2 * PI));
+							var modified_guess = guess - revolutions*2*PI;
 
 							// Convert answer to an angle between 0 and 2*PI
 							revolutions = floor(ANGLE_RADIANS / (2 * PI));
@@ -43,10 +45,12 @@
 							// Verify that the angles match
 							return abs( modified_angle - modified_guess ) &lt; 0.001;
 						</div>
+
 						<div class="show-guess">
-							KhanUtil.setAngle( guess[0] );
+							KhanUtil.setAngle( guess );
 						</div>
 						<div class="example"></div>
+
 					</div>
 				</div>
 

--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -27,7 +27,7 @@
 				</p>
 
 				<div class="solution" data-type="multiple">
-					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
+					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001" required><var>SOLUTION</var></div>
 
 					<div class="sol" data-type="custom">
 						<div class="instruction"></div>
@@ -41,6 +41,11 @@
 							// Convert answer to an angle between 0 and 2*PI
 							revolutions = floor(ANGLE_RADIANS / (2 * PI));
 							var modified_angle = ANGLE_RADIANS - revolutions*2*PI;
+
+							// If the angle is at zero, assume that it was not set.
+							// If the student knows the answer be memory, don't require
+							// them to set the angle.
+							if (abs(guess) &lt; 0.001) return true;
 
 							// Verify that the angles match
 							return abs( modified_angle - modified_guess ) &lt; 0.001;

--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -13,6 +13,7 @@
 				<div class="vars">
 					<var id="DEGREES">true</var>
 					<var id="ANGLE">randRangeNonZero( -90, 90 ) * 5</var>
+					<var id="ANGLE_RADIANS">ANGLE*2*PI/360</var>
 					<var id="PRETTY_ANGLE">ANGLE + "^{\\circ}"</var>
 					<var id="FN">randFromArray( [ "cos", "sin" ] )</var>
 					<var id="FNNAME">{ "cos": "cosine", "sin": "sine"}[FN]</var>
@@ -25,16 +26,39 @@
 					<code>\<var>FN</var>(<var>PRETTY_ANGLE</var>) = \text{?}</code>
 				</p>
 
+				<div class="solution" data-type="multiple">
+					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
+					<div class="sol" data-type="custom">
+						<div class="instruction"></div>
+						<div class="guess"> [ angle ] </div>
+						<div class="validator-function">
+							// Convert guess to an angle between 0 and 2*PI for comparison
+							var revolutions = floor(guess[0] / (2 * PI));
+							var modified_guess = guess[0] - revolutions*2*PI;
+
+							// Convert answer to an angle between 0 and 2*PI
+							revolutions = floor(ANGLE_RADIANS / (2 * PI));
+							var modified_angle = ANGLE_RADIANS - revolutions*2*PI;
+
+							// Verify that the angles match
+							return abs( modified_angle - modified_guess ) &lt; 0.001;
+						</div>
+						<div class="show-guess">
+							KhanUtil.setAngle( guess[0] );
+						</div>
+						<div class="example"></div>
+					</div>
+				</div>
+
 				<div class="problem">
 					<p>
-						Move the orange point around the unit circle and select an angle in order to find the <var>FNNAME</var> value above.
+						Move the orange point around the unit circle to the angle indicated inside the <var>FNNAME</var> expression above. <br />
+						Indicate the <var>FNNAME</var> value in the answer field.
 					</p>
 					<div class="graphie" id="unitcircle">
 						initUnitCircle( DEGREES );
 					</div>
 				</div>
-
-				<div class="solution" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
 
 				<div class="hints">
 					<p>
@@ -75,6 +99,7 @@
 						7*PI/6, 5*PI/4, 4*PI/3, 3*PI/2, 5*PI/3, 7*PI/4, 11*PI/6, 2*PI,
 						9*PI/4, 7*PI/3, 5*PI/2, 6*PI/2
 					])</var>
+					<var id="ANGLE_RADIANS">ANGLE</var>
 					<var id="PRETTY_ANGLE">piFraction(ANGLE)</var>
 					<var id="FN">randFromArray( [ "cos", "sin" ] )</var>
 					<var id="FNNAME">{ "cos": "cosine", "sin": "sine"}[FN]</var>

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -500,6 +500,7 @@ jQuery.extend( Khan.answerTypes, {
 
 		var ret = function() {
 			var valid = true,
+				missing_required_answer = false,
 				guess = [];
 
 			solutionarea.find( ".sol" ).each(function() {
@@ -509,11 +510,24 @@ jQuery.extend( Khan.answerTypes, {
 					// Don't short-circuit so we can record all guesses
 					valid = validator() && valid;
 
+					// If this is one of the required entries, and it is not filled in
+					// set the flag that indicates that a required entry is not filled in.
+					if ( jQuery( this ).attr( "required" ) != undefined && validator.guess === "") {
+						missing_required_answer = true;
+						// Break out of the each loop since a required item is not set.
+						return false;
+					}
 					guess.push( validator.guess );
 				}
 			});
 
-			ret.guess = guess;
+			// If a required answer was not provided, return "". This keeps the problem 
+			// from being submitted.
+			if (missing_required_answer === true) {
+				ret.guess = "";
+			} else {
+				ret.guess = guess;
+			}
 
 			return valid;
 		};


### PR DESCRIPTION
One item on trello Card Number 381:  https://trello.com/card/update-older-interactive-exercises-that-should-be-using-the-custom-answer-type/4d87e664967a0775082939ab/381

The unit circle exercise stored the cosine or sine value that was typed in, but did not save the location where the student placed the unit circle. The exercise now requires the student to set the unit circle to the correct angle (although it recognizes that 90 and -270 degrees are the same), and to have the correct answer in the box.

Sand Castle Link:

http://sandcastle.khanacademy.org/media/castles/llarsen71:UpdateOlderExercises/exercises/unit_circle.html
