### PR TITLE
Incorrect hint in Limits 2

### DIFF
--- a/exercises/limits_2.html
+++ b/exercises/limits_2.html
@@ -100,6 +100,8 @@
                 <div class="vars">
                     <var id="A">randRangeNonZero( -7, 7 )</var>
                     <var id="K">randRangeNonZero( -7, 7 )</var>
+					<var id="SIGN_LIM_LEFT">A > 0 ? "-" : "+"</var>
+					<var id="SIGN_LIM_RIGHT">SIGN_LIM_LEFT === "+" ? "-" : "+"</var>
                 </div>
 
                 <div class="question">
@@ -117,8 +119,8 @@
 
                 <div class="hints">
                     <p>Consider the behavior of the function as <code>x \to <var>K</var></code> from each direction.</p>
-                    <p>As <code>x</code> approaches <code><var>K</var></code> from the left, <code><var>B</var>x + <var>-K</var></code> starts negative and increases as it approaches <code>0</code>, so <code>\dfrac{<var>A</var>}{<var>B</var>x + <var>-K</var>}</code> approaches <code>-\infty</code>.</p>
-                    <p>As <code>x</code> approaches <code><var>K</var></code> from the right, <code><var>B</var>x + <var>-K</var></code> starts positive and decreases as it approaches <code>0</code>, so <code>\dfrac{<var>A</var>}{<var>B</var>x + <var>-K</var>}</code> approaches <code>+\infty</code>.</p>
+                    <p>As <code>x</code> approaches <code><var>K</var></code> from the left, <code><var>B</var>x + <var>-K</var></code> starts negative and increases as it approaches <code>0</code>, so <code>\dfrac{<var>A</var>}{<var>B</var>x + <var>-K</var>}</code> approaches <code><var>SIGN_LIM_LEFT</var>\infty</code>.</p>
+                    <p>As <code>x</code> approaches <code><var>K</var></code> from the right, <code><var>B</var>x + <var>-K</var></code> starts positive and decreases as it approaches <code>0</code>, so <code>\dfrac{<var>A</var>}{<var>B</var>x + <var>-K</var>}</code> approaches <code><var>SIGN_LIM_RIGHT</var>\infty</code>.</p>
                     <p>Since the left- and right-hand limits are not equal, the limit is not defined.</p>
                 </div>
             </div>


### PR DESCRIPTION
Fix #21281, #9686, #13996, #22644

When x approaches the number from the left, the denominator is negative and the hint says the lim tend to -infinity.
The problem was the code didn't took in consideration the sign of the numerator, because when the numerator is negative and denominator too, the lim would tend to +infinity.
Same thing from the right side.
