### PR TITLE
Fixing a minor bug that would sometimes prevent the user from submitting an answer

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1850,7 +1850,7 @@ var Khan = (function() {
             }
 
             // Stop if the form is already disabled and we're waiting for a response.
-            if ($("#answercontent input").not("#hint").is(":disabled")) {
+            if ($("#answercontent input").not("#hint,#next-question-button").is(":disabled")) {
                 return false;
             }
 


### PR DESCRIPTION
This bug showed up in my poking around with card types. It only happens when the "completed stack" view is commented out, and I'm not sure what that has to do with the check answer button but it looks to me like the next answer button is not intended to be enabled while doing an exercise.

I think this behavior is correct.
