### PR TITLE
Adding scratchpad room above multiplication problems (for carrying)

### DIFF
--- a/exercises/multiplication_1.5.html
+++ b/exercises/multiplication_1.5.html
@@ -26,6 +26,7 @@
 
 		<div class="problems">
 			<div>
+				<br>
 				<div class="graphie" id="numbers">
 					graph.multiplier = new Multiplier( BIG_FACTOR, SMALL_FACTOR );
 					graph.multiplier.show();

--- a/exercises/multiplication_2.html
+++ b/exercises/multiplication_2.html
@@ -15,6 +15,7 @@
 
 		<div class="problems">
 			<div>
+				<br>
 				<div class="graphie" id="numbers">
 					graph.multiplier = new Multiplier( BIG_FACTOR, SMALL_FACTOR );
 					graph.multiplier.show();

--- a/exercises/multiplication_3.html
+++ b/exercises/multiplication_3.html
@@ -15,6 +15,7 @@
 
 		<div class="problems">
 			<div>
+				<br>
 				<div class="graphie" id="numbers">
 					graph.multiplier = new Multiplier( BIG_FACTOR, SMALL_FACTOR );
 					graph.multiplier.show();

--- a/exercises/multiplication_4.html
+++ b/exercises/multiplication_4.html
@@ -15,6 +15,7 @@
 
 		<div class="problems">
 			<div>
+				<br>
 				<div class="graphie" id="numbers">
 					graph.multiplier = new Multiplier( BIG_FACTOR, SMALL_FACTOR );
 					graph.multiplier.show();

--- a/exercises/multiplying_decimals.html
+++ b/exercises/multiplying_decimals.html
@@ -22,6 +22,7 @@
 
 		<div class="problems">
 			<div>
+				<br>
 				<div class="graphie" id="numbers">
 					graph.multiplier = new Multiplier( BIG_FACTOR, SMALL_FACTOR, BIG_FACTOR_DIGITS, SMALL_FACTOR_DIGITS, BIG_FACTOR_DECIMAL, SMALL_FACTOR_DECIMAL );
 					graph.multiplier.show();


### PR DESCRIPTION
I noticed, when I was doing multiplication problems with my kids, that there was not enough room on the scratchpad for them to write the carry over numbers above the problem. I added an extra line above the multiplication problem to give students room to write.

Sandcastle link:
http://sandcastle.khanacademy.org/pull/17071/
