### PR TITLE
Ensure labels with no content are not MathJax'd

### DIFF
--- a/utils/graphie.js
+++ b/utils/graphie.js
@@ -279,7 +279,7 @@
                     padding: (pad != null ? pad : 7) + "px"
                 })).appendTo(el);
 
-                if (typeof MathJax !== "undefined" && (text+"").trim() !== "") {
+                if (typeof MathJax !== "undefined" && $.trim(text + "") !== "") {
                     // Add to the MathJax queue
                     if (latex) {
                         $.tmpl.type.code()(code[0]);

--- a/utils/graphie.js
+++ b/utils/graphie.js
@@ -279,7 +279,7 @@
                     padding: (pad != null ? pad : 7) + "px"
                 })).appendTo(el);
 
-                if (typeof MathJax !== "undefined") {
+                if (typeof MathJax !== "undefined" && (text+"").trim() !== "") {
                     // Add to the MathJax queue
                     if (latex) {
                         $.tmpl.type.code()(code[0]);


### PR DESCRIPTION
If a label has no content, still create it (in case it needs to be used later) but ensure that no MathJax is run on it, which might cause a [Math Processing Error] to be displayed

compare:
old: http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/congruent_triangles_2.html?nocache
new: http://sandcastle.khanacademy.org/media/castles/xymostech:fix-mathjax-errors/exercises/congruent_triangles_2.html?nocache

@spicyj @beneater review?
