### PR TITLE
Fix exercise: Scientific notation intuition hints

### DIFF
--- a/exercises/scientific_notation_intuition.html
+++ b/exercises/scientific_notation_intuition.html
@@ -160,10 +160,10 @@
 						Moving the decimal to the <span data-if="E < 0">right</span><span data-else>left</span>
 						<code><var>abs( E )</var></code> <var>plural( "place", abs( E ) )</var> is the same as
 						<span data-if="E < 0">multiplying</span><span data-else>dividing</span> by ten
-						<code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var>. Therefore, we need to 
-						<span data-if="E < 0">divide</span><span data-else>multiply</span> by ten
-						<code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var> &mdash; which is the same as
-						multiplying by <code class="hint_blue">10^{<var>E</var>}</code> &mdash; to counteract moving the decimal.
+						<code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var>. Therefore, to 
+						counteract moving the decimal, we need to <span data-if="E < 0">divide</span><span data-else>multiply</span>
+						by ten <code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var> &mdash; which is the same as
+						multiplying by <code class="hint_blue">10^{<var>E</var>}</code>.
 					</p>
 
 					<div>

--- a/exercises/scientific_notation_intuition.html
+++ b/exercises/scientific_notation_intuition.html
@@ -155,13 +155,15 @@
 						<code><var>abs( E )</var></code> <var>plural( "place", abs( E ) )</var> leaves us with
 						<code class="hint_pink"><var>BASE</var></code>.
 					</p>
-
+					
 					<p>
 						Moving the decimal to the <span data-if="E < 0">right</span><span data-else>left</span>
 						<code><var>abs( E )</var></code> <var>plural( "place", abs( E ) )</var> is the same as
-						<span data-if="E < 0">dividing</span><span data-else>multiplying</span> by ten
-						<code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var>&mdash;which is the same as
-						multiplying by <code class="hint_blue">10^{<var>E</var>}</code>.
+						<span data-if="E < 0">multiplying</span><span data-else>dividing</span> by ten
+						<code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var>. Therefore, we need to 
+						<span data-if="E < 0">divide</span><span data-else>multiply</span> by ten
+						<code><var>abs( E )</var></code> <var>plural( "time", abs( E ) )</var> &mdash; which is the same as
+						multiplying by <code class="hint_blue">10^{<var>E</var>}</code> &mdash; to counteract moving the decimal.
 					</p>
 
 					<div>


### PR DESCRIPTION
The hints currently say that moving the decimal to the right two times is the same as dividing by 10 two times. I think this hint can be clarified to say it's actually the same as multiplying by 10 two times, but that we perform the opposite operation to counteract the moving of the decimal.

Sandcastle: http://sandcastle.khanacademy.org/media/castles/smenks13:sciNot/exercises/scientific_notation_intuition.html
