### PR TITLE
Parabola intuition3 time line fix

### DIFF
--- a/exercises/parabola_intuition_3.html
+++ b/exercises/parabola_intuition_3.html
@@ -36,34 +36,34 @@
 					initAutoscaledGraph( [ [ -2.5, 2.5 ], [ -2.5, 2.5 ] ], {} );
 					addMouseLayer();
 
-					this.directrix = addMovableLine({
+					graph.directrix = addMovableLine({
 						coord: -1,
 						snap: 0.125,
 						vertical: false,
 					});
-					this.directrix.onMove = function( coord ) {
+					graph.directrix.onMove = function( coord ) {
 						jQuery("#directrix-label").html( "&lt;code&gt;" + fractionReduce.apply(KhanUtil, toFraction(coord, 0.001)) + "&lt;/code&gt;" ).tmpl();
 						jQuery("#directrix input").val(coord);
 					};
 
-					this.vertex = addMovablePoint({
+					graph.vertex = addMovablePoint({
 						coordX: 0,
 						coordY: 1,
 						snapX: 0.125,
 						snapY: 0.125,
 					});
-					this.vertex.onMove = function( coordX, coordY ) {
+					graph.vertex.onMove = function( coordX, coordY ) {
 						jQuery("#focus-x-label").html( "&lt;code&gt;" + fractionReduce.apply(KhanUtil, toFraction(coordX, 0.001)) + "&lt;/code&gt;" ).tmpl();
 						jQuery("#focus-y-label").html( "&lt;code&gt;" + fractionReduce.apply(KhanUtil, toFraction(coordY, 0.001)) + "&lt;/code&gt;" ).tmpl();
 						jQuery("#focus-x input").val(coordX);
 						jQuery("#focus-y input").val(coordY);
 					};
 
-					this.func = addInteractiveFn( function(x) {
+					graph.func = addInteractiveFn( function(x) {
 						return ( A * ( x - X1 ) * ( x - X1 ) ) + Y1;
 					}, {});
 
-					doParabolaInteraction( this.func, this.vertex, this.directrix );
+					doParabolaInteraction( graph.func, graph.vertex, graph.directrix );
 				</div>
 				<p>
 					The <span class="hint_green">two green line segments</span> you see when you point to the parabola are always the same
@@ -71,6 +71,17 @@
 				</p>
 
 				<div class="solution" data-type="multiple">
+					<div class="sol" data-type="custom">
+						<div class="guess"> [ graph.vertex.coord, graph.directrix.coord ] </div>
+						<div class="validator-function">
+							return true;
+						</div>
+						<div class="show-guess">
+							graph.vertex.setCoord( guess[0] );
+							graph.directrix.setCoord( guess[1] );
+						</div>
+					</div>
+
 					<p><span>Focus: </span><code>(</code><span id="focus-x-label"><code>0</code></span><code>\text{, }</code><span id="focus-y-label"><code>1</code></span><code>)</code></p>
 					<p>Directrix: <code>y = </code><span id="directrix-label"><code>-1</code></span></p>
 					<p>
@@ -94,8 +105,9 @@
 					All points on a parabola are equidistant from the focus and directrix. There is only one place to put the orange focus point
 					and directrix line where this is true.
 					<button onClick="javascript:
-						vertex.moveTo(KhanUtil.tmpl.getVAR('X1'), KhanUtil.tmpl.getVAR('Y1') + 1/(4*KhanUtil.tmpl.getVAR('A')));
-						directrix.moveTo(KhanUtil.tmpl.getVAR('Y1') - 1/(4*KhanUtil.tmpl.getVAR('A')));
+						graph = KhanUtil.currentGraph.graph;
+						graph.vertex.moveTo(KhanUtil.tmpl.getVAR('X1'), KhanUtil.tmpl.getVAR('Y1') + 1/(4*KhanUtil.tmpl.getVAR('A')));
+						graph.directrix.moveTo(KhanUtil.tmpl.getVAR('Y1') - 1/(4*KhanUtil.tmpl.getVAR('A')));
 					">Show me</button>
 				</p>
 				<p>

--- a/exercises/parabola_intuition_3.html
+++ b/exercises/parabola_intuition_3.html
@@ -86,9 +86,9 @@
 					<p>Directrix: <code>y = </code><span id="directrix-label"><code>-1</code></span></p>
 					<p>
 						Equation of the parabola:<br />
-						<code>y - </code><span class="sol" data-fallback="0"><var>Y1</var></span>
-						<code> = </code><span class="sol" data-fallback="1"><var>A</var></span>
-						<code>(x - </code><span class="sol" data-fallback="0"><var>X1</var></span>
+						<code>y - </code><span class="sol" data-fallback="0" required><var>Y1</var></span>
+						<code> = </code><span class="sol" data-fallback="1" required><var>A</var></span>
+						<code>(x - </code><span class="sol" data-fallback="0" required><var>X1</var></span>
 						<code>)^2</code>
 					</p>
 					<span class="sol" id="focus-x" style="display: none"><var>X1</var></span>

--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -28,13 +28,15 @@
 
 				<div class="solution" data-type="multiple">
 					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
+
 					<div class="sol" data-type="custom">
 						<div class="instruction"></div>
-						<div class="guess"> [ angle ] </div>
+						<div class="guess"> angle </div>
+
 						<div class="validator-function">
 							// Convert guess to an angle between 0 and 2*PI for comparison
-							var revolutions = floor(guess[0] / (2 * PI));
-							var modified_guess = guess[0] - revolutions*2*PI;
+							var revolutions = floor(guess / (2 * PI));
+							var modified_guess = guess - revolutions*2*PI;
 
 							// Convert answer to an angle between 0 and 2*PI
 							revolutions = floor(ANGLE_RADIANS / (2 * PI));
@@ -43,10 +45,12 @@
 							// Verify that the angles match
 							return abs( modified_angle - modified_guess ) &lt; 0.001;
 						</div>
+
 						<div class="show-guess">
-							KhanUtil.setAngle( guess[0] );
+							KhanUtil.setAngle( guess );
 						</div>
 						<div class="example"></div>
+
 					</div>
 				</div>
 

--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -27,7 +27,7 @@
 				</p>
 
 				<div class="solution" data-type="multiple">
-					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
+					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001" required><var>SOLUTION</var></div>
 
 					<div class="sol" data-type="custom">
 						<div class="instruction"></div>
@@ -41,6 +41,11 @@
 							// Convert answer to an angle between 0 and 2*PI
 							revolutions = floor(ANGLE_RADIANS / (2 * PI));
 							var modified_angle = ANGLE_RADIANS - revolutions*2*PI;
+
+							// If the angle is at zero, assume that it was not set.
+							// If the student knows the answer be memory, don't require
+							// them to set the angle.
+							if (abs(guess) &lt; 0.001) return true;
 
 							// Verify that the angles match
 							return abs( modified_angle - modified_guess ) &lt; 0.001;

--- a/exercises/unit_circle.html
+++ b/exercises/unit_circle.html
@@ -13,6 +13,7 @@
 				<div class="vars">
 					<var id="DEGREES">true</var>
 					<var id="ANGLE">randRangeNonZero( -90, 90 ) * 5</var>
+					<var id="ANGLE_RADIANS">ANGLE*2*PI/360</var>
 					<var id="PRETTY_ANGLE">ANGLE + "^{\\circ}"</var>
 					<var id="FN">randFromArray( [ "cos", "sin" ] )</var>
 					<var id="FNNAME">{ "cos": "cosine", "sin": "sine"}[FN]</var>
@@ -25,16 +26,39 @@
 					<code>\<var>FN</var>(<var>PRETTY_ANGLE</var>) = \text{?}</code>
 				</p>
 
+				<div class="solution" data-type="multiple">
+					<div class="sol" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
+					<div class="sol" data-type="custom">
+						<div class="instruction"></div>
+						<div class="guess"> [ angle ] </div>
+						<div class="validator-function">
+							// Convert guess to an angle between 0 and 2*PI for comparison
+							var revolutions = floor(guess[0] / (2 * PI));
+							var modified_guess = guess[0] - revolutions*2*PI;
+
+							// Convert answer to an angle between 0 and 2*PI
+							revolutions = floor(ANGLE_RADIANS / (2 * PI));
+							var modified_angle = ANGLE_RADIANS - revolutions*2*PI;
+
+							// Verify that the angles match
+							return abs( modified_angle - modified_guess ) &lt; 0.001;
+						</div>
+						<div class="show-guess">
+							KhanUtil.setAngle( guess[0] );
+						</div>
+						<div class="example"></div>
+					</div>
+				</div>
+
 				<div class="problem">
 					<p>
-						Move the orange point around the unit circle and select an angle in order to find the <var>FNNAME</var> value above.
+						Move the orange point around the unit circle to the angle indicated inside the <var>FNNAME</var> expression above. <br />
+						Indicate the <var>FNNAME</var> value in the answer field.
 					</p>
 					<div class="graphie" id="unitcircle">
 						initUnitCircle( DEGREES );
 					</div>
 				</div>
-
-				<div class="solution" data-type="decimal" data-inexact data-max-error="0.001"><var>SOLUTION</var></div>
 
 				<div class="hints">
 					<p>
@@ -75,6 +99,7 @@
 						7*PI/6, 5*PI/4, 4*PI/3, 3*PI/2, 5*PI/3, 7*PI/4, 11*PI/6, 2*PI,
 						9*PI/4, 7*PI/3, 5*PI/2, 6*PI/2
 					])</var>
+					<var id="ANGLE_RADIANS">ANGLE</var>
 					<var id="PRETTY_ANGLE">piFraction(ANGLE)</var>
 					<var id="FN">randFromArray( [ "cos", "sin" ] )</var>
 					<var id="FNNAME">{ "cos": "cosine", "sin": "sine"}[FN]</var>

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -500,6 +500,7 @@ jQuery.extend( Khan.answerTypes, {
 
 		var ret = function() {
 			var valid = true,
+				missing_required_answer = false,
 				guess = [];
 
 			solutionarea.find( ".sol" ).each(function() {
@@ -509,11 +510,24 @@ jQuery.extend( Khan.answerTypes, {
 					// Don't short-circuit so we can record all guesses
 					valid = validator() && valid;
 
+					// If this is one of the required entries, and it is not filled in
+					// set the flag that indicates that a required entry is not filled in.
+					if ( jQuery( this ).attr( "required" ) != undefined && validator.guess === "") {
+						missing_required_answer = true;
+						// Break out of the each loop since a required item is not set.
+						return false;
+					}
 					guess.push( validator.guess );
 				}
 			});
 
-			ret.guess = guess;
+			// If a required answer was not provided, return "". This keeps the problem 
+			// from being submitted.
+			if (missing_required_answer === true) {
+				ret.guess = "";
+			} else {
+				ret.guess = guess;
+			}
 
 			return valid;
 		};

--- a/utils/interactive.js
+++ b/utils/interactive.js
@@ -645,6 +645,22 @@ jQuery.extend( KhanUtil, {
 			}
 		});
 
+		// Immediately Move to the x or y coodinate that is given
+		movableLine.setCoord = function ( coord ) {
+			if (options.vertical) {
+				this.visibleShape.translate( coord * graph.scale[0] - this.visibleShape.attr("translation").x, 0 );
+				this.mouseTarget.attr( "x", coord / graph.scale[0] + graph.range[0][0] - 10 );
+			} else {
+				this.visibleShape.translate( 0, -coord * graph.scale[1] - this.visibleShape.attr("translation").y );
+				this.mouseTarget.attr( "y", (graph.range[1][1] - coord) * graph.scale[1] - 10 );
+			}
+
+			this.coord = coord;
+			if ( jQuery.isFunction( this.onMove ) ) {
+				this.onMove(coord);
+			}
+		}
+
 		// Method to let the caller animate the line to a new position. Useful
 		// as part of a hint to show the user the correct place to put the line.
 		movableLine.moveTo = function( coord ) {


### PR DESCRIPTION
Updated the parabola intuition 3 exercise to use a custom answer type so that it works with the time line view.

Added a new setCoord function for the movableLine. Previously it only had a moveTo animation call. An animation is not what is needed for the time line initialization.

Sandcastle Link:
http://sandcastle.khanacademy.org/media/castles/llarsen71:ParabolaIntuition3Update/exercises/parabola_intuition_3.html

One item on trello Card Number 381: https://trello.com/card/update-older-interactive-exercises-that-should-be-using-the-custom-answer-type/4d87e664967a0775082939ab/381
