### PR TITLE
Congruent angles: Fixes #24216

### DIFF
--- a/exercises/congruent_angles.html
+++ b/exercises/congruent_angles.html
@@ -33,7 +33,7 @@
 
                     graph.congruency = addCongruency({ y1: -0.7, y2: 3.7 });
 
-                    graph.cross = graph.congruency.addLine({ start: [5, 1.5], angle: ANGLE });
+                    graph.cross = graph.congruency.addLine({ start: [5, 1.5], angle: ((ANGLE===90) ? (Math.floor(Math.random()*2)?ANGLE=91:ANGLE=89 ): ANGLE) });
                     graph.bottom = graph.congruency.addLine({ start: [0, 0], end: [10, 0] });
                     graph.top = graph.congruency.addLine({ start: [0, 3], end: [10, 3] });
 


### PR DESCRIPTION
Fixes #24216
The error happens due to the angle being 90 degrees. 

The fix checks for ANGLE=90 and if it is so, sets it 89 or 91.

PS: There may be a better fix, for instance changing the congruency.js so that slopes are checked if they can be calculated. But for this exercise I think just not choosing angle 90 works and if we want to keep the 90 also, the solution need to change as if the angle is 90 then all the other angles are congruent.
