### PR TITLE
Add an "almost correct" for users on telling time

### DIFF
--- a/exercises/telling_time_2.html
+++ b/exercises/telling_time_2.html
@@ -195,6 +195,9 @@
 
 						correctMinuteAngle = roundToNearest( minuteSnapDegrees, correctMinuteAngle );
 						correctHourAngle = roundToNearest( hourSnapDegrees, correctHourAngle );
+
+						almostCorrectHourAngle = timeToDegrees( 5 * HOUR ) 
+						almostCorrectHourAngle = roundToNearest( 360 / 12,  almostCorrectHourAngle )
 					</div>
 				</div>
 
@@ -218,6 +221,10 @@
 							return "";
 						}
 
+						if (minuteAngle === correctMinuteAngle &amp;&amp; hourAngle !== correctHourAngle &amp;&amp; hourAngle === almostCorrectHourAngle) {
+							return "Almost correct, but the hour hand shouldn't be exactly on the hour.";
+						}
+						
 						return (minuteAngle === correctMinuteAngle) &amp;&amp; (hourAngle === correctHourAngle);
 
 					</div>


### PR DESCRIPTION
Fix for #18057 #17998 #17688 #17469 #17479 #17445 #17548 #17406 #17239 #17093 (and many others - most of the telling time bugs are this issue)

Many users place the hour hand at precisely hour intervals rather than the appropriate point between hours, so for 6:45 they would put the hour hand at precisely 6. And when they submit this as their answer they get a "wrong" response and end up frustrated because they're certain they're correct.

This fix detects that scenario and gives an "almost correct" message and provides a hint to tell them they need to adjust the hour hand.

http://sandcastle.khanacademy.org/pull/18106/
