### PR TITLE
Updated several number line related exercise to fix exercise timeline

### DIFF
--- a/exercises/decimals_on_the_number_line_1.html
+++ b/exercises/decimals_on_the_number_line_1.html
@@ -9,47 +9,43 @@
 	<div class="exercise">
 	<div class="vars">
 		<var id="LOWER_BOUND">0</var>
-		<var id="UPPER_BOUND">10</var>
+		<var id="UPPER_BOUND">1</var>
 
-		<var id="LOWER_VALUE">0</var>
-		<var id="UPPER_VALUE">1</var>
-
-		<var id="TICK_MARK_SOLUTION">randRange(1, 9)</var>
-		<var id="MARK_INCREMENT">UPPER_VALUE / UPPER_BOUND</var>
-
-		<var id="SOLUTION">LOWER_VALUE + TICK_MARK_SOLUTION / UPPER_BOUND</var>
-
-
+		<var id="MARK_INCREMENT"> 0.1 </var>
+		<var id="TENTHS"> randRange(1, 9) </var>
+		<var id="SOLUTION"> TENTHS * MARK_INCREMENT </var>
 	</div>
+
 	<div class="problems">
 		<div>
 			<div class="question">
-				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to  <strong><code>\color{orange}{<var>SOLUTION</var>}</code></strong> on the number line.</p>
+				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to <strong><code>\color{orange}{<var>SOLUTION</var>}</code></strong> on the number line.</p>
+
 				<div class="graphie" id="number-line">
 					init({
-						range: [ [LOWER_BOUND - 1, UPPER_BOUND + 1], [-1, 1] ],
-						scale: [60, 40]
+						range: [ [LOWER_BOUND - 0.3, UPPER_BOUND + 0.4], [-1, 1] ],
+						scale: [350, 40]
 					});
 
-                    style({arrows: "&gt;"});
-					line( [ 0, 0 ], [ UPPER_BOUND + 0.25, 0 ] );
+					style({arrows: "&gt;"});
+					line( [ 0, 0 ], [ UPPER_BOUND + 0.06, 0 ] );
 
 					style({arrows: "-&gt;"});
-					line( [ 0, 0 ], [ LOWER_BOUND - 0.25, 0 ] );
+					line( [ 0, 0 ], [ LOWER_BOUND - 0.06, 0 ] );
 
 					style({arrows: ""});
-					for ( var x = LOWER_BOUND; x &lt;= UPPER_BOUND; x++ ) {
+					for ( var x = LOWER_BOUND; x &lt;= UPPER_BOUND; x += MARK_INCREMENT ) {
 						line( [ x, -0.2 ], [ x, 0.2 ] );
 					}
 
 					style({ stroke: BLUE, strokeWidth: 3.5 });
 					line( [ LOWER_BOUND, -0.2], [LOWER_BOUND, 0.2]);
-					label( [ LOWER_BOUND, -0.53 ],  LOWER_VALUE, "center", { color: BLUE });
+					label( [ LOWER_BOUND, -0.53 ],  LOWER_BOUND, "center", { color: BLUE });
 					line( [ UPPER_BOUND, -0.2], [UPPER_BOUND, 0.2]);
-					label( [ UPPER_BOUND, -0.53 ],  UPPER_VALUE, "center", { color: BLUE });
+					label( [ UPPER_BOUND, -0.53 ],  UPPER_BOUND, "center", { color: BLUE });
 
 					addMouseLayer();
-					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.025 });
 					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
@@ -62,7 +58,7 @@
 				<span class="instruction"> Move the orange dot to select your answer. </span>
 				<div class="guess"> graph.movablePoint.coord[0] </div>
 				<div class="validator-function">
-					return abs( TICK_MARK_SOLUTION - guess ) &lt; 0.001;
+					return abs( SOLUTION - guess ) &lt; 0.001;
 				</div>
 				<div class="show-guess">
 					graph.movablePoint.setCoord( [ guess, 0 ] );
@@ -71,21 +67,23 @@
 
 			<div class="hints">
 				<p>Above we've drawn the number line from 0 to 1, divided into 10 equal pieces.</p>
+
 				<div>
 				    <p>The line is divided into 10 pieces, which means:</p>
 				    <p><code>\color{green}{\text{piece of line}}</code> = <code>\color{red}{<var>MARK_INCREMENT</var>}</code>
 				</div>
 
 				<p><code>\color{orange}{<var>SOLUTION</var>}</code> = 
-				<code>\color{red}{<var>MARK_INCREMENT</var>}</code> * <code>\color{blue}{<var>TICK_MARK_SOLUTION</var>}</code></p>
+				<code>\color{red}{<var>MARK_INCREMENT</var>}</code> * <code>\color{blue}{<var>TENTHS</var>}</code></p>
 				<p>Therefore, moving the <code>\color{orange}{\text{orange dot}}</code>
