### PR TITLE
Fix commafy() util function to insert commas into 4-digit numbers, 4-place decimals

### DIFF
--- a/utils/math-format.js
+++ b/utils/math-format.js
@@ -350,11 +350,9 @@ jQuery.extend(KhanUtil, {
 	commafy: function( num ) {
 		var str = num.toString().split( "." );
 
-		if ( str[0].length >= 5 ) {
-			str[0] = str[0].replace( /(\d)(?=(\d{3})+$)/g, '$1{,}' );
-		}
+		str[0] = str[0].replace( /(\d)(?=(\d{3})+$)/g, '$1{,}' );
 
-		if ( str[1] && str[1].length >= 5 ) {
+		if (str[1]) {
 			str[1] = str[1].replace( /(\d{3})(?=\d)/g, '$1\\;' );
 		}
 

--- a/utils/test/index.html
+++ b/utils/test/index.html
@@ -44,6 +44,8 @@
 	<script src="calculus.js"></script>
 	<script src="../tmpl.js"></script>
 	<script src="tmpl.js"></script>
+	<script src="../math-format.js"></script>
+	<script src="math-format.js"></script>
 </head>
 <body>
 	<h1 id="qunit-header">Utility Test Suite</h1>

--- a/utils/test/math-format.js
+++ b/utils/test/math-format.js
@@ -1,0 +1,24 @@
+module("math-format");
+
+(function(){
+
+var commafy = KhanUtil.commafy;
+
+test( "commafy for whole numbers", 6, function() {
+  equals( commafy(1),       "1",             "Commafying one-digit numbers" );
+  equals( commafy(12),      "12",            "Commafying two-digit numbers" );
+  equals( commafy(123),     "123",           "Commafying three-digit numbers" );
+  equals( commafy(1234),    "1{,}234",       "Commafying four-digit numbers" );
+  equals( commafy(1234567), "1{,}234{,}567", "Commafying longer numbers" );
+  equals( commafy(-1234),   "-1{,}234",      "Commafying negative numbers" );
+});
+
+test( "commafy for decimals", 5, function() {
+  equals( commafy(1.23),            "1.23",                        "Commafying numbers with 2 decimal places" );
+  equals( commafy(1.234),           "1.234",                       "Commafying numbers with 3 decimal places" );
+  equals( commafy(1.2345),          "1.234\\;5",                   "Commafying numbers with 4 decimal places" );
+  equals( commafy(1.23456789),      "1.234\\;567\\;89",            "Commafying numbers with many decimal places" );
+  equals( commafy(1234567.8901234), "1{,}234{,}567.890\\;123\\;4", "Commafying large decimals with many decimal places" );
+});
+
+})();


### PR DESCRIPTION
The commafy() util function will only comma-separate numbers with 5 or more digits (e.g. 10,000) but will not comma-separate numbers with 4 digits (e.g. 4000).

It also does not add the "\;" into decimal places for numbers with four decimal places (e.g. 1.2345 should be 1.234\;5).

Is this intentional?

If not, this pull fixes the two bugs and includes test coverage.
