### PR TITLE
Fix for #16779. Modify utils/polynomial.js for coefficient of -1

### DIFF
--- a/utils/polynomials.js
+++ b/utils/polynomials.js
@@ -11,6 +11,8 @@ jQuery.extend(KhanUtil, {
 				return coef;
 			} else if ( degree === 1 ) {
 				return [ "*", coef, vari ];
+			} else if ( coef === -1 && degree % 2 === 0 && typeof vari === "number" ) {
+				return [ "*", coef * -1, [ "^", vari * -1, degree ] ];
 			} else {
 				return [ "*", coef, [ "^", vari, degree ] ];
 			}


### PR DESCRIPTION
Modify utils/polynomial.js to assume a coefficient of -1 and a positive numbered degree means (coefficient_base)^degree rather than coefficient_(base)^degree, so that what displays as -n^2 to the user works for all values of n.

See my comment on #16779 for a more detailed explanation of the problem.

Tested with polynomials:
f(x) = 3x
f(x) = -2x^2 + 3x -3
f(x) = -x^2 + 3x - 3
