### PR TITLE
first pass at solving problem of duplicate problems

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -958,16 +958,16 @@ var Khan = (function() {
      * a duplicate (or too similar) to a recently done problem in the same
      * exercise.
      */
-    function isDuplicatedProblem() {
+    function shouldSkipProblem() {
         // We don't need to skip duplicate problems in test mode, which allows
         // us to use the LocalStore localStorage abstraction from shared-package
         if (typeof LocalStore === "undefined") {
             return false;
         }
 
-        var cacheKey = 'prevProblems:' + user + ':' + exerciseName;
+        var cacheKey = "prevProblems:" + user + ':' + exerciseName;
         var cached = LocalStore.get(cacheKey);
-        var lastProblemNum = (cached && cached['lastProblemNum']) || 0;
+        var lastProblemNum = (cached && cached["lastProblemNum"]) || 0;
 
         if (lastProblemNum === problemNum) {
             // Getting here means the user refreshed the page or returned to
@@ -976,7 +976,7 @@ var Khan = (function() {
             return false;
         }
 
-        var pastHashes = (cached && cached['history']) || [];
+        var pastHashes = (cached && cached["history"]) || [];
         var varsHash = $.tmpl.getVarsHash();
 
         // Should skip the current problem if we've already seen it in the past
@@ -989,7 +989,7 @@ var Khan = (function() {
         } else {
             consecutiveSkips = 0;
             pastHashes.push(varsHash);
-            if (pastHashes.length > dupWindowSize) {
+            while (pastHashes.length > dupWindowSize) {
                 pastHashes.shift();
             }
 
@@ -1130,7 +1130,7 @@ var Khan = (function() {
         problem.runModules(problem, "Load");
         problem.runModules(problem);
 
-        if (isDuplicatedProblem()) {
+        if (shouldSkipProblem()) {
             // If this is a duplicate problem we should skip, just generate
             // another problem of the same problem type but w/ a different seed.
             clearExistingProblem();
@@ -2480,9 +2480,15 @@ var Khan = (function() {
     }
 
     function getSeedsSkippedCacheKey() {
-        return 'seedsSkipped:' + user + ':' + exerciseName;
+        return "seedsSkipped:" + user + ":" + exerciseName;
     }
 
+    /**
+     * Advances the seed (as if the problem number had been advanced) without
+     * actually changing the problem number. Caches how many seeds we've skipped
+     * so that refreshing does not change the generated problem.
+     * @param {number} num Number of times to advance the seed.
+     */
     function nextSeed(num) {
         seedsSkipped += num;
         if (typeof LocalStore !== "undefined") {

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -967,12 +967,12 @@ var Khan = (function() {
 
         var cacheKey = 'prevProblems:' + user + ':' + exerciseName;
         var cached = LocalStore.get(cacheKey);
-        var lastProblemNum = (cached && cached['lastProblemNum']) || 1;
+        var lastProblemNum = (cached && cached['lastProblemNum']) || 0;
 
         if (lastProblemNum === problemNum) {
-            // Getting here means the user refreshed the page, returned to this
-            // exercise after being away, or it's the user's first problem. So,
-            // we don't need to and shouldn't skip this problem.
+            // Getting here means the user refreshed the page or returned to
+            // this exercise after being away. So, we don't need to and
+            // shouldn't skip this problem.
             return false;
         }
 

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -962,7 +962,7 @@ var Khan = (function() {
         // We don't need to skip duplicate problems in test mode, which allows
         // us to use the LocalStore localStorage abstraction from shared-package
         if (typeof LocalStore === "undefined") {
-            return;
+            return false;
         }
 
         var cacheKey = 'prevProblems:' + user + ':' + exerciseName;
@@ -970,22 +970,20 @@ var Khan = (function() {
         var lastProblemNum = (cached && cached['lastProblemNum']) || 1;
 
         if (lastProblemNum === problemNum) {
-            // Getting here means the user refreshed the page, didn't complete
-            // the last problem, or it's the user's first problem. So, we don't
-            // need to and shouldn't skip this problem.
-            return;
+            // Getting here means the user refreshed the page, returned to this
+            // exercise after being away, or it's the user's first problem. So,
+            // we don't need to and shouldn't skip this problem.
+            return false;
         }
 
         var pastHashes = (cached && cached['history']) || [];
         var varsHash = $.tmpl.getVarsHash();
 
-        // Skip the current problem if we've already seen it in the past few
-        // problems, but not if we've been fruitlessly skipping for a while. The
-        // latter situation could happen if a problem has very few unique
+        // Should skip the current problem if we've already seen it in the past
+        // few problems, but not if we've been fruitlessly skipping for a while.
+        // The latter situation could happen if a problem has very few unique
         // problems (eg. exterior angles problem type of angles_of_a_polygon).
         if (_.contains(pastHashes, varsHash) && consecutiveSkips < dupWindowSize) {
-            // Skip to the next problem by advancing the seed (but not the
-            // problem number).
             consecutiveSkips++;
             return true;
         } else {
@@ -996,9 +994,9 @@ var Khan = (function() {
             }
 
             LocalStore.set(cacheKey, {
-                'lastProblemNum': problemNum,
-                'history': pastHashes
-            })
+                lastProblemNum: problemNum,
+                history: pastHashes
+            });
             return false;
         }
     }

--- a/utils/tmpl.js
+++ b/utils/tmpl.js
@@ -242,6 +242,24 @@ $.tmpl = {
         }
     },
 
+    /**
+     * Get a hash of the problem variables for duplication detection purposes.
+     */
+    // TODO(david): Allow exercise developers to specify which variables are not
+    //     important for duplicate determination purposes.
+    // TODO(david): Just a possibility, but allow exercise developers to specify
+    //     their own variable hash function, so that, eg. for addition 1, 2 + 3
+    //     could hash to the same value as 3 + 2.
+    getVarsHash: function() {
+        // maybe TODO(david): Can base-64 encode the crc32 integer if we want to
+        //     save a few bytes, since localStorage stores strings only.
+        return KhanUtil.crc32(JSON.stringify(VARS, function(key, value) {
+            // Just convert top-level values to strings instead of recursively
+            // stringifying, due to issues with circular references.
+            return key.length ? String(value) : value;
+        }));
+    },
+
     // Make sure any HTML formatting is stripped
     cleanHTML: function(text) {
         return ("" + text).replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&");


### PR DESCRIPTION
I went through a few iterations before settling on this solution:
# Attempted solutions
1. Have an RNG that does not repeat itself.
   
   I considered a linear feedback shift register, a linear congruential generator, and just a Fisher-Yates shuffle to generate a random permutation of all numbers in a range. I went with the latter because it's easy to understand and modify to generate any number of different random permutations of a range. However, after speaking with Ben Alpert, I decided to drop this for solution 2.
   
   cons: 
   - requires "flag day" where viewing old problems are invalidated because the RNG is different. 
   - Also, if we wish to have only 200 possible problems as we do now, we could only ensure that the first call to the RNG in a problem is a non-duplicate, which may require exercise developers to specify the first non-trivial call to the RNG (since the first call to an RNG may be just a problem. This is a leaky abstraction. :(
   - to make this work with data-ensure loops and randRangeNonZero, the code could get a little convoluted.
2. Pre-process (eg. during deploy-time) the exercises to find seeds that generate duplicate problems, and discard (all but 1 of) those seeds.
   
   I spent a day attempting to hack around jsdom's deficiencies (eg. no XHRs) and bugs, but doing all this required lots of changes to khan-exercise.js, may be brittle, and ultimately I decided to try out phantomjs before getting this to work.
   
   I then tried out phantomjs, which is headless webkit using QtWebkit. This took only 10 mins to get working with our exercises, but QtWebkit is very slow and after a day of optimizations removing unnecessary steps, it still took over half an hour to pre-process less than half the exercises. Due to other cons below, I dropped this solution as well.
   
   pros:
   - does not invalidate viewing of old problems done
   - allows exercise developers to more precisely define what a duplicate problem is for a an exercise (if they specify the VARS hashing function).
   
   cons:
   - pre-processing slows down deploy time by hours. This is because we need to run makeProblem 200 times on every problem type in each exercise, and QtWebkit is slow. We could cache these results, but every time there is a change to khan-exercise.js or any javascript file, would need to re-run the pre-processing to be safe. I also didn't think it'd be wise to spend more time doing optimizations.
3. At run-time, check if the current problem is similar to any of the last 5 problems done. If so, skip it.
   
   This is the final solution that was implemented in this commit. It uses localStorage for state persistence. It does not screw up problem numbers (they still only increase by 1 for each problem done) and refreshing the page would not change the problem.
   
   pros:
   - is not brittle
   - does not slow down deploy
   - does not invalidate older problems
   - is simple and not much code (eg. does not have to know about different problem types, but option 2 does) (compared to the options above)
   - allows exercise developers to more precisely define what a duplicate problem is for an exercise (if they specify the VARS hashing function).
   
   cons:
   - a tiny bit slower during run-time due to having to re-run half of makeProblem a few times if we need to skip
   - possibility of having a duplicate problem after 5 problems (the current window size), but this is a very minor con.

I need to go for dinner now. If I think of other things to add, I'll add it to the pull request message.

@beneater @kamens @spicyj (almost a full bengineer review)
