### PR TITLE
create() calls activate(), so activate() should be defined before the call to create() is queued

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1461,8 +1461,6 @@ var Khan = (function() {
                 });
             };
 
-            MathJax.Hub.Queue(function() {create(0);});
-
             var activate = function(slideNum) {
                 var hint, thisState,
                     thisSlide = states.eq(slideNum),
@@ -1511,6 +1509,8 @@ var Khan = (function() {
                     }
                 }
             };
+
+            MathJax.Hub.Queue(function() {create(0);});
 
             // Allow users to use arrow keys to move up and down the timeline
             $(document).keydown(function(event) {


### PR DESCRIPTION
In the unlikely event MathJax isn't slow, it seems like `create()` could get called before `MathJax.Hub.Queue(function() {create(0);});` returns. Since `create()` calls `activate()`, this fails since `activate()` isn't defined yet.

@spicyj review
