### PR TITLE
Numberline 3 fix #18092 and other related (marked notabug)

### DIFF
--- a/exercises/number_line_3.html
+++ b/exercises/number_line_3.html
@@ -67,7 +67,6 @@
                         if ( DISTANCE === 0 ) {
                             color = "#FFA500";
                         }
-                        //label( [ NUMBER, -0.53 ],  NUMBER, "center", { color: "#FFA500" });
                         label( [ NUMBER+DISTANCE, -0.53 ],  NUMBER+DISTANCE, "center", { color: color });
                     </div>
                 </div>

--- a/exercises/number_line_3.html
+++ b/exercises/number_line_3.html
@@ -57,16 +57,17 @@
                         style({ stroke: color, fill: color, strokeWidth: 3.5, arrows: "->" });
                         line( [ MIDPOINT, 0 ], [ NUMBER+DISTANCE, 0 ] );
                         graph.blueDot.toFront();
+                        graph.orangeDot.toFront();
                     </div>
                 </div>
                 <div>
-                    <p>Thus, the <span data-if="DISTANCE !== 0">blue</span><span data-else>orange</span> dot represents the number <code><var>NUMBER+DISTANCE</var></code>.</p>
+                    <p class="final_answer">Thus, the <span data-if="DISTANCE !== 0">blue</span><span data-else>orange</span> dot represents the number <code><var>NUMBER+DISTANCE</var></code>.</p>
                     <div class="graphie" data-update="number-line">
                         var color = "#6495ED";
                         if ( DISTANCE === 0 ) {
                             color = "#FFA500";
                         }
-                        label( [ NUMBER, -0.53 ],  NUMBER, "center", { color: "#FFA500" });
+                        //label( [ NUMBER, -0.53 ],  NUMBER, "center", { color: "#FFA500" });
                         label( [ NUMBER+DISTANCE, -0.53 ],  NUMBER+DISTANCE, "center", { color: color });
                     </div>
                 </div>


### PR DESCRIPTION
removed the labeling for the orange dot which may be causing confusion (not important given hints).
added class="final_answer" to bold answer.
also added a toFront to orange dot so don't end up with weird looking graphs when orange dot is on marked number.
