### PR TITLE
When asking people to determine the slope, do not show lines with slope +/-1

### DIFF
--- a/exercises/slope_of_a_line.html
+++ b/exercises/slope_of_a_line.html
@@ -16,7 +16,7 @@
 	<div class="exercise">
 	<div class="problems">
 		<div id="give-two-points" data-weight="3">
-			<div class="vars" data-ensure="Math.pow(Y1 - Y2, 2) + Math.pow(X1 - X2, 2) < 36 && X1 < X2 && (X2 - X1) != (Y2 - Y1) && (X2 - X1) != (Y1 - Y2)">
+			<div class="vars" data-ensure="Math.pow(Y1 - Y2, 2) + Math.pow(X1 - X2, 2) < 36 && X1 < X2 && Math.abs(M) !== 1">
 				<var id="X1">randRange(-9, 9)</var>
 				<var id="Y1">randRange(-9, 9)</var>
 

--- a/exercises/slope_of_a_line.html
+++ b/exercises/slope_of_a_line.html
@@ -16,7 +16,7 @@
 	<div class="exercise">
 	<div class="problems">
 		<div id="give-two-points" data-weight="3">
-			<div class="vars" data-ensure="Math.pow(Y1 - Y2, 2) + Math.pow(X1 - X2, 2) < 36 && X1 < X2">
+			<div class="vars" data-ensure="Math.pow(Y1 - Y2, 2) + Math.pow(X1 - X2, 2) < 36 && X1 < X2 && (X2 - X1) != (Y2 - Y1) && (X2 - X1) != (Y1 - Y2)">
 				<var id="X1">randRange(-9, 9)</var>
 				<var id="Y1">randRange(-9, 9)</var>
 


### PR DESCRIPTION
This is based on feedback from a user:

> From my tutoring experience I have a suggestion for the problems
> associated with 'Slope of a Line'. One class of problems gives two
> points and asks the user to find the slope of the line. My suggestion
> is not to include problems where the slope is 1, or -1. A common
> confusion in the youth is if change in y or change in x is in the
> numerator. In problems where the slope is 1, or -1 you can mix up the
> dx and dy and still get the problem right leading to more confusion.

Slope 1/-1 is rather uncommon in this exercise anyway, so it's not a
big change to disallow it.