-				<code>\color{blue}{<var>TICK_MARK_SOLUTION</var>}</code> place<var>plural(TICK_MARK_SOLUTION)</var> will put it at the position
+				<code>\color{blue}{<var>TENTHS</var>}</code> place<var>plural(TENTHS)</var> will put it at the position
 				<code>\color{orange}{<var>SOLUTION</var>}</code>.</p>
 
 				<div>
 					<div class="graphie" data-update="number-line">
-							for ( var x = LOWER_BOUND + 1; x &lt; UPPER_BOUND; x++ ) {
-								label( [ LOWER_BOUND + x, -0.53 ], x / UPPER_BOUND, "center");
+							var MI = MARK_INCREMENT;
+							for ( var x = LOWER_BOUND + MI; x &lt; UPPER_BOUND - MI/2; x += MI ) {
+								label( [ LOWER_BOUND + x, -0.53 ], x.toFixed(1) , "center");
 							}
 					</div>
 				</div>
@@ -93,11 +91,11 @@
 				<div>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: "#6495ED", fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
-						line( [ 0, 0 ], [ TICK_MARK_SOLUTION, 0 ] );
+						line( [ 0, 0 ], [ SOLUTION, 0 ] );
 						graph.movablePoint.visibleShape.toFront();
 
-						label( [ TICK_MARK_SOLUTION, -0.53 ], SOLUTION, "center", { color: "orange" });
-						graph.movablePoint.moveTo( TICK_MARK_SOLUTION, 0 );
+						label( [ TENTHS, -0.53 ], SOLUTION, "center", { color: "orange" });
+						graph.movablePoint.moveTo( SOLUTION, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>SOLUTION</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/decimals_on_the_number_line_1.html
+++ b/exercises/decimals_on_the_number_line_1.html
@@ -49,18 +49,24 @@
 					label( [ UPPER_BOUND, -0.53 ],  UPPER_VALUE, "center", { color: BLUE });
 
 					addMouseLayer();
-					this.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
-					movablePoint.onMove = function( x, y ) {
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
+					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
-						jQuery("#solutionarea input").val( x );
 					};
 				</div>
 			</div>
-				<div class="solution" data-type="multiple">
-				<span>Move the orange dot to select your answer.</span>
-				<div class="sol" data-type="decimal" style="display:none"><var>TICK_MARK_SOLUTION</var></div>
+
+			<div class="solution" data-type="custom">
+				<span class="instruction"> Move the orange dot to select your answer. </span>
+				<div class="guess"> graph.movablePoint.coord[0] </div>
+				<div class="validator-function">
+					return abs( TICK_MARK_SOLUTION - guess ) &lt; 0.001;
+				</div>
+				<div class="show-guess">
+					graph.movablePoint.setCoord( [ guess, 0 ] );
+				</div>
 			</div>
 
 			<div class="hints">
@@ -70,25 +76,28 @@
 				    <p><code>\color{green}{\text{piece of line}}</code> = <code>\color{red}{<var>MARK_INCREMENT</var>}</code>
 				</div>
 
-				<p><code>\color{orange}{<var>SOLUTION</var>}</code> = <code>\color{red}{<var>MARK_INCREMENT</var>}</code> * <code>\color{blue}{<var>TICK_MARK_SOLUTION</var>}</code></p>
-				<p>Therefore, moving the <code>\color{orange}{\text{orange dot}}</code> <code>\color{blue}{<var>TICK_MARK_SOLUTION</var>}</code> place<var>plural(TICK_MARK_SOLUTION)</var> will put it at the position <code>\color{orange}{<var>SOLUTION</var>}</code>.</p>
+				<p><code>\color{orange}{<var>SOLUTION</var>}</code> = 
+				<code>\color{red}{<var>MARK_INCREMENT</var>}</code> * <code>\color{blue}{<var>TICK_MARK_SOLUTION</var>}</code></p>
+				<p>Therefore, moving the <code>\color{orange}{\text{orange dot}}</code>
+				<code>\color{blue}{<var>TICK_MARK_SOLUTION</var>}</code> place<var>plural(TICK_MARK_SOLUTION)</var> will put it at the position
+				<code>\color{orange}{<var>SOLUTION</var>}</code>.</p>
 
 				<div>
 					<div class="graphie" data-update="number-line">
-    					for ( var x = LOWER_BOUND + 1; x &lt; UPPER_BOUND; x++ ) {
-    					    label( [ LOWER_BOUND + x, -0.53 ], x / UPPER_BOUND, "center");
-    					}
-                    </div>
+							for ( var x = LOWER_BOUND + 1; x &lt; UPPER_BOUND; x++ ) {
+								label( [ LOWER_BOUND + x, -0.53 ], x / UPPER_BOUND, "center");
+							}
+					</div>
 				</div>
 
 				<div>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: "#6495ED", fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
 						line( [ 0, 0 ], [ TICK_MARK_SOLUTION, 0 ] );
-						movablePoint.visibleShape.toFront();
+						graph.movablePoint.visibleShape.toFront();
 
 						label( [ TICK_MARK_SOLUTION, -0.53 ], SOLUTION, "center", { color: "orange" });
-						movablePoint.moveTo( TICK_MARK_SOLUTION, 0 );
+						graph.movablePoint.moveTo( TICK_MARK_SOLUTION, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>SOLUTION</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/decimals_on_the_number_line_2.html
+++ b/exercises/decimals_on_the_number_line_2.html
@@ -29,7 +29,7 @@
 						scale: [120, 40]
 					});
 
-                    style({arrows: "&gt;"});
+					style({arrows: "&gt;"});
 					line( [ 0, 0 ], [ UPPER_BOUND + 0.25, 0 ] );
 
 					style({arrows: "-&gt;"});
@@ -53,47 +53,61 @@
 					label( [ 0, -0.53 ],  "0", "center", { color: GREEN });
 
 					addMouseLayer();
-					this.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.1 });
-					movablePoint.onMove = function( x, y ) {
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.1 });
+					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
-						jQuery("#solutionarea input").val( x );
 					};
 				</div>
 			</div>
