### PR TITLE
Modify method of hashing VARS for detecting duplicate problems

### DIFF
--- a/utils/tmpl.js
+++ b/utils/tmpl.js
@@ -257,7 +257,7 @@ $.tmpl = {
         // Just convert top-level values to strings instead of recursively
         // stringifying, due to issues with circular references.
         return KhanUtil.crc32(JSON.stringify($.map(VARS, function(value, key) {
-            return [key, key.length ? String(value) : value];
+            return [key, String(value)];
         })));
     },
 

--- a/utils/tmpl.js
+++ b/utils/tmpl.js
@@ -253,11 +253,12 @@ $.tmpl = {
     getVarsHash: function() {
         // maybe TODO(david): Can base-64 encode the crc32 integer if we want to
         //     save a few bytes, since localStorage stores strings only.
-        return KhanUtil.crc32(JSON.stringify(VARS, function(key, value) {
-            // Just convert top-level values to strings instead of recursively
-            // stringifying, due to issues with circular references.
-            return key.length ? String(value) : value;
-        }));
+
+        // Just convert top-level values to strings instead of recursively
+        // stringifying, due to issues with circular references.
+        return KhanUtil.crc32(JSON.stringify($.map(VARS, function(value, key) {
+            return [key, key.length ? String(value) : value];
+        })));
     },
 
     // Make sure any HTML formatting is stripped


### PR DESCRIPTION
@divad12

The Firefox 3.6 implementation of JSON.stringify() seems to operate recursively regardless of what the replacer function returns. It seems the replacer function only modifies how each element is encoded; it doesn't limit recursion. Thus some exercises were broken when using FF 3.6.
