### PR TITLE
Improve clarity of number line 3

### DIFF
--- a/exercises/number_line_3.html
+++ b/exercises/number_line_3.html
@@ -9,14 +9,13 @@
 	<div class="exercise">
 	<div class="vars">
 		<var id="MIDPOINT">randRange( -15, 15 )</var>
-		<var id="DISTANCE">randRange( -2, 2 )</var>
+		<var id="DISTANCE">randRangeExclude( -2, 2,[0] )</var>
 		<var id="NUMBER">randRangeExclude( max(MIDPOINT-5, MIDPOINT-5-DISTANCE),min(MIDPOINT+5, MIDPOINT+5-DISTANCE), [ 0, MIDPOINT - DISTANCE ] )</var>
 	</div>
 	<div class="problems">
 		<div>
 			<div class="question">
-				<p data-if="DISTANCE !== 0">What number is <strong><var>plural( abs( DISTANCE ), "position")</var> to the <span data-if="DISTANCE < 1">left</span><span data-else>right</span> of the orange dot</strong>? The distance between adjacent tick marks is 1.</p>
-				<p data-else>What number does the orange dot represent? The distance between adjacent tick marks is 1.</p>
+				<p data-if="DISTANCE !== 0">What number is <strong><var>plural( abs( DISTANCE ), "position")</var></strong> to the <strong><span data-if="DISTANCE < 1">left</span><span data-else>right</span></strong> of the <strong>orange dot</strong>? The distance between adjacent tick marks is 1.</p>
 				<div class="graphie" id="number-line">
 					init({
 						range: [ [ MIDPOINT-6, MIDPOINT+6 ], [ -1, 1 ] ]

--- a/exercises/number_line_3.html
+++ b/exercises/number_line_3.html
@@ -9,7 +9,7 @@
 	<div class="exercise">
 	<div class="vars">
 		<var id="MIDPOINT">randRange( -15, 15 )</var>
-		<var id="DISTANCE">randRangeExclude( -2, 2,[0] )</var>
+		<var id="DISTANCE">randRangeExclude( -2, 2, [ 0 ] )</var>
 		<var id="NUMBER">randRangeExclude( max(MIDPOINT-5, MIDPOINT-5-DISTANCE),min(MIDPOINT+5, MIDPOINT+5-DISTANCE), [ 0, MIDPOINT - DISTANCE ] )</var>
 	</div>
 	<div class="problems">

--- a/exercises/telling_time_2.html
+++ b/exercises/telling_time_2.html
@@ -195,6 +195,9 @@
 
 						correctMinuteAngle = roundToNearest( minuteSnapDegrees, correctMinuteAngle );
 						correctHourAngle = roundToNearest( hourSnapDegrees, correctHourAngle );
+
+						almostCorrectHourAngle = timeToDegrees( 5 * HOUR ) 
+						almostCorrectHourAngle = roundToNearest( 360 / 12,  almostCorrectHourAngle )
 					</div>
 				</div>
 
@@ -218,6 +221,10 @@
 							return "";
 						}
 
+						if (minuteAngle === correctMinuteAngle &amp;&amp; hourAngle !== correctHourAngle &amp;&amp; hourAngle === almostCorrectHourAngle) {
+							return "Almost correct, but the hour hand shouldn't be exactly on the hour.";
+						}
+						
 						return (minuteAngle === correctMinuteAngle) &amp;&amp; (hourAngle === correctHourAngle);
 
 					</div>


### PR DESCRIPTION
A lot of users seem to think that the question is asking what the value is at the orange dot (for example bug #18092 but at least several dozen have been closed as notabug).

To try and improve this I've made two changes:

1) I've stopped it asking the question "What number does the orange dot represent?" as this essentially duplicates the number line 2 questions, and if users get that as the first question they may assume all of the questions are asking them to do the same. 

2) I've changed the strong tags to highlight the important words in the question sentence more clearly.
