### PR TITLE
Number Line 3: Replace terms bigger/smaller with greater than/less than for clarity

### DIFF
--- a/exercises/number_line_3.html
+++ b/exercises/number_line_3.html
@@ -39,7 +39,7 @@
 
 			<div class="hints">
 				<p>We know where <code><var>MIDPOINT</var></code> is on this number line because it is labeled.</p>
-				<p>Numbers to the left of <code><var>MIDPOINT</var></code> are smaller, while numbers to the right of <code><var>MIDPOINT</var></code> are bigger.</p>
+				<p>Numbers to the left are less than <code><var>MIDPOINT</var></code>, while numbers to the right are greater than <code><var>MIDPOINT</var></code>.</p>
 				<div data-if="DISTANCE !== 0">
 					<p>We need to find the number represented by the blue dot, which is <var>plural( abs( DISTANCE ), "position")</var> to the <span data-if="DISTANCE < 1">left</span><span data-else>right</span> of the orange dot.</p>
 					<div class="graphie" data-update="number-line">


### PR DESCRIPTION
Bugs #17979, #17387, #13990

Students were getting confused because the hints say that number to the left on the number line are smaller, which doesn't make sense for negative numbers (because while -10 is less than -4 and falls to the left of it on the number line, -10 is also bigger than -4). 

Replaced the term smaller/bigger with "greater than"/"less than" which should be understandable to the students doing this exercise.