-				<div class="solution" data-type="multiple">
-				<span>Move the orange dot to select your answer.</span>
-				<div class="sol" data-type="decimal" style="display:none"><var>SOLUTION</var></div>
+
+			<div class="solution" data-type="custom">
+				<span class="instruction"> Move the orange dot to select your answer. </span>
+				<div class="guess"> graph.movablePoint.coord[0] </div>
+				<div class="validator-function">
+					return abs( SOLUTION - guess ) &lt; 0.001;
+				</div>
+				<div class="show-guess">
+					graph.movablePoint.setCoord( [ guess, 0 ] );
+				</div>
 			</div>
 
 			<div class="hints">
-				<p> Because <code>\color{orange}{<var>SOLUTION</var>}</code> is <span data-if="SOLUTION > 0">positive</span><span data-else>negative</span> the orange dot will be to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of 0.</p>
+				<p> Because <code>\color{orange}{<var>SOLUTION</var>}</code> is <span data-if="SOLUTION > 0">positive</span>
+				<span data-else>negative</span> the orange dot will be to the <span data-if="SOLUTION > 0">right</span>
+				<span data-else>left</span> of 0.</p>
+
 				<div data-if="abs(SOLUTION) > 1">
-				    <p>Separate the decimal from the whole number:</p>
-				    <p><code>\color{orange}{<var>SOLUTION</var>}</code> = <code>\color{blue}{<var>SOLUTION_WHOLE</var>}</code> + <code>\color{blue}{<var>SOLUTION_DECIMAL</var>}</code>
-				</div>
-				<div>
-				    <p>Therefore, we know <code>\color{orange}{<var>SOLUTION</var>}</code> lies between <code>\color{orange}{<var>SOLUTION_WHOLE</var>}</code> and <code>\color{orange}{<var>SOLUTION_WHOLE + (SOLUTION > 0 ? 1 : -1)</var>}</code> on the number line.</p>
-				    <div class="graphie" data-update="number-line">
-				        style({ stroke: "#FFA500", strokeWidth: 3.5 });
-				        line( [SOLUTION_WHOLE, -0.2], [SOLUTION_WHOLE, 0.2]);
-					    line( [SOLUTION_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [SOLUTION_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
-				    </div>
+					<p>Separate the decimal from the whole number:</p>
+					<p><code>\color{orange}{<var>SOLUTION</var>}</code> = 
+					<code>\color{blue}{<var>SOLUTION_WHOLE</var>}</code> + <code>\color{blue}{<var>SOLUTION_DECIMAL</var>}</code>
 				</div>
 
-                <div>
+				<div>
+					<p>Therefore, we know <code>\color{orange}{<var>SOLUTION</var>}</code> lies between 
+					<code>\color{orange}{<var>SOLUTION_WHOLE</var>}</code> and 
+					<code>\color{orange}{<var>SOLUTION_WHOLE + (SOLUTION > 0 ? 1 : -1)</var>}</code> on the number line.</p>
+					<div class="graphie" data-update="number-line">
+						style({ stroke: "#FFA500", strokeWidth: 3.5 });
+						line( [SOLUTION_WHOLE, -0.2], [SOLUTION_WHOLE, 0.2]);
+						line( [SOLUTION_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [SOLUTION_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
+					</div>
+				</div>
+
+				<div>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: GREEN, fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
 						line( [ 0, 0 ], [ SOLUTION, 0 ] );
-						movablePoint.visibleShape.toFront();
+						graph.movablePoint.visibleShape.toFront();
 					</div>
 					<p>The orange dot should be shifted to the position <code>\color{orange}{<var>SOLUTION</var>}</code> right of 0.</p>
 				</div>
+
 				<div>
 					<div class="graphie" data-update="number-line">
 						label( [ SOLUTION, -0.53 ],  SOLUTION, "center", { color: "#FFA500" });
-						movablePoint.moveTo( SOLUTION, 0 );
+						graph.movablePoint.moveTo( SOLUTION, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>SOLUTION</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/fractions_on_the_number_line_1.html
+++ b/exercises/fractions_on_the_number_line_1.html
@@ -20,7 +20,8 @@
 		<var id="LOWER_SCALED">LOWER_BOUND * DENOMINATOR</var>
 		<var id="UPPER_SCALED">UPPER_BOUND * DENOMINATOR</var>
 
-		<var id="SOLUTION">NUMERATOR</var>
+		<var id="SOLUTION">NUMERATOR / DENOMINATOR</var>
+		<var id="SCALE">4.5</var>
 	</div>
 	<div class="problems">
 		<div>
@@ -30,27 +31,31 @@
 
 				<div class="graphie" id="number-line">
 					init({
-						range: [ [LOWER_SCALED - 1, UPPER_SCALED + 1], [-1, 1] ],
-						scale: [80, 40]
+						range: [ [LOWER_BOUND - 0.3, UPPER_BOUND + 0.4], [-1, 1] ],
+						scale: [80*SCALE, 40]
 					});
 
+					// Draw Number Line
 					style({arrows: "&gt;"});
-					line( [ LOWER_SCALED, 0 ], [ UPPER_SCALED + 0.25, 0 ] );
+					line( [ LOWER_BOUND, 0 ], [ UPPER_BOUND + 0.25 / SCALE, 0 ] );
 					style({arrows: ""});
-					for ( var x = LOWER_SCALED; x &lt;= UPPER_SCALED; x++ ) {
+
+					// Draw Number Line Tick marks
+					for ( var x = LOWER_BOUND; x &lt;= UPPER_BOUND; x += 1 / DENOMINATOR ) {
 						line( [ x, -0.2 ], [ x, 0.2 ] );
 					}
 
+					// 0 and 1 tick marks
 					style({ stroke: BLUE, strokeWidth: 3.5 });
-					line( [ LOWER_SCALED, -0.2], [LOWER_SCALED, 0.2]);
-					label( [ LOWER_SCALED, -0.53 ],  LOWER_BOUND, "center", { color: BLUE });
-					line( [ UPPER_SCALED, -0.2], [UPPER_SCALED, 0.2]);
-					label( [ UPPER_SCALED, -0.53 ],  UPPER_BOUND, "center", { color: BLUE });
+					line( [ LOWER_BOUND, -0.2], [LOWER_BOUND, 0.2]);
+					label( [ LOWER_BOUND, -0.53 ],  LOWER_BOUND, "center", { color: BLUE });
+					line( [ UPPER_BOUND, -0.2], [UPPER_BOUND, 0.2]);
+					label( [ UPPER_BOUND, -0.53 ],  UPPER_BOUND, "center", { color: BLUE });
 
 					addMouseLayer();
-					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 / DENOMINATOR });
 					graph.movablePoint.onMove = function( x, y ) {
-						if (x &lt; LOWER_SCALED || UPPER_SCALED &lt; x) {
+						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
 					};
@@ -61,7 +66,7 @@
 				<span class="instruction"> Move the orange dot to select your answer. </span>
 				<div class="guess"> graph.movablePoint.coord[0] </div>
 				<div class="validator-function">
-					return abs( NUMERATOR - guess ) &lt; 0.001;
+					return abs( SOLUTION - guess ) &lt; 0.001;
 				</div>
 				<div class="show-guess">
 					graph.movablePoint.setCoord( [ guess, 0 ] );
@@ -76,7 +81,7 @@
 				<div>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: "#6495ED", fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
-						line( [ 0, 0 ], [ NUMERATOR, 0 ] );
+						line( [ 0, 0 ], [ SOLUTION, 0 ] );
 						graph.movablePoint.visibleShape.toFront();
 					</div>
 					<p>The orange dot should be shifted <span class="hint_blue"><code><strong><var>NUMERATOR</var></strong></code></span>
@@ -86,8 +91,8 @@
 
 				<div>
 					<div class="graphie" data-update="number-line">
-						label( [ NUMERATOR, -0.83 ],  fraction(NUMERATOR, DENOMINATOR), "center", { color: "#FFA500" });
-						graph.movablePoint.moveTo( NUMERATOR, 0 );
+						label( [ SOLUTION, -0.83 ],  fraction(NUMERATOR, DENOMINATOR), "center", { color: "#FFA500" });
+						graph.movablePoint.moveTo( SOLUTION, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>fraction(NUMERATOR, DENOMINATOR)</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/fractions_on_the_number_line_1.html
+++ b/exercises/fractions_on_the_number_line_1.html
@@ -25,14 +25,16 @@
 	<div class="problems">
 		<div>
 			<div class="question">
-				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to   <strong><code>\color{orange}{<var>fraction(NUMERATOR, DENOMINATOR)</var>}</code></strong> on the number line.</p>
+				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to 
+				<strong><code>\color{orange}{<var>fraction(NUMERATOR, DENOMINATOR)</var>}</code></strong> on the number line.</p>
+
 				<div class="graphie" id="number-line">
 					init({
 						range: [ [LOWER_SCALED - 1, UPPER_SCALED + 1], [-1, 1] ],
 						scale: [80, 40]
 					});
 
-                    style({arrows: "&gt;"});
+					style({arrows: "&gt;"});
 					line( [ LOWER_SCALED, 0 ], [ UPPER_SCALED + 0.25, 0 ] );
 					style({arrows: ""});
 					for ( var x = LOWER_SCALED; x &lt;= UPPER_SCALED; x++ ) {
@@ -46,35 +48,46 @@
 					label( [ UPPER_SCALED, -0.53 ],  UPPER_BOUND, "center", { color: BLUE });
 
 					addMouseLayer();
-					this.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
-					movablePoint.onMove = function( x, y ) {
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
+					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_SCALED || UPPER_SCALED &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
-						jQuery("#solutionarea input").val( x );
 					};
 				</div>
 			</div>
-				<div class="solution" data-type="multiple">
-				<span>Move the orange dot to select your answer.</span>
-				<div class="sol" data-type="decimal" style="display:none"><var>SOLUTION</var></div>
+
+			<div class="solution" data-type="custom">
+				<span class="instruction"> Move the orange dot to select your answer. </span>
+				<div class="guess"> graph.movablePoint.coord[0] </div>
+				<div class="validator-function">
+					return abs( NUMERATOR - guess ) &lt; 0.001;
+				</div>
+				<div class="show-guess">
+					graph.movablePoint.setCoord( [ guess, 0 ] );
+				</div>
 			</div>
 
 			<div class="hints">
 				<p>Above we've drawn the number line from 0 to 1, divided into equal pieces.</p>
-				<p>The number line is divided into <code><var>DENOMINATOR</var></code> equal pieces, so each piece represents <code><var>fraction(1, DENOMINATOR)</var></code>.</p>
+				<p>The number line is divided into <code><var>DENOMINATOR</var></code> equal pieces, so each piece represents
+				<code><var>fraction(1, DENOMINATOR)</var></code>.</p>
+
 				<div>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: "#6495ED", fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
 						line( [ 0, 0 ], [ NUMERATOR, 0 ] );
-						movablePoint.visibleShape.toFront();
+						graph.movablePoint.visibleShape.toFront();
 					</div>
-					<p>The orange dot should be shifted <span class="hint_blue"><code><strong><var>NUMERATOR</var></strong></code></span> segment<var>plural(NUMERATOR)</var> over, as <code><var>fraction(NUMERATOR, DENOMINATOR)</var> = <var>NUMERATOR</var>*<var>fraction(1, DENOMINATOR)</var></code></p>
+					<p>The orange dot should be shifted <span class="hint_blue"><code><strong><var>NUMERATOR</var></strong></code></span>
+					segment<var>plural(NUMERATOR)</var> over, as <code><var>fraction(NUMERATOR, DENOMINATOR)</var> = 
+					<var>NUMERATOR</var>*<var>fraction(1, DENOMINATOR)</var></code></p>
 				</div>
+
 				<div>
 					<div class="graphie" data-update="number-line">
 						label( [ NUMERATOR, -0.83 ],  fraction(NUMERATOR, DENOMINATOR), "center", { color: "#FFA500" });
-						movablePoint.moveTo( NUMERATOR, 0 );
+						graph.movablePoint.moveTo( NUMERATOR, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>fraction(NUMERATOR, DENOMINATOR)</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/fractions_on_the_number_line_2.html
+++ b/exercises/fractions_on_the_number_line_2.html
@@ -27,14 +27,16 @@
 	<div class="problems">
 		<div>
 			<div class="question">
-				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to  <strong><code>\color{orange}{<var>NUMBER</var>}</code></strong> on the number line.</p>
+				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to
+				<strong><code>\color{orange}{<var>NUMBER</var>}</code></strong> on the number line.</p>
+
 				<div class="graphie" id="number-line">
 					init({
 						range: [ [LOWER_BOUND - 1, UPPER_BOUND + 1], [-1, 1] ],
 						scale: [80 * SCALE, 40]
 					});
 
-                    style({arrows: "&gt;"});
+					style({arrows: "&gt;"});
 					line( [ 0, 0 ], [ UPPER_BOUND + 0.25/SCALE, 0 ] );
 
 					style({arrows: "-&gt;"});
@@ -51,54 +53,68 @@
 					line( [ UPPER_BOUND, -0.2], [UPPER_BOUND, 0.2]);
 					label( [ UPPER_BOUND, -0.53 ],  UPPER_BOUND, "center", { color: GREEN });
 
-                    line( [ 0, -0.2], [0, 0.2]);
+					line( [ 0, -0.2], [0, 0.2]);
 					label( [ 0, -0.53 ],  "0", "center", { color: GREEN });
 
 					addMouseLayer();
-					this.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 1 / DENOMINATOR });
-					movablePoint.onMove = function( x, y ) {
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 1 / DENOMINATOR });
+					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
-						jQuery("#solutionarea input").val( roundTo(5, x) );
 					};
 				</div>
 			</div>
-				<div class="solution" data-type="multiple">
-				<span>Move the orange dot to select your answer.</span>
-				<div class="sol" data-type="decimal" style="display:none"><var>roundTo(5, SOLUTION)</var></div>
+
+			<div class="solution" data-type="custom">
+				<span class="instruction"> Move the orange dot to select your answer. </span>
+				<div class="guess"> graph.movablePoint.coord[0] </div>
+				<div class="validator-function">
+					return abs( SOLUTION - guess ) &lt; 0.001;
+				</div>
+				<div class="show-guess">
+					graph.movablePoint.setCoord( [ guess, 0 ] );
+				</div>
 			</div>
 
 			<div class="hints">
-				<p> Because <code>\color{orange}{<var>NUMBER</var>}</code> is <span data-if="SOLUTION > 0">positive</span><span data-else>negative</span> the orange dot will be to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of 0.</p>
+				<p> Because <code>\color{orange}{<var>NUMBER</var>}</code> is <span data-if="SOLUTION > 0">positive</span>
+				<span data-else>negative</span> the orange dot will be to the <span data-if="SOLUTION > 0">right</span>
+				<span data-else>left</span> of 0.</p>
+
 				<div data-if="IS_MIXED < 1 && abs(SOLUTION) > 1">
-				    <p>Let's convert the improper fraction <code>\color{orange}{<var>NUMBER</var>}</code> to a mixed number:</p>
-				    <p><code>\color{orange}{<var>NUMBER</var>}</code> = <code>\color{blue}{<var>M_NUMBER</var>}</code></p>
-			    </div>
-				<div>
-				    <p>Therefore, we know <code>\color{blue}{<var>M_NUMBER</var>}</code> lies between <code>\color{green}{<var>M_WHOLE</var>}</code> and <code>\color{green}{<var>M_WHOLE + (SOLUTION > 1 ? 1 : -1)</var>}</code> on the number line.</p>
-				    <div class="graphie" data-update="number-line">
-				        style({ stroke: "#FFA500", strokeWidth: 3.5 });
-				        line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
-					    line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
-				    </div>
+					<p>Let's convert the improper fraction <code>\color{orange}{<var>NUMBER</var>}</code> to a mixed number:</p>
+					<p><code>\color{orange}{<var>NUMBER</var>}</code> = <code>\color{blue}{<var>M_NUMBER</var>}</code></p>
 				</div>
+
 				<div>
-				    <p><code>\color{blue}{<var>M_NUMBER</var>}</code> is <code>\color{green}{<var>fraction(M_NUMERATOR, DENOMINATOR)</var>}</code> to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of <code>\color{green}{<var>M_WHOLE</var>}</code> on the number line.</p>
+					<p>Therefore, we know <code>\color{blue}{<var>M_NUMBER</var>}</code> lies between <code>\color{green}{<var>M_WHOLE</var>}</code>
+					and <code>\color{green}{<var>M_WHOLE + (SOLUTION > 1 ? 1 : -1)</var>}</code> on the number line.</p>
+					<div class="graphie" data-update="number-line">
+						style({ stroke: "#FFA500", strokeWidth: 3.5 });
+						line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
+						line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
+					</div>
+				</div>
+
+				<div>
+					<p><code>\color{blue}{<var>M_NUMBER</var>}</code> is <code>\color{green}{<var>fraction(M_NUMERATOR, DENOMINATOR)</var>}</code>
+					to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of <code>\color{green}{<var>M_WHOLE</var>}</code>
+					on the number line.</p>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: GREEN, fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
 						line( [ M_WHOLE, 0 ], [ SOLUTION, 0 ] );
-						movablePoint.visibleShape.toFront();
-
+						graph.movablePoint.visibleShape.toFront();
 						style({ stroke: "#FFA500", strokeWidth: 3.5, arrows: "" });
-				        line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
-					    line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
+						line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
+						line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
 					</div>
 				</div>
+
 				<div>
 					<div class="graphie" data-update="number-line">
 						label( [ SOLUTION, -0.83 ],  NUMBER, "center", { color: "#FFA500" });
-						movablePoint.moveTo( SOLUTION, 0 );
+						graph.movablePoint.moveTo( SOLUTION, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>NUMBER</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/fractions_on_the_number_line_3.html
+++ b/exercises/fractions_on_the_number_line_3.html
@@ -22,17 +22,20 @@
 		<var id="IS_MIXED">0</var>
 		<var id="NUMBER">IS_MIXED === 1 && abs(SOLUTION) > 1  ? M_NUMBER : fraction(NUMERATOR, DENOMINATOR)</var>
 	</div>
+
 	<div class="problems">
 		<div>
 			<div class="question">
-				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to   <strong><code>\color{orange}{<var>NUMBER</var>}</code></strong> on the number line.</p>
+				<p>Move the <strong><code>\color{orange}{\text{orange dot}}</code></strong> to
+				<strong><code>\color{orange}{<var>NUMBER</var>}</code></strong> on the number line.</p>
+
 				<div class="graphie" id="number-line">
 					init({
 						range: [ [LOWER_BOUND - 1, UPPER_BOUND + 1], [-1, 1] ],
 						scale: [80, 40]
 					});
 
-                    style({arrows: "&gt;"});
+					style({arrows: "&gt;"});
 					line( [ 0, 0 ], [ UPPER_BOUND + 0.25, 0 ] );
 
 					style({arrows: "-&gt;"});
@@ -49,54 +52,69 @@
 					line( [ UPPER_BOUND, -0.2], [UPPER_BOUND, 0.2]);
 					label( [ UPPER_BOUND, -0.53 ],  UPPER_BOUND, "center", { color: GREEN });
 
-                    line( [ 0, -0.2], [0, 0.2]);
+					line( [ 0, -0.2], [0, 0.2]);
 					label( [ 0, -0.53 ],  "0", "center", { color: GREEN });
 
 					addMouseLayer();
-					this.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 1 / DENOMINATOR });
-					movablePoint.onMove = function( x, y ) {
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 1 / DENOMINATOR });
+					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
-						jQuery("#solutionarea input").val( roundTo(5, x) );
 					};
 				</div>
 			</div>
-				<div class="solution" data-type="multiple">
-				<span>Move the orange dot to select your answer.</span>
-				<div class="sol" data-type="decimal" style="display:none"><var>roundTo(5, SOLUTION)</var></div>
+
+			<div class="solution" data-type="custom">
+				<span class="instruction"> Move the orange dot to select your answer. </span>
+				<div class="guess"> graph.movablePoint.coord[0] </div>
+				<div class="validator-function">
+					return abs( SOLUTION - guess ) &lt; 0.001;
+				</div>
+				<div class="show-guess">
+					graph.movablePoint.setCoord( [ guess, 0 ] );
+				</div>
 			</div>
 
 			<div class="hints">
-				<p> Because <code>\color{orange}{<var>NUMBER</var>}</code> is <span data-if="SOLUTION > 0">positive</span><span data-else>negative</span> the orange dot will be to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of 0.</p>
+				<p> Because <code>\color{orange}{<var>NUMBER</var>}</code> is <span data-if="SOLUTION > 0">positive</span>
+				<span data-else>negative</span> the orange dot will be to the <span data-if="SOLUTION > 0">right</span>
+				<span data-else>left</span> of 0.</p>
+
 				<div data-if="IS_MIXED < 1 && abs(SOLUTION) > 1">
-				    <p>Let's convert the improper fraction <code>\color{orange}{<var>NUMBER</var>}</code> to a mixed number:</p>
-				    <p><code>\color{orange}{<var>NUMBER</var>}</code> = <code>\color{blue}{<var>M_NUMBER</var>}</code></p>
-			    </div>
-				<div>
-				    <p>Therefore, we know <code>\color{blue}{<var>M_NUMBER</var>}</code> lies between <code>\color{green}{<var>M_WHOLE</var>}</code> and <code>\color{green}{<var>M_WHOLE + (SOLUTION > 1 ? 1 : -1)</var>}</code> on the number line.</p>
-				    <div class="graphie" data-update="number-line">
-				        style({ stroke: "#FFA500", strokeWidth: 3.5 });
-				        line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
-					    line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
-				    </div>
+					<p>Let's convert the improper fraction <code>\color{orange}{<var>NUMBER</var>}</code> to a mixed number:</p>
+					<p><code>\color{orange}{<var>NUMBER</var>}</code> = <code>\color{blue}{<var>M_NUMBER</var>}</code></p>
 				</div>
+
 				<div>
-				    <p><code>\color{blue}{<var>M_NUMBER</var>}</code> is <code>\color{green}{<var>fraction(M_NUMERATOR, DENOMINATOR)</var>}</code> to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of <code>\color{green}{<var>M_WHOLE</var>}</code> on the number line.</p>
+					<p>Therefore, we know <code>\color{blue}{<var>M_NUMBER</var>}</code> lies between <code>\color{green}{<var>M_WHOLE</var>}</code>
+					and <code>\color{green}{<var>M_WHOLE + (SOLUTION > 1 ? 1 : -1)</var>}</code> on the number line.</p>
+					<div class="graphie" data-update="number-line">
+						style({ stroke: "#FFA500", strokeWidth: 3.5 });
+						line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
+						line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
+					</div>
+				</div>
+
+				<div>
+					<p><code>\color{blue}{<var>M_NUMBER</var>}</code> is <code>\color{green}{<var>fraction(M_NUMERATOR, DENOMINATOR)</var>}</code>
+					to the <span data-if="SOLUTION > 0">right</span><span data-else>left</span> of <code>\color{green}{<var>M_WHOLE</var>}</code>
+					on the number line.</p>
 					<div class="graphie" data-update="number-line">
 						style({ stroke: GREEN, fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
 						line( [ M_WHOLE, 0 ], [ SOLUTION, 0 ] );
-						movablePoint.visibleShape.toFront();
+						graph.movablePoint.visibleShape.toFront();
 
 						style({ stroke: "#FFA500", strokeWidth: 3.5, arrows: "" });
-				        line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
-					    line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
+						line( [M_WHOLE, -0.2], [M_WHOLE, 0.2]);
+						line( [M_WHOLE + (SOLUTION > 0 ? 1 : -1), -0.2], [M_WHOLE + (SOLUTION > 0 ? 1 : -1), 0.2]);
 					</div>
 				</div>
+
 				<div>
 					<div class="graphie" data-update="number-line">
 						label( [ SOLUTION, -0.83 ],  NUMBER, "center", { color: "#FFA500" });
-						movablePoint.moveTo( SOLUTION, 0 );
+						graph.movablePoint.moveTo( SOLUTION, 0 );
 					</div>
 					<p>The orange number shows where <code>\color{orange}{<var>NUMBER</var>}</code> is on the number line.</p>
 				</div>

--- a/exercises/number_line.html
+++ b/exercises/number_line.html
@@ -41,12 +41,12 @@
 
 			<div class="solution" data-type="custom">
 				<span class="instruction"> Move the orange dot to select your answer. </span>
-				<div class="guess"> graph.movablePoint.coord </div>
+				<div class="guess"> graph.movablePoint.coord[0] </div>
 				<div class="validator-function">
-					return abs( NUMBER - guess[0] ) &lt; 0.001;
+					return abs( NUMBER - guess ) &lt; 0.001;
 				</div>
 				<div class="show-guess">
-					graph.movablePoint.setCoord( guess );
+					graph.movablePoint.setCoord( [ guess, 0 ] );
 				</div>
 			</div>
 

--- a/exercises/number_line.html
+++ b/exercises/number_line.html
@@ -30,18 +30,24 @@
 					label( [ 0, -0.53 ],  "0", "center", { color: "#6495ED" });
 
 					addMouseLayer();
-					this.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
-					movablePoint.onMove = function( x, y ) {
+					graph.movablePoint = addMovablePoint({ constraints: { constrainY: true }, snapX: 0.25 });
+					graph.movablePoint.onMove = function( x, y ) {
 						if (x &lt; LOWER_BOUND || UPPER_BOUND &lt; x) {
 							return false; // don't allow the point to move past the bounds
 						}
-						jQuery("#solutionarea input").val( x );
 					};
 				</div>
 			</div>
-				<div class="solution" data-type="multiple">
-				<span>Move the orange dot to select your answer.</span>
-				<div class="sol" data-type="decimal" style="display:none"><var>NUMBER</var></div>
+
+			<div class="solution" data-type="custom">
+				<span class="instruction"> Move the orange dot to select your answer. </span>
+				<div class="guess"> graph.movablePoint.coord </div>
+				<div class="validator-function">
+					return abs( NUMBER - guess[0] ) &lt; 0.001;
+				</div>
+				<div class="show-guess">
+					graph.movablePoint.setCoord( guess );
+				</div>
 			</div>
 
 			<div class="hints">
@@ -52,14 +58,14 @@
 					<div class="graphie" data-update="number-line">
 						style({ stroke: "#6495ED", fill: "#6495ED", strokeWidth: 3.5, arrows: "-&gt;" });
 						line( [ 0, 0 ], [ NUMBER, 0 ] );
-						movablePoint.visibleShape.toFront();
+						graph.movablePoint.visibleShape.toFront();
 					</div>
 					<p>The orange dot should be <var>plural( abs( NUMBER ), "position")</var> to the <span data-if="NUMBER &lt; 0">left</span><span data-else>right</span> of 0.</p>
 				</div>
 				<div>
 					<div class="graphie" data-update="number-line">
 						label( [ NUMBER, -0.53 ],  NUMBER, "center", { color: "#FFA500" });
-						movablePoint.moveTo( NUMBER, 0 );
+						graph.movablePoint.moveTo( NUMBER, 0 );
 					</div>
 					<p>The orange number shows where <var>NUMBER</var> is on the number line.</p>
 				</div>


### PR DESCRIPTION
Previously, the exercise timeline did not update the number line to show students guesses. The exercises were updated to use the custom answer type, and code was added to update the exercise timeline correctly.

Several number line related exercises were updated.

Items are from trello Card Number 381: https://trello.com/card/update-older-interactive-exercises-that-should-be-using-the-custom-answer-type/4d87e664967a0775082939ab/381

Sandcastle link:
http://sandcastle.khanacademy.org/pull/15816/

Run the pages with ?debug added to the URL. If you try the exercise, then click on 'problem history', the location of the point on the number line will now update as you select the different items on the time line.
