### PR TITLE
Fill-in-blanks and Find-wrong-statement proof exercises

### DIFF
--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -255,191 +255,126 @@
                 });
 
                 for(var line in graph.congruency.lines){
-                            for(var line2 in graph.congruency.lines){
+                    for(var line2 in graph.congruency.lines){
 
-                                $(function(){
-                                    var $statement = $("."+line+"-"+line2);
-                                    var firstLine = graph.congruency.lines[line];
-                                    var secondLine = graph.congruency.lines[line2];
+                        $(function(){
+                            var $statement = $("."+line+"-"+line2);
+                            var firstLine = graph.congruency.lines[line];
+                            var secondLine = graph.congruency.lines[line2];
 
-                                    if($statement.length > 0){
-                                        $statement.bind("vmouseover", function(event) {
-                                            firstLine.setHighlighted({
-                                                stroke: ORANGE,
-                                                "stroke-width": 3
-                                            });
-                                            secondLine.setHighlighted({
-                                                stroke: BLUE,
-                                                "stroke-width": 3
-                                            });
-                                            $(this).bind("vmouseout", function(event) {
-                                                firstLine.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                                secondLine.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                            });
-                                        });
-
-                                    }
-                                });
-                            }
-                        }
-
-                        for(var angle in graph.congruency.angles){
-                            for(var angle2 in graph.congruency.angles){
-                                $(function(){
-                                    var $statement = $("."+angle+"-"+angle2);
-                                    var firstAngle = graph.congruency.angles[angle];
-                                    var secondAngle = graph.congruency.angles[angle2];
-
-                                    if($statement.length > 0){
-                                        $statement.bind("vmouseover", function(event) {
-                                            var firstState = firstAngle.state;
-                                            var secondState = secondAngle.state;
-                                            var maxState = Math.max(firstState,secondState);
-
-                                            firstAngle.setHighlighted({
-                                                stroke: ORANGE,
-                                                "stroke-width": 3
-                                            });
-                                            secondAngle.setHighlighted({
-                                                stroke: BLUE,
-                                                "stroke-width": 3
-                                            });
-                                            firstAngle.setState(maxState > 0 ? maxState : 1);
-                                            secondAngle.setState(maxState > 0 ? maxState : 1);
-                                            $(this).bind("vmouseout", function(event) {
-                                                firstAngle.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                                secondAngle.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                                firstAngle.setState(firstState);
-                                                secondAngle.setState(secondState);
-                                            });
-                                        });
-                                    }
-                                });
-                            }
-                        }
-
-                        for(var i=0; i<(TRIANGLES.length); i++){
-                            for(var j=0; j<(TRIANGLES.length); j++){
-                                for(var k=0; k<3; k++){
-                                // >
-                                    $(function(){
-                                        var triangle = TRIANGLES[i];
-                                        var triangle2 = TRIANGLES[j];
-
-                                        var seg1_1 = triangle.segs[k].toString().substring(3,5);
-                                        var seg1_2 = triangle.segs[(k+1) % 3].toString().substring(3,5);
-                                        var seg1_3 = triangle.segs[(k+2) % 3].toString().substring(3,5);
-
-                                        var seg2_1 = triangle2.segs[k].toString().substring(3,5);
-                                        var seg2_2 = triangle2.segs[(k+1) % 3].toString().substring(3,5);
-                                        var seg2_3 = triangle2.segs[(k+2) % 3].toString().substring(3,5);
-
-                                        var triangleSegs = [seg1_1, seg1_2, seg1_3];
-                                        var triangle2Segs = [seg2_1, seg2_2, seg2_3];
-                                        var sharedSeg = [-1, -1];
-
-                                        for(var l=0; l<3; l++){
-                                            for(var m=0; m<3; m++){
-                                            // >
-                                                if(triangleSegs[l] === triangle2Segs[m]){
-                                                    sharedSeg = [l,m];
-                                                }
-                                            }
-                                        }
-
-
-                                        var $statement = $("."+seg1_1+"-"+seg1_2+"-"+seg1_3+"-"+seg2_1+"-"+seg2_2+"-"+seg2_3);
-
-                                        var line1_1 = graph.congruency.lines[seg1_1];
-                                        var line1_2 = graph.congruency.lines[seg1_2];
-                                        var line1_3 = graph.congruency.lines[seg1_3];
-
-                                        var line2_1 = graph.congruency.lines[seg2_1];
-                                        var line2_2 = graph.congruency.lines[seg2_2];
-                                        var line2_3 = graph.congruency.lines[seg2_3];
-
-                                        var triangleLines = [line1_1, line1_2, line1_3];
-                                        var triangle2Lines = [line2_1, line2_2, line2_3];
-
-                                        if($statement.length > 0){
-                                            $statement.bind("vmouseover", function(event) {
-                                                for(var l=0; l<3; l++){
-                                                // >
-                                                    if(sharedSeg[0] != l){
-                                                        triangleLines[l].setUnselectedStyle({
-                                                            stroke: ORANGE,
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                    else{
-                                                        triangleLines[l].setUnselectedStyle({
-                                                            stroke: "black",
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                }
-
-                                                for(var l=0; l<3; l++){
-                                                // >
-                                                    if(sharedSeg[1] != l){
-                                                        triangle2Lines[l].setUnselectedStyle({
-                                                            stroke: BLUE,
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                    else{
-                                                        triangle2Lines[l].setUnselectedStyle({
-                                                            stroke: "black",
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                }
-
-                                                $(this).bind("vmouseout", function(event) {
-                                                    line1_1.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line1_2.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line1_3.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-
-                                                    line2_1.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line2_2.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line2_3.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                });
-                                            });
-                                        }
+                            if($statement.length > 0){
+                                $statement.bind("vmouseover", function(event) {
+                                    firstLine.setHighlighted({
+                                        stroke: ORANGE,
+                                        "stroke-width": 3
                                     });
-                                }
+                                    secondLine.setHighlighted({
+                                        stroke: BLUE,
+                                        "stroke-width": 3
+                                    });
+                                    $(this).bind("vmouseout", function(event) {
+                                        firstLine.unsetHighlighted({
+                                            stroke: "black",
+                                            "stroke-width": 2
+                                        });
+                                        secondLine.unsetHighlighted({
+                                            stroke: "black",
+                                            "stroke-width": 2
+                                        });
+                                    });
+                                });
+
                             }
+                        });
+                    }
+                }
+
+                for(var angle in graph.congruency.angles){
+                    for(var angle2 in graph.congruency.angles){
+                        $(function(){
+                            var $statement = $("."+angle+"-"+angle2);
+                            var firstAngle = graph.congruency.angles[angle];
+                            var secondAngle = graph.congruency.angles[angle2];
+
+                            if($statement.length > 0){
+                                $statement.bind("vmouseover", function(event) {
+                                    var firstState = firstAngle.state;
+                                    var secondState = secondAngle.state;
+                                    var maxState = Math.max(firstState,secondState);
+
+                                    firstAngle.setHighlighted({
+                                        stroke: ORANGE,
+                                        "stroke-width": 3
+                                    });
+                                    secondAngle.setHighlighted({
+                                        stroke: BLUE,
+                                        "stroke-width": 3
+                                    });
+                                    firstAngle.setState(maxState > 0 ? maxState : 1);
+                                    secondAngle.setState(maxState > 0 ? maxState : 1);
+                                    $(this).bind("vmouseout", function(event) {
+                                        firstAngle.unsetHighlighted({
+                                            stroke: "black",
+                                            "stroke-width": 2
+                                        });
+                                        secondAngle.unsetHighlighted({
+                                            stroke: "black",
+                                            "stroke-width": 2
+                                        });
+                                        firstAngle.setState(firstState);
+                                        secondAngle.setState(secondState);
+                                    });
+                                });
+                            }
+                        });
+                    }
+                }
+
+                for(var line in graph.congruency.lines){
+                    $(function(){
+                        var $statements = $("."+line);
+                        for(var i = 0; i&lt;$statements.length; i++){
+                            var highlightLine = graph.congruency.lines[line];
+                            var highlightDiv = $($statements[i]);
+
+                            highlightDiv.bind("vmouseover", function(event) {
+                                highlightLine.setHighlighted({
+                                    stroke: ORANGE,
+                                    "stroke-width": 3
+                                });
+                                $(this).bind("vmouseout", function(event) {
+                                    highlightLine.unsetHighlighted({
+                                        stroke: "black",
+                                        "stroke-width": 2
+                                    });
+                                });
+                            });
                         }
+                    });
+                }
+
+                for(var line in graph.congruency.lines){
+                    $(function(){
+                        var $statements = $("."+line + "2");
+                        for(var i = 0; i&lt;$statements.length; i++){
+                            var highlightLine = graph.congruency.lines[line];
+                            var highlightDiv = $($statements[i]);
+
+                            highlightDiv.bind("vmouseover", function(event) {
+                                highlightLine.setHighlighted({
+                                    stroke: BLUE,
+                                    "stroke-width": 3
+                                });
+                                $(this).bind("vmouseout", function(event) {
+                                    highlightLine.unsetHighlighted({
+                                        stroke: "black",
+                                        "stroke-width": 2
+                                    });
+                                });
+                            });
+                        }
+                    });
+                }
 
             </div>
         </div>

--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -42,42 +42,8 @@
             <var id="EF">new Seg("E","F")</var>
             <var id="FE">EF</var>
 
-            <!-- <var id="AB">new Seg("A","B")</var>
-            <var id="BA">AB</var>
-            <var id="AC">new Seg("A","C")</var>
-            <var id="CA">AC</var>
-            <var id="AD">new Seg("A","D")</var>
-            <var id="DA">AD</var>
-            <var id="AE">new Seg("A","E")</var>
-            <var id="EA">AE</var>
-            <var id="BC">new Seg("B","C")</var>
-            <var id="CB">BC</var>
-            <var id="BD">new Seg("B","D")</var>
-            <var id="DB">BD</var>
-            <var id="BE">new Seg("B","E")</var>
-            <var id="EB">BE</var>
-            <var id="CD">new Seg("C","D")</var>
-            <var id="DC">CD</var>
-            <var id="CE">new Seg("C","E")</var>
-            <var id="EC">CE</var>
-            <var id="DE">new Seg("D","E")</var>
-            <var id="ED">DE</var> -->
-
-            <!-- <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,BE,EB,CD,DC,CE,EC,DE,ED]</var> -->
             <var id="SEGS">[AB,BA,AC,CA,AD,DA,AF,FA,BC,CB,BD,DB,BE,EB,CE,EC,CF,FC,DE,ED,DF,FD,EF,FE]</var>
 
-            <!-- <var id="ang1">new Ang("D","A","C", null)</var>
-            <var id="ang2">new Ang("C","A","B", null)</var>
-            <var id="ang3">new Ang("C","B","A", null)</var>
-            <var id="ang4">new Ang("C","B","E", null)</var>
-            <var id="ang5">new Ang("A","C","B", null)</var>
-            <var id="ang6">new Ang("A","C","D", null)</var>
-            <var id="ang7">new Ang("B","C","E", null)</var>
-            <var id="ang8">new Ang("D","C","E", null)</var>
-            <var id="ang9">new Ang("A","D","C", null)</var>
-            <var id="ang10">new Ang("C","D","E", null)</var>
-            <var id="ang11">new Ang("C","E","D", null)</var>
-            <var id="ang12">new Ang("C","E","B", null)</var> -->
             <var id="ang1">new Ang("B","A","C")</var>
             <var id="ang2">new Ang("A","B","C")</var>
             <var id="ang3">new Ang("A","C","B")</var>
@@ -93,27 +59,16 @@
 
             <var id="ANGS">[ang1, ang2, ang3, ang4, ang5, ang6, ang7, ang8, ang9, ang10, ang11, ang12]</var>
 
-            <!-- <var id="SUPPLEMENTARY_ANGS">[addAngs(ang5, ang6), addAngs(ang6, ang8), addAngs(ang8, ang7), addAngs(ang7, ang5)]</var> -->
             <var id="SUPPLEMENTARY_ANGS">[addAngs(ang2, addAngs(ang5, ang4)), addAngs(ang3, addAngs(ang6, ang7)), addAngs(ang9, addAngs(ang10,ang11))]</var>
 
-            <!-- <var id="ALTERNATE_INTERIOR_ANGS">[[ang1, ang12], [ang2, ang11], [ang10, ang3], [ang9, ang4]]</var> -->
             <var id="ALTERNATE_INTERIOR_ANGS">[[ang5, ang9], [ang6, ang11]]</var>
 
-            <!-- <var id="ABC">new Triang([AB, BC, CA], [ang3, ang5, ang2])</var>
-            <var id="BCE">new Triang([BC, CE, EB], [ang7, ang12, ang4])</var>
-            <var id="ECD">new Triang([EC, CD, DE], [ang8, ang10, ang11])</var>
-            <var id="DCA">new Triang([DC, CA, AD], [ang6, ang1, ang9])</var>
-            <var id="ABE">new Triang([AB, BE, EA], [addAngs(ang3, ang4), ang12, ang2])</var>
-            <var id="ADE">new Triang([AD, DE, EA], [addAngs(ang9, ang10), ang11, ang1])</var>
-            <var id="BED">new Triang([BE, ED, DB], [addAngs(ang12, ang11), ang10, ang4])</var>
-            <var id="BAD">new Triang([BA, AD, DB], [addAngs(ang2, ang1), ang9, ang3])</var> -->
             <var id="ABC">new Triang([AB, BC, CA], [ang2, ang3, ang1])</var>
             <var id="BDE">new Triang([BD, DE, EB], [ang8, ang9, ang4])</var>
             <var id="BCE">new Triang([BC, CE, EB], [ang6, ang10, ang5])</var>
             <var id="CEF">new Triang([CE, EF, FC], [ang11, ang12, ang7])</var>
             <var id="ADF">new Triang([AD, DF, FA], [ang8, ang12, ang1])</var>
 
-            <!-- <var id="TRIANGLES">[ABC, BCE, ECD, DCA, ABE, ADE, BED, BAD]</var> -->
             <var id="TRIANGLES">[ABC, BDE, BCE, CEF]</var>
 
             <var id="STATEMENTS">initProof(SEGS, ANGS, TRIANGLES, SUPPLEMENTARY_ANGS, ALTERNATE_INTERIOR_ANGS, 3, 0.25, "all")</var>
@@ -127,7 +82,7 @@
         </div>
 
         <div class="problem">
-            <p class="question"> <code> \overline{AB} </code> is parallel to <code> \overline{DE} </code>, and <code> \overline{AD} </code> is parallel to <code> \overline{BE} </code>. Figure not drawn to scale. </p>
+            <p class="question"> <code> \overline{BC} </code> is parallel to <code> \overline{DF} </code>. Figure not drawn to scale. </p>
             <div class="graphie">
                 init({
                     range: [[-5, 5], [-5, 5]],

--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -259,14 +259,13 @@
 
                 for(var line in graph.congruency.lines){
                     for(var line2 in graph.congruency.lines){
-
-                        $(function(){
+                        (function() {
                             var $statement = $("."+line+"-"+line2);
                             var firstLine = graph.congruency.lines[line];
                             var secondLine = graph.congruency.lines[line2];
 
                             if($statement.length &gt; 0){
-                                $statement.bind("vmouseover", function(event) {
+                                $statement.live("vmouseover", function(event) {
                                     firstLine.setHighlighted({
                                         stroke: ORANGE,
                                         "stroke-width": 3
@@ -291,19 +290,19 @@
                                     "stroke-width": 2
                                 });
                             }
-                        });
+                        })();
                     }
                 }
 
                 for(var angle in graph.congruency.angles){
                     for(var angle2 in graph.congruency.angles){
-                        $(function(){
+                        (function(){
                             var $statement = $("."+angle+"-"+angle2);
                             var firstAngle = graph.congruency.angles[angle];
                             var secondAngle = graph.congruency.angles[angle2];
 
                             if($statement.length &gt; 0){
-                                $statement.bind("vmouseover", function(event) {
+                                $statement.live("vmouseover", function(event) {
                                     var firstState = firstAngle.state;
                                     var secondState = secondAngle.state;
                                     var maxState = Math.max(firstState,secondState);
@@ -332,18 +331,18 @@
                                     });
                                 });
                             }
-                        });
+                        })();
                     }
                 }
 
                 for(var line in graph.congruency.lines){
-                    $(function(){
+                    (function(){
                         var $statements = $("."+line);
                         for(var i = 0; i&lt;$statements.length; i++){
                             var highlightLine = graph.congruency.lines[line];
                             var highlightDiv = $($statements[i]);
 
-                            highlightDiv.bind("vmouseover", function(event) {
+                            highlightDiv.live("vmouseover", function(event) {
                                 highlightLine.setHighlighted({
                                     stroke: ORANGE,
                                     "stroke-width": 3
@@ -356,17 +355,17 @@
                                 });
                             });
                         }
-                    });
+                    })();
                 }
 
                 for(var line in graph.congruency.lines){
-                    $(function(){
+                    (function(){
                         var $statements = $("."+line + "2");
                         for(var i = 0; i&lt;$statements.length; i++){
                             var highlightLine = graph.congruency.lines[line];
                             var highlightDiv = $($statements[i]);
 
-                            highlightDiv.bind("vmouseover", function(event) {
+                            highlightDiv.live("vmouseover", function(event) {
                                 highlightLine.setHighlighted({
                                     stroke: BLUE,
                                     "stroke-width": 3
@@ -380,7 +379,7 @@
                                 });
                             });
                         }
-                    });
+                    })();
                 }
 
             </div>

--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -255,33 +255,27 @@
                 });
 
                 for(var line in graph.congruency.lines){
-                            for(var line2 in graph.congruency.lines){
+                    for(var line2 in graph.congruency.lines){
 
-                                $(function(){
-                                    var $statement = $("."+line+"-"+line2);
-                                    var firstLine = graph.congruency.lines[line];
-                                    var secondLine = graph.congruency.lines[line2];
+                        $(function(){
+                            var $statement = $("."+line+"-"+line2);
+                            var firstLine = graph.congruency.lines[line];
+                            var secondLine = graph.congruency.lines[line2];
 
-                                    if($statement.length &gt; 0){
-                                        $statement.bind("vmouseover", function(event) {
-                                            firstLine.setHighlighted({
-                                                stroke: ORANGE,
-                                                "stroke-width": 3
-                                            });
-                                            secondLine.setHighlighted({
-                                                stroke: BLUE,
-                                                "stroke-width": 3
-                                            });
-                                            $(this).bind("vmouseout", function(event) {
-                                                firstLine.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                                secondLine.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                            });
+                            if($statement.length &gt; 0){
+                                $statement.bind("vmouseover", function(event) {
+                                    firstLine.setHighlighted({
+                                        stroke: ORANGE,
+                                        "stroke-width": 3
+                                    });
+                                    secondLine.setHighlighted({
+                                        stroke: BLUE,
+                                        "stroke-width": 3
+                                    });
+                                    $(this).bind("vmouseout", function(event) {
+                                        firstLine.unsetHighlighted({
+                                            stroke: "black",
+                                            "stroke-width": 2
                                         });
                                         secondLine.unsetHighlighted({
                                             stroke: "black",
@@ -289,47 +283,42 @@
                                         });
                                     });
                                 });
-
+                                secondLine.unsetHighlighted({
+                                    stroke: "black",
+                                    "stroke-width": 2
+                                });
                             }
                         });
                     }
                 }
 
-                        for(var angle in graph.congruency.angles){
-                            for(var angle2 in graph.congruency.angles){
-                                $(function(){
-                                    var $statement = $("."+angle+"-"+angle2);
-                                    var firstAngle = graph.congruency.angles[angle];
-                                    var secondAngle = graph.congruency.angles[angle2];
+                for(var angle in graph.congruency.angles){
+                    for(var angle2 in graph.congruency.angles){
+                        $(function(){
+                            var $statement = $("."+angle+"-"+angle2);
+                            var firstAngle = graph.congruency.angles[angle];
+                            var secondAngle = graph.congruency.angles[angle2];
 
-                                    if($statement.length &gt; 0){
-                                        $statement.bind("vmouseover", function(event) {
-                                            var firstState = firstAngle.state;
-                                            var secondState = secondAngle.state;
-                                            var maxState = Math.max(firstState,secondState);
+                            if($statement.length &gt; 0){
+                                $statement.bind("vmouseover", function(event) {
+                                    var firstState = firstAngle.state;
+                                    var secondState = secondAngle.state;
+                                    var maxState = Math.max(firstState,secondState);
 
-                                            firstAngle.setHighlighted({
-                                                stroke: ORANGE,
-                                                "stroke-width": 3
-                                            });
-                                            secondAngle.setHighlighted({
-                                                stroke: BLUE,
-                                                "stroke-width": 3
-                                            });
-                                            firstAngle.setState(maxState &gt; 0 ? maxState : 1);
-                                            secondAngle.setState(maxState &gt; 0 ? maxState : 1);
-                                            $(this).bind("vmouseout", function(event) {
-                                                firstAngle.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                                secondAngle.unsetHighlighted({
-                                                    stroke: "black",
-                                                    "stroke-width": 2
-                                                });
-                                                firstAngle.setState(firstState);
-                                                secondAngle.setState(secondState);
-                                            });
+                                    firstAngle.setHighlighted({
+                                        stroke: ORANGE,
+                                        "stroke-width": 3
+                                    });
+                                    secondAngle.setHighlighted({
+                                        stroke: BLUE,
+                                        "stroke-width": 3
+                                    });
+                                    firstAngle.setState(maxState &gt; 0 ? maxState : 1);
+                                    secondAngle.setState(maxState &gt; 0 ? maxState : 1);
+                                    $(this).bind("vmouseout", function(event) {
+                                        firstAngle.unsetHighlighted({
+                                            stroke: "black",
+                                            "stroke-width": 2
                                         });
                                         secondAngle.unsetHighlighted({
                                             stroke: "black",

--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -47,7 +47,7 @@
             <var id="ED">DE</var>
 
 
-            <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,CD,DC,CE,EC,DE,ED]</var>
+            <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,BE,EB,CD,DC,CE,EC,DE,ED]</var>
 
             <var id="ang1">new Ang("D","A","C", null)</var>
             <var id="ang2">new Ang("C","A","B", null)</var>

--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -17,15 +17,32 @@
 <body>
     <div class="exercise">
         <div class="vars">
-            <var id="A">[-4,2]</var>
-            <var id="B">[4,2]</var>
-            <var id="C">[0,0]</var>
-            <var id="D">[-4,-2]</var>
-            <var id="E">[4,-2]</var>
-
-            <var id="POINTS">["A","B","C","D","E"]</var>
-
             <var id="AB">new Seg("A","B")</var>
+            <var id="BA">AB</var>
+            <var id="AC">new Seg("A","C")</var>
+            <var id="CA">AC</var>
+            <var id="AD">new Seg("A","D")</var>
+            <var id="DA">AD</var>
+            <var id="AF">new Seg("A","F")</var>
+            <var id="FA">AF</var>
+            <var id="BC">new Seg("B","C")</var>
+            <var id="CB">BC</var>
+            <var id="BD">new Seg("B","D")</var>
+            <var id="DB">BD</var>
+            <var id="BE">new Seg("B","E")</var>
+            <var id="EB">BE</var>
+            <var id="CE">new Seg("C","E")</var>
+            <var id="EC">CE</var>
+            <var id="CF">new Seg("C","F")</var>
+            <var id="FC">CF</var>
+            <var id="DE">new Seg("D","E")</var>
+            <var id="ED">DE</var>
+            <var id="DF">new Seg("D","F")</var>
+            <var id="FD">DF</var>
+            <var id="EF">new Seg("E","F")</var>
+            <var id="FE">EF</var>
+
+            <!-- <var id="AB">new Seg("A","B")</var>
             <var id="BA">AB</var>
             <var id="AC">new Seg("A","C")</var>
             <var id="CA">AC</var>
@@ -44,12 +61,12 @@
             <var id="CE">new Seg("C","E")</var>
             <var id="EC">CE</var>
             <var id="DE">new Seg("D","E")</var>
-            <var id="ED">DE</var>
+            <var id="ED">DE</var> -->
 
+            <!-- <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,BE,EB,CD,DC,CE,EC,DE,ED]</var> -->
+            <var id="SEGS">[AB,BA,AC,CA,AD,DA,AF,FA,BC,CB,BD,DB,BE,EB,CE,EC,CF,FC,DE,ED,DF,FD,EF,FE]</var>
 
-            <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,BE,EB,CD,DC,CE,EC,DE,ED]</var>
-
-            <var id="ang1">new Ang("D","A","C", null)</var>
+            <!-- <var id="ang1">new Ang("D","A","C", null)</var>
             <var id="ang2">new Ang("C","A","B", null)</var>
             <var id="ang3">new Ang("C","B","A", null)</var>
             <var id="ang4">new Ang("C","B","E", null)</var>
@@ -60,24 +77,44 @@
             <var id="ang9">new Ang("A","D","C", null)</var>
             <var id="ang10">new Ang("C","D","E", null)</var>
             <var id="ang11">new Ang("C","E","D", null)</var>
-            <var id="ang12">new Ang("C","E","B", null)</var>
+            <var id="ang12">new Ang("C","E","B", null)</var> -->
+            <var id="ang1">new Ang("B","A","C")</var>
+            <var id="ang2">new Ang("A","B","C")</var>
+            <var id="ang3">new Ang("A","C","B")</var>
+            <var id="ang4">new Ang("D","B","E")</var>
+            <var id="ang5">new Ang("E","B","C")</var>
+            <var id="ang6">new Ang("B","C","E")</var>
+            <var id="ang7">new Ang("E","C","F")</var>
+            <var id="ang8">new Ang("B","D","E")</var>
+            <var id="ang9">new Ang("B","E","D")</var>
+            <var id="ang10">new Ang("B","E","C")</var>
+            <var id="ang11">new Ang("C","E","F")</var>
+            <var id="ang12">new Ang("C","F","E")</var>
 
             <var id="ANGS">[ang1, ang2, ang3, ang4, ang5, ang6, ang7, ang8, ang9, ang10, ang11, ang12]</var>
 
-            <var id="SUPPLEMENTARY_ANGS">[addAngs(ang5, ang6), addAngs(ang6, ang8), addAngs(ang8, ang7), addAngs(ang7, ang5)]</var>
+            <!-- <var id="SUPPLEMENTARY_ANGS">[addAngs(ang5, ang6), addAngs(ang6, ang8), addAngs(ang8, ang7), addAngs(ang7, ang5)]</var> -->
+            <var id="SUPPLEMENTARY_ANGS">[addAngs(ang2, addAngs(ang5, ang4)), addAngs(ang3, addAngs(ang6, ang7)), addAngs(ang9, addAngs(ang10,ang11))]</var>
 
-            <var id="ALTERNATE_INTERIOR_ANGS">[[ang1, ang12], [ang2, ang11], [ang10, ang3], [ang9, ang4]]</var>
+            <!-- <var id="ALTERNATE_INTERIOR_ANGS">[[ang1, ang12], [ang2, ang11], [ang10, ang3], [ang9, ang4]]</var> -->
+            <var id="ALTERNATE_INTERIOR_ANGS">[[ang5, ang9], [ang6, ang11]]</var>
 
-            <var id="ABC">new Triang([AB, BC, CA], [ang3, ang5, ang2])</var>
+            <!-- <var id="ABC">new Triang([AB, BC, CA], [ang3, ang5, ang2])</var>
             <var id="BCE">new Triang([BC, CE, EB], [ang7, ang12, ang4])</var>
             <var id="ECD">new Triang([EC, CD, DE], [ang8, ang10, ang11])</var>
             <var id="DCA">new Triang([DC, CA, AD], [ang6, ang1, ang9])</var>
             <var id="ABE">new Triang([AB, BE, EA], [addAngs(ang3, ang4), ang12, ang2])</var>
             <var id="ADE">new Triang([AD, DE, EA], [addAngs(ang9, ang10), ang11, ang1])</var>
             <var id="BED">new Triang([BE, ED, DB], [addAngs(ang12, ang11), ang10, ang4])</var>
-            <var id="BAD">new Triang([BA, AD, DB], [addAngs(ang2, ang1), ang9, ang3])</var>
+            <var id="BAD">new Triang([BA, AD, DB], [addAngs(ang2, ang1), ang9, ang3])</var> -->
+            <var id="ABC">new Triang([AB, BC, CA], [ang2, ang3, ang1])</var>
+            <var id="BDE">new Triang([BD, DE, EB], [ang8, ang9, ang4])</var>
+            <var id="BCE">new Triang([BC, CE, EB], [ang6, ang10, ang5])</var>
+            <var id="CEF">new Triang([CE, EF, FC], [ang11, ang12, ang7])</var>
+            <var id="ADF">new Triang([AD, DF, FA], [ang8, ang12, ang1])</var>
 
-            <var id="TRIANGLES">[ABC, BCE, ECD, DCA, ABE, ADE, BED, BAD]</var>
+            <!-- <var id="TRIANGLES">[ABC, BCE, ECD, DCA, ABE, ADE, BED, BAD]</var> -->
+            <var id="TRIANGLES">[ABC, BDE, BCE, CEF]</var>
 
             <var id="STATEMENTS">initProof(SEGS, ANGS, TRIANGLES, SUPPLEMENTARY_ANGS, ALTERNATE_INTERIOR_ANGS, 3, 0.25, "all")</var>
             <var id="KNOWN">STATEMENTS[0]</var>
@@ -100,11 +137,12 @@
 
                 graph.congruency = addCongruency({ y1: -0.7, y2: 10.7 });
 
-                graph.congruency.addPoint("A", [-4, 4]);
-                graph.congruency.addPoint("B", [3, 4]);
-                graph.congruency.addPoint("C", [0, 0]);
-                graph.congruency.addPoint("D", [-3, -4]);
-                graph.congruency.addPoint("E", [4, -4]);
+                graph.congruency.addPoint("A", [0, 4]);
+                graph.congruency.addPoint("B", [-2, 0]);
+                graph.congruency.addPoint("C", [2, 0]);
+                graph.congruency.addPoint("D", [-4, -4]);
+                graph.congruency.addPoint("E", [0, -4]);
+                graph.congruency.addPoint("F", [4, -4]);
 
                 graph.congruency.addLine({
                     start: "A",
@@ -126,7 +164,7 @@
                 });
                 graph.congruency.addLine({
                     start: "A",
-                    end: "E",
+                    end: "F",
                     clickable: true,
                     maxState: 3
                 });
@@ -150,19 +188,31 @@
                 });
                 graph.congruency.addLine({
                     start: "C",
-                    end: "D",
-                    clickable: true,
-                    maxState: 3
-                });
-                graph.congruency.addLine({
-                    start: "E",
-                    end: "D",
+                    end: "E",
                     clickable: true,
                     maxState: 3
                 });
                 graph.congruency.addLine({
                     start: "C",
+                    end: "F",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "D",
                     end: "E",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "D",
+                    end: "F",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "E",
+                    end: "F",
                     clickable: true,
                     maxState: 3
                 });
@@ -172,15 +222,11 @@
                 graph.congruency.addAngles("C", { maxState: 3 });
                 graph.congruency.addAngles("D", { maxState: 3 });
                 graph.congruency.addAngles("E", { maxState: 3 });
+                graph.congruency.addAngles("F", { maxState: 3 });
 
-                graph.congruency.addAngle("DAC", { maxState: 3 });
-                graph.congruency.addAngle("CAB", { maxState: 3 });
-                graph.congruency.addAngle("ABC", { maxState: 3 });
-                graph.congruency.addAngle("CBE", { maxState: 3 });
-                graph.congruency.addAngle("BEC", { maxState: 3 });
-                graph.congruency.addAngle("CED", { maxState: 3 });
-                graph.congruency.addAngle("EDC", { maxState: 3 });
-                graph.congruency.addAngle("CDA", { maxState: 3 });
+                graph.congruency.addAngle("BAC", { maxState: 3 });
+                graph.congruency.addAngle("EDB", { maxState: 3 });
+                graph.congruency.addAngle("CFE", { maxState: 3 });
 
                 for(var angle in graph.congruency.angles){
                     graph.congruency.angles[angle].setSelectedStyle({
@@ -189,11 +235,13 @@
                     });
                 }
 
-                graph.congruency.addLabel("A", "left");
-                graph.congruency.addLabel("B", "right");
+                graph.congruency.addLabel("A", "above");
+                graph.congruency.addLabel("B", "left");
                 graph.congruency.addLabel("C", "right");
-                graph.congruency.addLabel("D", "left");
-                graph.congruency.addLabel("E", "right");
+                graph.congruency.addLabel("D", "below");
+                graph.congruency.addLabel("E", "below");
+                graph.congruency.addLabel("F", "below");
+
 
                 var hintsLeft = FILL_BLANKS_NUM*2;
                 $(".missingStatement").keyup(function(){

--- a/exercises/geometry_proofs_1.html
+++ b/exercises/geometry_proofs_1.html
@@ -397,12 +397,12 @@
                 <div class="instruction">
                     Fill in the blanks in this proof that <var> FINISHED </var>.
                 </div>
-                <div class="guess">[outputKnownProof()]</div>
+                <div class="guess">1</div>
                 <div class="validator-function">
                     return FILL_BLANKS_NUM==0;
                 </div>
                 <div class="show-guess">
-
+                    return outputKnownProof();
                 </div>
             </div>
             <div class="hints">

--- a/exercises/geometry_proofs_2.html
+++ b/exercises/geometry_proofs_2.html
@@ -415,7 +415,7 @@
                     <var id="ED">DE</var>
                     
 
-                   <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,CD,DC,CE,EC,DE,ED]</var>
+                   <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,BE,EB,CD,DC,CE,EC,DE,ED]</var>
 
                     <var id="ang1">new Ang("D","A","C", null)</var>
                     <var id="ang2">new Ang("C","A","B", null)</var>

--- a/exercises/geometry_proofs_2.html
+++ b/exercises/geometry_proofs_2.html
@@ -633,111 +633,50 @@
                             }
                         }
 
-                        for(var i=0; i&lt;(TRIANGLES.length); i++){
-                            for(var j=0; j&lt;(TRIANGLES.length); j++){
-                                for(var k=0; k&lt;3; k++){
-                                    $(function(){
-                                        var triangle = TRIANGLES[i];
-                                        var triangle2 = TRIANGLES[j];
+                        for(var line in graph.congruency.lines){
+                            $(function(){
+                                var $statements = $("."+line);
+                                for(var i = 0; i&lt;$statements.length; i++){
+                                    var highlightLine = graph.congruency.lines[line];
+                                    var highlightDiv = $($statements[i]);
 
-                                        var seg1_1 = triangle.segs[k].toString().substring(3,5);
-                                        var seg1_2 = triangle.segs[(k+1) % 3].toString().substring(3,5);
-                                        var seg1_3 = triangle.segs[(k+2) % 3].toString().substring(3,5);
-
-                                        var seg2_1 = triangle2.segs[k].toString().substring(3,5);
-                                        var seg2_2 = triangle2.segs[(k+1) % 3].toString().substring(3,5);
-                                        var seg2_3 = triangle2.segs[(k+2) % 3].toString().substring(3,5);
-
-                                        var triangleSegs = [seg1_1, seg1_2, seg1_3];
-                                        var triangle2Segs = [seg2_1, seg2_2, seg2_3];
-                                        var sharedSeg = [-1, -1];
-
-                                        for(var l=0; l&lt;3; l++){
-                                            for(var m=0; m&lt;3; m++){
-                                                if(triangleSegs[l] === triangle2Segs[m]){
-                                                    sharedSeg = [l,m];
-                                                }
-                                            }
-                                        }
-
-
-                                        var $statement = $("."+seg1_1+"-"+seg1_2+"-"+seg1_3+"-"+seg2_1+"-"+seg2_2+"-"+seg2_3);
-
-                                        var line1_1 = graph.congruency.lines[seg1_1];
-                                        var line1_2 = graph.congruency.lines[seg1_2];
-                                        var line1_3 = graph.congruency.lines[seg1_3];
-
-                                        var line2_1 = graph.congruency.lines[seg2_1];
-                                        var line2_2 = graph.congruency.lines[seg2_2];
-                                        var line2_3 = graph.congruency.lines[seg2_3];
-
-                                        var triangleLines = [line1_1, line1_2, line1_3];
-                                        var triangle2Lines = [line2_1, line2_2, line2_3];
-
-                                        if($statement.length &gt; 0){
-                                            $statement.bind("vmouseover", function(event) {
-                                                for(var l=0; l&lt;3; l++){
-                                                    if(sharedSeg[0] != l){
-                                                        triangleLines[l].setUnselectedStyle({
-                                                            stroke: ORANGE,
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                    else{
-                                                        triangleLines[l].setUnselectedStyle({
-                                                            stroke: "black",
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                }
-
-                                                for(var l=0; l&lt;3; l++){
-                                                    if(sharedSeg[1] != l){
-                                                        triangle2Lines[l].setUnselectedStyle({
-                                                            stroke: BLUE,
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                    else{
-                                                        triangle2Lines[l].setUnselectedStyle({
-                                                            stroke: "black",
-                                                            "stroke-width": 3
-                                                        });
-                                                    }
-                                                }
-
-                                                $(this).bind("vmouseout", function(event) {
-                                                    line1_1.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line1_2.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line1_3.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-
-                                                    line2_1.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line2_2.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                    line2_3.setUnselectedStyle({
-                                                        stroke: "black",
-                                                        "stroke-width": 2
-                                                    });
-                                                });
+                                    highlightDiv.bind("vmouseover", function(event) {
+                                        highlightLine.setHighlighted({
+                                            stroke: ORANGE,
+                                            "stroke-width": 3
+                                        });
+                                        $(this).bind("vmouseout", function(event) {
+                                            highlightLine.unsetHighlighted({
+                                                stroke: "black",
+                                                "stroke-width": 2
                                             });
-                                        }
+                                        });
                                     });
                                 }
-                            }
+                            });
+                        }
+
+                        for(var line in graph.congruency.lines){
+                            $(function(){
+                                var $statements = $("."+line + "2");
+                                for(var i = 0; i&lt;$statements.length; i++){
+                                    var highlightLine = graph.congruency.lines[line];
+                                    var highlightDiv = $($statements[i]);
+
+                                    highlightDiv.bind("vmouseover", function(event) {
+                                        highlightLine.setHighlighted({
+                                            stroke: BLUE,
+                                            "stroke-width": 3
+                                        });
+                                        $(this).bind("vmouseout", function(event) {
+                                            highlightLine.unsetHighlighted({
+                                                stroke: "black",
+                                                "stroke-width": 2
+                                            });
+                                        });
+                                    });
+                                }
+                            });
                         }
                     </div>
                 </div>

--- a/exercises/geometry_proofs_2.html
+++ b/exercises/geometry_proofs_2.html
@@ -391,7 +391,7 @@
                     <p data-else>There is no wrong statement in this proof.</p>
                 </div>
             </div> -->
-            <div id="parallelogram">
+            <div id="triforce">
                 <div class="vars">
                     <var id="AB">new Seg("A","B")</var>
                     <var id="BA">AB</var>
@@ -399,53 +399,53 @@
                     <var id="CA">AC</var>
                     <var id="AD">new Seg("A","D")</var>
                     <var id="DA">AD</var>
-                    <var id="AE">new Seg("A","E")</var>
-                    <var id="EA">AE</var>
+                    <var id="AF">new Seg("A","F")</var>
+                    <var id="FA">AF</var>
                     <var id="BC">new Seg("B","C")</var>
                     <var id="CB">BC</var>
                     <var id="BD">new Seg("B","D")</var>
                     <var id="DB">BD</var>
                     <var id="BE">new Seg("B","E")</var>
                     <var id="EB">BE</var>
-                    <var id="CD">new Seg("C","D")</var>
-                    <var id="DC">CD</var>
                     <var id="CE">new Seg("C","E")</var>
                     <var id="EC">CE</var>
+                    <var id="CF">new Seg("C","F")</var>
+                    <var id="FC">CF</var>
                     <var id="DE">new Seg("D","E")</var>
                     <var id="ED">DE</var>
-                    
+                    <var id="DF">new Seg("D","F")</var>
+                    <var id="FD">DF</var>
+                    <var id="EF">new Seg("E","F")</var>
+                    <var id="FE">EF</var>
 
-                   <var id="SEGS">[AB,BA,AC,CA,AD,DA,AE,EA,BC,CB,BD,DB,BE,EB,CD,DC,CE,EC,DE,ED]</var>
+                    <var id="SEGS">[AB,BA,AC,CA,AD,DA,AF,FA,BC,CB,BD,DB,BE,EB,CE,EC,CF,FC,DE,ED,DF,FD,EF,FE]</var>
 
-                    <var id="ang1">new Ang("D","A","C", null)</var>
-                    <var id="ang2">new Ang("C","A","B", null)</var>
-                    <var id="ang3">new Ang("C","B","A", null)</var>
-                    <var id="ang4">new Ang("C","B","E", null)</var>
-                    <var id="ang5">new Ang("A","C","B", null)</var>
-                    <var id="ang6">new Ang("A","C","D", null)</var>
-                    <var id="ang7">new Ang("B","C","E", null)</var>
-                    <var id="ang8">new Ang("D","C","E", null)</var>
-                    <var id="ang9">new Ang("A","D","C", null)</var>
-                    <var id="ang10">new Ang("C","D","E", null)</var>
-                    <var id="ang11">new Ang("C","E","D", null)</var>
-                    <var id="ang12">new Ang("C","E","B", null)</var>
+                    <var id="ang1">new Ang("B","A","C")</var>
+                    <var id="ang2">new Ang("A","B","C")</var>
+                    <var id="ang3">new Ang("A","C","B")</var>
+                    <var id="ang4">new Ang("D","B","E")</var>
+                    <var id="ang5">new Ang("E","B","C")</var>
+                    <var id="ang6">new Ang("B","C","E")</var>
+                    <var id="ang7">new Ang("E","C","F")</var>
+                    <var id="ang8">new Ang("B","D","E")</var>
+                    <var id="ang9">new Ang("B","E","D")</var>
+                    <var id="ang10">new Ang("B","E","C")</var>
+                    <var id="ang11">new Ang("C","E","F")</var>
+                    <var id="ang12">new Ang("C","F","E")</var>
 
                     <var id="ANGS">[ang1, ang2, ang3, ang4, ang5, ang6, ang7, ang8, ang9, ang10, ang11, ang12]</var>
 
-                    <var id="SUPPLEMENTARY_ANGS">[addAngs(ang5, ang6), addAngs(ang6, ang8), addAngs(ang8, ang7), addAngs(ang7, ang5)]</var>
+                    <var id="SUPPLEMENTARY_ANGS">[addAngs(ang2, addAngs(ang5, ang4)), addAngs(ang3, addAngs(ang6, ang7)), addAngs(ang9, addAngs(ang10,ang11))]</var>
 
-                    <var id="ALTERNATE_INTERIOR_ANGS">[[ang1, ang12], [ang2, ang11], [ang10, ang3], [ang9, ang4]]</var>
+                    <var id="ALTERNATE_INTERIOR_ANGS">[[ang5, ang9], [ang6, ang11]]</var>
 
-                    <var id="ABC">new Triang([AB, BC, CA], [ang3, ang5, ang2])</var>
-                    <var id="BCE">new Triang([BC, CE, EB], [ang7, ang12, ang4])</var>
-                    <var id="ECD">new Triang([EC, CD, DE], [ang8, ang10, ang11])</var>
-                    <var id="DCA">new Triang([DC, CA, AD], [ang6, ang1, ang9])</var>
-                    <var id="ABE">new Triang([AB, BE, EA], [addAngs(ang3, ang4), ang12, ang2])</var>
-                    <var id="ADE">new Triang([AD, DE, EA], [addAngs(ang9, ang10), ang11, ang1])</var>
-                    <var id="BED">new Triang([BE, ED, DB], [addAngs(ang12, ang11), ang10, ang4])</var>
-                    <var id="BAD">new Triang([BA, AD, DB], [addAngs(ang2, ang1), ang9, ang3])</var>
+                    <var id="ABC">new Triang([AB, BC, CA], [ang2, ang3, ang1])</var>
+                    <var id="BDE">new Triang([BD, DE, EB], [ang8, ang9, ang4])</var>
+                    <var id="BCE">new Triang([BC, CE, EB], [ang6, ang10, ang5])</var>
+                    <var id="CEF">new Triang([CE, EF, FC], [ang11, ang12, ang7])</var>
+                    <var id="ADF">new Triang([AD, DF, FA], [ang8, ang12, ang1])</var>
 
-                    <var id="TRIANGLES">[ABC, BCE, ECD, DCA, ABE, ADE, BED, BAD]</var>
+                    <var id="TRIANGLES">[ABC, BDE, BCE, CEF]</var>
 
                     <var id="STATEMENTS">initProof(SEGS, ANGS, TRIANGLES, SUPPLEMENTARY_ANGS, ALTERNATE_INTERIOR_ANGS, 3, 0.25, "all")</var>
                     <var id="KNOWN">STATEMENTS[0]</var>
@@ -464,7 +464,7 @@
 
                 <div class="problem">
                     <p class="question">What's the first wrong statement in the proof below that <var>FINISHED</var><code> \; ?</code></br></br>
-                    <code> \overline{AB} </code> is parallel to <code> \overline{DE} </code>, and <code> \overline{AD} </code> is parallel to <code> \overline{BE} </code>. This diagram is not drawn to scale.</p>
+                    <code> \overline{BC} </code> is parallel to <code> \overline{DF} </code>. This diagram is not drawn to scale.</p>
                     <div class="graphie">
                         init({
                             range: [[-5, 5], [-5, 5]],
@@ -474,210 +474,227 @@
 
                         graph.congruency = addCongruency({ y1: -0.7, y2: 10.7 });
 
-                        graph.congruency.addPoint("A", [-4, 4]);
-                        graph.congruency.addPoint("B", [3, 4]);
-                        graph.congruency.addPoint("C", [0, 0]);
-                        graph.congruency.addPoint("D", [-3, -4]);
-                        graph.congruency.addPoint("E", [4, -4]);
+                        graph.congruency.addPoint("A", [0, 4]);
+                graph.congruency.addPoint("B", [-2, 0]);
+                graph.congruency.addPoint("C", [2, 0]);
+                graph.congruency.addPoint("D", [-4, -4]);
+                graph.congruency.addPoint("E", [0, -4]);
+                graph.congruency.addPoint("F", [4, -4]);
 
-                        graph.congruency.addLine({
-                            start: "A",
-                            end: "B",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "A",
-                            end: "C",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "A",
-                            end: "D",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "A",
-                            end: "E",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "B",
-                            end: "C",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "B",
-                            end: "D",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "E",
-                            end: "B",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "E",
-                            end: "D",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "C",
-                            end: "D",
-                            clickable: true,
-                            maxState: 3
-                        });
-                        graph.congruency.addLine({
-                            start: "C",
-                            end: "E",
-                            clickable: true,
-                            maxState: 3
-                        });
+                graph.congruency.addLine({
+                    start: "A",
+                    end: "B",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "A",
+                    end: "C",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "A",
+                    end: "D",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "A",
+                    end: "F",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "B",
+                    end: "C",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "B",
+                    end: "D",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "B",
+                    end: "E",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "C",
+                    end: "E",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "C",
+                    end: "F",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "D",
+                    end: "E",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "D",
+                    end: "F",
+                    clickable: true,
+                    maxState: 3
+                });
+                graph.congruency.addLine({
+                    start: "E",
+                    end: "F",
+                    clickable: true,
+                    maxState: 3
+                });
 
-                        graph.congruency.addAngles("A", { maxState: 3 });
-                        graph.congruency.addAngles("B", { maxState: 3 });
-                        graph.congruency.addAngles("C", { maxState: 3 });
-                        graph.congruency.addAngles("D", { maxState: 3 });
-                        graph.congruency.addAngles("E", { maxState: 3 });
+                graph.congruency.addAngles("A", { maxState: 3 });
+                graph.congruency.addAngles("B", { maxState: 3 });
+                graph.congruency.addAngles("C", { maxState: 3 });
+                graph.congruency.addAngles("D", { maxState: 3 });
+                graph.congruency.addAngles("E", { maxState: 3 });
+                graph.congruency.addAngles("F", { maxState: 3 });
 
-                        graph.congruency.addAngle("DAC", { maxState: 3 });
-                        graph.congruency.addAngle("CAB", { maxState: 3 });
-                        graph.congruency.addAngle("ABC", { maxState: 3 });
-                        graph.congruency.addAngle("CBE", { maxState: 3 });
-                        graph.congruency.addAngle("BEC", { maxState: 3 });
-                        graph.congruency.addAngle("CED", { maxState: 3 });
-                        graph.congruency.addAngle("EDC", { maxState: 3 });
-                        graph.congruency.addAngle("CDA", { maxState: 3 });
+                graph.congruency.addAngle("BAC", { maxState: 3 });
+                graph.congruency.addAngle("EDB", { maxState: 3 });
+                graph.congruency.addAngle("CFE", { maxState: 3 });
 
-                        graph.congruency.addLabel("A", "left");
-                        graph.congruency.addLabel("B", "right");
-                        graph.congruency.addLabel("C", "right");
-                        graph.congruency.addLabel("D", "left");
-                        graph.congruency.addLabel("E", "right");
+                for(var angle in graph.congruency.angles){
+                    graph.congruency.angles[angle].setSelectedStyle({
+                        stroke: "black",
+                        "stroke-width": 3
+                    });
+                }
 
-                        for(var angle in graph.congruency.angles){
-                            graph.congruency.angles[angle].setSelectedStyle({
-                                stroke: "black",
-                                "stroke-width": 3
-                            });
-                        }
+                graph.congruency.addLabel("A", "above");
+                graph.congruency.addLabel("B", "left");
+                graph.congruency.addLabel("C", "right");
+                graph.congruency.addLabel("D", "below");
+                graph.congruency.addLabel("E", "below");
+                graph.congruency.addLabel("F", "below");
 
-                        for(var line in graph.congruency.lines){
-                            for(var line2 in graph.congruency.lines){
+                for(var angle in graph.congruency.angles){
+                    graph.congruency.angles[angle].setSelectedStyle({
+                        stroke: "black",
+                        "stroke-width": 3
+                    });
+                }
 
-                                $(function(){
-                                    var $statement = $("."+line+"-"+line2);
-                                    var firstLine = graph.congruency.lines[line];
-                                    var secondLine = graph.congruency.lines[line2];
+                for(var line in graph.congruency.lines){
+                    for(var line2 in graph.congruency.lines){
 
-                                    if($statement.length &gt; 0){
-                                        $statement.bind("vmouseover", function(event) {
-                                            firstLine.setHighlighted({
-                                                stroke: ORANGE,
-                                                "stroke-width": 3
-                                            });
-                                            secondLine.setHighlighted({
-                                                stroke: BLUE,
-                                                "stroke-width": 3
-                                            });
-                                            $(this).bind("vmouseout", function(event) {
-                                                firstLine.unsetHighlighted();
-                                                secondLine.unsetHighlighted();
-                                            });
-                                        });
+                        $(function(){
+                            var $statement = $("."+line+"-"+line2);
+                            var firstLine = graph.congruency.lines[line];
+                            var secondLine = graph.congruency.lines[line2];
 
-                                    }
+                            if($statement.length &gt; 0){
+                                $statement.bind("vmouseover", function(event) {
+                                    firstLine.setHighlighted({
+                                        stroke: ORANGE,
+                                        "stroke-width": 3
+                                    });
+                                    secondLine.setHighlighted({
+                                        stroke: BLUE,
+                                        "stroke-width": 3
+                                    });
+                                    $(this).bind("vmouseout", function(event) {
+                                        firstLine.unsetHighlighted();
+                                        secondLine.unsetHighlighted();
+                                    });
+                                });
+
+                            }
+                        });
+                    }
+                }
+
+                for(var angle in graph.congruency.angles){
+                    for(var angle2 in graph.congruency.angles){
+                        $(function(){
+                            var $statement = $("."+angle+"-"+angle2);
+                            var firstAngle = graph.congruency.angles[angle];
+                            var secondAngle = graph.congruency.angles[angle2];
+
+                            if($statement.length &gt; 0){
+                                $statement.bind("vmouseover", function(event) {
+                                    var firstState = firstAngle.state;
+                                    var secondState = secondAngle.state;
+                                    var maxState = Math.max(firstState,secondState);
+
+                                    firstAngle.setHighlighted({
+                                        stroke: ORANGE,
+                                        "stroke-width": 3
+                                    });
+                                    secondAngle.setHighlighted({
+                                        stroke: BLUE,
+                                        "stroke-width": 3
+                                    });
+                                    firstAngle.setState(maxState &gt; 0 ? maxState : 1);
+                                    secondAngle.setState(maxState &gt; 0 ? maxState : 1);
+                                    $(this).bind("vmouseout", function(event) {
+                                        firstAngle.unsetHighlighted();
+                                        secondAngle.unsetHighlighted();
+                                        firstAngle.setState(firstState);
+                                        secondAngle.setState(secondState);
+                                    });
                                 });
                             }
-                        }
+                        });
+                    }
+                }
 
-                        for(var angle in graph.congruency.angles){
-                            for(var angle2 in graph.congruency.angles){
-                                $(function(){
-                                    var $statement = $("."+angle+"-"+angle2);
-                                    var firstAngle = graph.congruency.angles[angle];
-                                    var secondAngle = graph.congruency.angles[angle2];
+                for(var line in graph.congruency.lines){
+                    $(function(){
+                        var $statements = $("."+line);
+                        for(var i = 0; i&lt;$statements.length; i++){
+                            var highlightLine = graph.congruency.lines[line];
+                            var highlightDiv = $($statements[i]);
 
-                                    if($statement.length &gt; 0){
-                                        $statement.bind("vmouseover", function(event) {
-                                            var firstState = firstAngle.state;
-                                            var secondState = secondAngle.state;
-                                            var maxState = Math.max(firstState,secondState);
-
-                                            firstAngle.setHighlighted({
-                                                stroke: ORANGE,
-                                                "stroke-width": 3
-                                            });
-                                            secondAngle.setHighlighted({
-                                                stroke: BLUE,
-                                                "stroke-width": 3
-                                            });
-                                            firstAngle.setState(maxState &gt; 0 ? maxState : 1);
-                                            secondAngle.setState(maxState &gt; 0 ? maxState : 1);
-                                            $(this).bind("vmouseout", function(event) {
-                                                firstAngle.unsetHighlighted();
-                                                secondAngle.unsetHighlighted();
-                                                firstAngle.setState(firstState);
-                                                secondAngle.setState(secondState);
-                                            });
-                                        });
-                                    }
+                            highlightDiv.bind("vmouseover", function(event) {
+                                highlightLine.setHighlighted({
+                                    stroke: ORANGE,
+                                    "stroke-width": 3
                                 });
-                            }
-                        }
-
-                        for(var line in graph.congruency.lines){
-                            $(function(){
-                                var $statements = $("."+line);
-                                for(var i = 0; i&lt;$statements.length; i++){
-                                    var highlightLine = graph.congruency.lines[line];
-                                    var highlightDiv = $($statements[i]);
-
-                                    highlightDiv.bind("vmouseover", function(event) {
-                                        highlightLine.setHighlighted({
-                                            stroke: ORANGE,
-                                            "stroke-width": 3
-                                        });
-                                        $(this).bind("vmouseout", function(event) {
-                                            highlightLine.unsetHighlighted({
-                                                stroke: "black",
-                                                "stroke-width": 2
-                                            });
-                                        });
+                                $(this).bind("vmouseout", function(event) {
+                                    highlightLine.unsetHighlighted({
+                                        stroke: "black",
+                                        "stroke-width": 2
                                     });
-                                }
+                                });
                             });
                         }
+                    });
+                }
 
-                        for(var line in graph.congruency.lines){
-                            $(function(){
-                                var $statements = $("."+line + "2");
-                                for(var i = 0; i&lt;$statements.length; i++){
-                                    var highlightLine = graph.congruency.lines[line];
-                                    var highlightDiv = $($statements[i]);
+                for(var line in graph.congruency.lines){
+                    $(function(){
+                        var $statements = $("."+line + "2");
+                        for(var i = 0; i&lt;$statements.length; i++){
+                            var highlightLine = graph.congruency.lines[line];
+                            var highlightDiv = $($statements[i]);
 
-                                    highlightDiv.bind("vmouseover", function(event) {
-                                        highlightLine.setHighlighted({
-                                            stroke: BLUE,
-                                            "stroke-width": 3
-                                        });
-                                        $(this).bind("vmouseout", function(event) {
-                                            highlightLine.unsetHighlighted({
-                                                stroke: "black",
-                                                "stroke-width": 2
-                                            });
-                                        });
+                            highlightDiv.bind("vmouseover", function(event) {
+                                highlightLine.setHighlighted({
+                                    stroke: BLUE,
+                                    "stroke-width": 3
+                                });
+                                $(this).bind("vmouseout", function(event) {
+                                    highlightLine.unsetHighlighted({
+                                        stroke: "black",
+                                        "stroke-width": 2
                                     });
-                                }
+                                });
                             });
                         }
+                    });
+                }
                     </div>
                 </div>
 

--- a/exercises/geometry_proofs_2.html
+++ b/exercises/geometry_proofs_2.html
@@ -589,13 +589,13 @@
                 for(var line in graph.congruency.lines){
                     for(var line2 in graph.congruency.lines){
 
-                        $(function(){
+                        (function(){
                             var $statement = $("."+line+"-"+line2);
                             var firstLine = graph.congruency.lines[line];
                             var secondLine = graph.congruency.lines[line2];
 
                             if($statement.length &gt; 0){
-                                $statement.bind("vmouseover", function(event) {
+                                $statement.live("vmouseover", function(event) {
                                     firstLine.setHighlighted({
                                         stroke: ORANGE,
                                         "stroke-width": 3
@@ -611,19 +611,19 @@
                                 });
 
                             }
-                        });
+                        })();
                     }
                 }
 
                 for(var angle in graph.congruency.angles){
                     for(var angle2 in graph.congruency.angles){
-                        $(function(){
+                        (function(){
                             var $statement = $("."+angle+"-"+angle2);
                             var firstAngle = graph.congruency.angles[angle];
                             var secondAngle = graph.congruency.angles[angle2];
 
                             if($statement.length &gt; 0){
-                                $statement.bind("vmouseover", function(event) {
+                                $statement.live("vmouseover", function(event) {
                                     var firstState = firstAngle.state;
                                     var secondState = secondAngle.state;
                                     var maxState = Math.max(firstState,secondState);
@@ -646,18 +646,18 @@
                                     });
                                 });
                             }
-                        });
+                        })();
                     }
                 }
 
                 for(var line in graph.congruency.lines){
-                    $(function(){
+                    (function(){
                         var $statements = $("."+line);
                         for(var i = 0; i&lt;$statements.length; i++){
                             var highlightLine = graph.congruency.lines[line];
                             var highlightDiv = $($statements[i]);
 
-                            highlightDiv.bind("vmouseover", function(event) {
+                            highlightDiv.live("vmouseover", function(event) {
                                 highlightLine.setHighlighted({
                                     stroke: ORANGE,
                                     "stroke-width": 3
@@ -670,17 +670,17 @@
                                 });
                             });
                         }
-                    });
+                    })();
                 }
 
                 for(var line in graph.congruency.lines){
-                    $(function(){
+                    (function(){
                         var $statements = $("."+line + "2");
                         for(var i = 0; i&lt;$statements.length; i++){
                             var highlightLine = graph.congruency.lines[line];
                             var highlightDiv = $($statements[i]);
 
-                            highlightDiv.bind("vmouseover", function(event) {
+                            highlightDiv.live("vmouseover", function(event) {
                                 highlightLine.setHighlighted({
                                     stroke: BLUE,
                                     "stroke-width": 3
@@ -693,7 +693,7 @@
                                 });
                             });
                         }
-                    });
+                    })();
                 }
                     </div>
                 </div>

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -160,17 +160,19 @@
                                 return;
                             }
 
-                            var verifyTriangles = verifyStatementArgs(thing1+"="+thing2, reason, "triangle congruence");
-                            var verifyAngles = verifyStatementArgs(thing1+"="+thing2, reason, "angle equality");
-                            var verifySegments = verifyStatementArgs(thing1+"="+thing2, reason, "segment equality");
+                            var verifyTriangles = thing1.length === 3 && thing2.length === 3 ? verifyStatementArgs(thing1+"="+thing2, reason, "triangle congruence") : false;
+                            var verifyAngles = thing1.length === 3 && thing2.length === 3 ? verifyStatementArgs(thing1+"="+thing2, reason, "angle equality") : false;
+                            var verifySegments = thing1.length === 2 && thing2.length === 2 ? verifyStatementArgs(thing1+"="+thing2, reason, "segment equality") : false;
 
                             if(verifyTriangles === true || verifyAngles === true || verifySegments === true){
                                 $(".statements").html(outputKnownProof());
                                 _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
-                                console.log("thinks statement is true");
+                                console.log("thinks statement is true " + reason);
                                 $("#thing1").val("");
                                 $("#thing2").val("");
                                 $("#reason").val("");
+                                $("#symbol1").html("");
+                                $("#symbol2").html("");
                                 if(userProofDone === true){
                                     $(".nextStatement").hide();
                                     $("#hint").attr("disabled", true);
@@ -193,8 +195,16 @@
                                 $("#symbol1").html(" \\triangle ");
                                 $("#symbol2").html(" \\triangle ");
                             }
-                            $("#symbol1").html(" \\angle ");
+                            else if(curVal === "vertical angles" || curVal === "alternate angles"){
+                                $("#symbol1").html(" \\angle ");
+                                $("#symbol2").html(" \\angle ");
+                            }
+                            else{
+                                $("#symbol1").html("");
+                                $("#symbol2").html("");
+                            }
                             $.tmpl.type.code()($("#symbol1")[0]);
+                            $.tmpl.type.code()($("#symbol2")[0]);
                             $(".nextStatement input").keyup(); 
                         });
 
@@ -239,12 +249,12 @@
                     <div class="instruction">
                         When you enter the next statement in the proof, and a valid reason, that statement will be added to the proof. When you're done, hit check answer.
                     </div>
-                    <div class="guess">[knownEqualities]</div>
+                    <div class="guess">1</div>
                     <div class="validator-function">
                         return isProofDone();
                     </div>
                     <div class="show-guess">
-                        
+                        return knownEqualities;
                     </div>
                 </div>
                 <div class="hints">

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -250,7 +250,7 @@
 
                 <p class="statements"> <var> outputKnownProof() </var></p>
                 <p class="nextStatement">
-                    <code id="symbol1"></code> <input type="text" id="thing1"></input> <code> \cong </code> <code id="symbol2"></code> <input type="text" id="thing2" > </input> because 
+                    <input type="text" id="thing1"></input> <code> \cong </code> <input type="text" id="thing2" > </input> because 
                     <select id="reason">
                         <option value="">select a reason</option>
                         <option value="SSS">side-side-side congruence</option>
@@ -519,7 +519,7 @@
                 
                 <p class="statements"> <var> outputKnownProof() </var></p>
                 <p class="nextStatement">
-                    <code id="symbol1"></code> <input type="text" id="thing1"></input> <code> \cong </code> <code id="symbol2"></code> <input type="text" id="thing2" > </input> because 
+                    <input type="text" id="thing1"></input> <code> \cong </code> <input type="text" id="thing2" > </input> because 
                     <select id="reason">
                         <option value="">select a reason</option>
                         <option value="SSS">side-side-side congruence</option>
@@ -795,7 +795,7 @@
 
                 <p class="statements"> <var> outputKnownProof() </var></p>
                 <p class="nextStatement">
-                    <code id="symbol1"></code> <input type="text" id="thing1"></input> <code> \cong </code> <code id="symbol2"></code> <input type="text" id="thing2" > </input> because 
+                    <input type="text" id="thing1"></input> <code> \cong </code> <input type="text" id="thing2" > </input> because 
                     <select id="reason">
                         <option value="">select a reason</option>
                         <option value="SSS">side-side-side congruence</option>

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -148,30 +148,53 @@
                         $(".hint2").hide();
                         $(".hint3").hide();
 
-                        var hint = "you haven't entered anything!";
+                        var hint = nextStatementHint();
 
                         $(".nextStatement input").keyup(function(){
-                            var triangles = [];
-                            triangles[0] = $("#thing1").val();
-                            triangles[1] = $("#thing2").val();
+                            var thing1 = $("#thing1").val().toUpperCase();
+                            var thing2 = $("#thing2").val().toUpperCase();
                             var reason = $("#reason").val();
 
-                            var verify = verifyStatementArgs(triangles[0]+"="+triangles[1], reason, "triangle congruence");
-                            if(verify.length > 0){
-                                hint = verify;
+                            if(thing1.length === 0 && thing2.length === 0){
+                                hint = nextStatementHint();
+                                return;
                             }
-                            else if(!verify){
-                                hint = "you've put in triangles that are in the figure, but your reason isn't right.";
-                            }
-                            else{
-                                hint = "you've already finished! Hit the check answer button."
+
+                            var verifyTriangles = verifyStatementArgs(thing1+"="+thing2, reason, "triangle congruence");
+                            var verifyAngles = verifyStatementArgs(thing1+"="+thing2, reason, "angle equality");
+                            var verifySegments = verifyStatementArgs(thing1+"="+thing2, reason, "segment equality");
+
+                            if(verifyTriangles === true || verifyAngles === true || verifySegments === true){
                                 $(".statements").html(outputKnownProof());
                                 _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
-                                $(".nextStatement").hide();
+                                console.log("thinks statement is true");
+                                $("#thing1").val("");
+                                $("#thing2").val("");
+                                $("#reason").val("");
+                                if(userProofDone === true){
+                                    $(".nextStatement").hide();
+                                    $("#hint").attr("disabled", true);
+                                }
+                                else{
+                                    hint = nextStatementHint();
+                                }
+                            }
+                            else if(verifyTriangles === false || verifyAngles === false || verifySegments === false){
+                                hint = nextStatementHint();
+                            }
+                            else{
+                                hint = "The things you've entered aren't valid segments, angles, or triangles in the figure.";
                             }
                             console.log(hint);
                         });
                         $("#reason").change(function(){ 
+                            var curVal = $("#reason").val();
+                            if(curVal === "SSS" || curVal === "ASA" || curVal === "SAS" || curVal === "AAS"){
+                                $("#symbol1").html(" \\triangle ");
+                                $("#symbol2").html(" \\triangle ");
+                            }
+                            $("#symbol1").html(" \\angle ");
+                            $.tmpl.type.code()($("#symbol1")[0]);
                             $(".nextStatement input").keyup(); 
                         });
 
@@ -195,13 +218,16 @@
 
                 <p class="statements"> <var> outputKnownProof() </var></p>
                 <p class="nextStatement">
-                    <code> \bigtriangleup </code> <input type="text" id="thing1"></input> <code> =  \bigtriangleup </code> <input type="text" id="thing2" > </input> because 
+                    <code id="symbol1"></code> <input type="text" id="thing1"></input> <code> \cong </code> <code id="symbol2"></code> <input type="text" id="thing2" > </input> because 
                     <select id="reason">
                         <option value="">select a reason</option>
                         <option value="SSS">side-side-side congruence</option>
                         <option value="ASA">angle-side-angle congruence</option>
                         <option value="SAS">side-angle-side congruence</option>
                         <option value="AAS">angle-angle-side congruence</option>
+                        <option value="vertical angles">vertical angles are equal</option>
+                        <option value="alternate angles">alternate interior angles are equal</option>
+                        <option value="CPCTC">corresp. parts of congruent triangles are congruent</option>
                     </select>
                 </p>
                 <div class="customHints">

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -148,7 +148,9 @@
                         $(".hint2").hide();
                         $(".hint3").hide();
 
-                        var hint = nextStatementHint();
+                        var hintCategory = "good format but wrong";
+                        var hintsLeft = 2;
+                        var giveAway = false;
 
                         $(".nextStatement input").keyup(function(){
                             var thing1 = $("#thing1").val().toUpperCase();
@@ -156,7 +158,7 @@
                             var reason = $("#reason").val();
 
                             if(thing1.length === 0 && thing2.length === 0){
-                                hint = nextStatementHint();
+                                hintCategory = "good format but wrong";
                                 return;
                             }
 
@@ -178,19 +180,23 @@
                                     $("#hint").attr("disabled", true);
                                 }
                                 else{
-                                    hint = nextStatementHint();
+                                    hintsLeft = 2;
+                                    $("#hint").val("I'd like a hint (2 hints left for this step)");
+                                    $("#hint").attr("disabled", false);
+                                    hintCategory = "good format but wrong";
+                                    giveAway = false;
                                 }
                             }
                             else if(verifyTriangles === false || verifyAngles === false || verifySegments === false){
-                                hint = nextStatementHint();
+                                hintCategory = "good format but wrong";
                             }
                             else{
-                                hint = "The things you've entered aren't valid segments, angles, or triangles in the figure.";
+                                hintCategory = "bad format";
                             }
-                            console.log(hint);
+                            console.log(hintCategory);
                         });
                         $("#reason").change(function(){ 
-                            var curVal = $("#reason").val();
+                            <!-- var curVal = $("#reason").val();
                             if(curVal === "SSS" || curVal === "ASA" || curVal === "SAS" || curVal === "AAS"){
                                 $("#symbol1").html(" \\triangle ");
                                 $("#symbol2").html(" \\triangle ");
@@ -204,23 +210,41 @@
                                 $("#symbol2").html("");
                             }
                             $.tmpl.type.code()($("#symbol1")[0]);
-                            $.tmpl.type.code()($("#symbol2")[0]);
+                            $.tmpl.type.code()($("#symbol2")[0]); -->
                             $(".nextStatement input").keyup(); 
                         });
 
+                        var storedHint = "";
                         $("#hint").click(function(){
-                            console.log("custom hint");
-                            if(HINTS_LEFT === 3){
-                                $(".hint1").show();
+                            if(hintsLeft &gt; 0){
+                                hintsLeft--;
+                                if(hintCategory === "bad format"){
+                                    hintsLeft++;
+                                    var stepsLeft = hintsLeft + " hint" + (hintsLeft === 1 ? "" : "s") + " left";
+                                    $(this).val("I'd like a hint (" + stepsLeft + " for this step)");
+                                    $(this).attr("disabled", false);
+                                    $(".actualHints").append("&lt;p&gt; The things you've entered aren't segments, angles, or triangles in the figure. &lt;/p&gt;");
+                                }
+                                else{
+                                    var stepsLeft = hintsLeft + " hint" + (hintsLeft === 1 ? "" : "s") + " left";
+                                    $(this).val("I'd like a hint (" + stepsLeft + " for this step)");
+                                    $(this).attr("disabled", false);
+                                    if(!giveAway){
+                                        var nextHintSet = nextStatementHint();
+                                        $(".actualHints").append("&lt;p&gt;"+nextHintSet[0]+"&lt;/p&gt;");
+                                        storedHint = nextHintSet[1];
+                                    }
+                                    else{
+                                        $(".actualHints").append("&lt;p&gt;"+storedHint+"&lt;/p&gt;");
+                                        storedHint = "";
+                                    }
+                                    _.each($(".actualHints code"), function(tag){ $.tmpl.type.code()(tag); });
+                                    giveAway = !giveAway;
+                                }
+                                if(hintsLeft === 0){
+                                    $("#hint").attr("disabled", true);
+                                }
                             }
-                            else if(HINTS_LEFT === 2){
-                                $(".hint2").html("In the step you're working on, "+hint);
-                                $(".hint2").show();
-                            }
-                            else{
-                                $(".hint3").show();
-                            }
-                            HINTS_LEFT--;
                         });
 
                     </div>
@@ -240,10 +264,7 @@
                         <option value="CPCTC">corresp. parts of congruent triangles are congruent</option>
                     </select>
                 </p>
-                <div class="customHints">
-                    <p class="hint1">Given the statements you have, you can prove <var> FINISHED </var> in one step. What triangle congruence postulate should you use?</p>
-                    <p class="hint2"></p>
-                    <p class="hint3">You can prove <var> FINISHED </var> by <var> finishedEqualities[finalRelation] </var>.</p>
+                <div class="actualHints">
                 </div>
                 <div class="solution" data-type="custom">
                     <div class="instruction">
@@ -317,7 +338,7 @@
                 </div>
                 <p class="question">
                     <p>Prove <var> FINISHED </var>.</p>
-                    <p>This figure is not drawn to scale.</p>
+                    <p> <code> \overline{AB} </code> is parallel to <code> \overline{DE} </code>. This figure is not drawn to scale.</p>
                 </p>
 
                 <div class="problem">
@@ -392,74 +413,146 @@
                         graph.congruency.addLabel("D", "left");
                         graph.congruency.addLabel("E", "right");
 
-                        $(".triangleStatement").hide();
+                        $(".hint1").hide();
+                        $(".hint2").hide();
+                        $(".hint3").hide();
 
-                        $(".angleStatement input").keyup(function(){
-                            var angles = [];
-                            angles[0] = $(".angleStatement .thing1").val();
-                            angles[1] = $(".angleStatement .thing2").val();
-                            var reason = $(".angleStatement .reason").val();
+                        var hintCategory = "good format but wrong";
+                        var hintsLeft = 2;
+                        var giveAway = false;
 
-                            var verify = verifyStatementArgs(angles[0]+"="+angles[1], reason, "angle equality");
-                            if(verify.length > 0){
-                                hint = verify;
+                        $(".nextStatement input").keyup(function(){
+                            var thing1 = $("#thing1").val().toUpperCase();
+                            var thing2 = $("#thing2").val().toUpperCase();
+                            var reason = $("#reason").val();
+
+                            if(thing1.length === 0 && thing2.length === 0){
+                                hintCategory = "good format but wrong";
+                                return;
                             }
-                            else if(!verify){
-                                hint = "you've put in angles that are in the figure, but your reason isn't right.";
-                            }
-                            else{
-                                hint = "you've already finished! Hit the check answer button."
+
+                            var verifyTriangles = thing1.length === 3 && thing2.length === 3 ? verifyStatementArgs(thing1+"="+thing2, reason, "triangle congruence") : false;
+                            var verifyAngles = thing1.length === 3 && thing2.length === 3 ? verifyStatementArgs(thing1+"="+thing2, reason, "angle equality") : false;
+                            var verifySegments = thing1.length === 2 && thing2.length === 2 ? verifyStatementArgs(thing1+"="+thing2, reason, "segment equality") : false;
+
+                            if(verifyTriangles === true || verifyAngles === true || verifySegments === true){
                                 $(".statements").html(outputKnownProof());
                                 _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
-                                $(".angleStatement").hide();
-                                $(".triangleStatement").show();
+                                console.log("thinks statement is true " + reason);
+                                $("#thing1").val("");
+                                $("#thing2").val("");
+                                $("#reason").val("");
+                                $("#symbol1").html("");
+                                $("#symbol2").html("");
+                                if(userProofDone === true){
+                                    $(".nextStatement").hide();
+                                    $("#hint").attr("disabled", true);
+                                }
+                                else{
+                                    hintsLeft = 2;
+                                    $("#hint").val("I'd like a hint (2 hints left for this step)");
+                                    $("#hint").attr("disabled", false);
+                                    hintCategory = "good format but wrong";
+                                    giveAway = false;
+                                }
                             }
-                            console.log(hint);
+                            else if(verifyTriangles === false || verifyAngles === false || verifySegments === false){
+                                hintCategory = "good format but wrong";
+                            }
+                            else{
+                                hintCategory = "bad format";
+                            }
+                            console.log(hintCategory);
                         });
-                        $(".angleStatement select").change(function(){ 
-                            $(".angleStatement input").keyup(); 
+                        $("#reason").change(function(){ 
+                            <!-- var curVal = $("#reason").val();
+                            if(curVal === "SSS" || curVal === "ASA" || curVal === "SAS" || curVal === "AAS"){
+                                $("#symbol1").html(" \\triangle ");
+                                $("#symbol2").html(" \\triangle ");
+                            }
+                            else if(curVal === "vertical angles" || curVal === "alternate angles"){
+                                $("#symbol1").html(" \\angle ");
+                                $("#symbol2").html(" \\angle ");
+                            }
+                            else{
+                                $("#symbol1").html("");
+                                $("#symbol2").html("");
+                            }
+                            $.tmpl.type.code()($("#symbol1")[0]);
+                            $.tmpl.type.code()($("#symbol2")[0]); -->
+                            $(".nextStatement input").keyup(); 
+                        });
+
+                        
+                        var storedHint = "";
+                        $("#hint").click(function(){
+                            if(hintsLeft &gt; 0){
+                                hintsLeft--;
+                                if(hintCategory === "bad format"){
+                                    hintsLeft++;
+                                    var stepsLeft = hintsLeft + " hint" + (hintsLeft === 1 ? "" : "s") + " left";
+                                    $(this).val("I'd like a hint (" + stepsLeft + " for this step)");
+                                    $(this).attr("disabled", false);
+                                    $(".actualHints").append("&lt;p&gt; The things you've entered aren't segments, angles, or triangles in the figure. &lt;/p&gt;");
+                                }
+                                else{
+                                    var stepsLeft = hintsLeft + " hint" + (hintsLeft === 1 ? "" : "s") + " left";
+                                    $(this).val("I'd like a hint (" + stepsLeft + " for this step)");
+                                    $(this).attr("disabled", false);
+                                    if(!giveAway){
+                                        var nextHintSet = nextStatementHint();
+                                        $(".actualHints").append("&lt;p&gt;"+nextHintSet[0]+"&lt;/p&gt;");
+                                        storedHint = nextHintSet[1];
+                                    }
+                                    else{
+                                        $(".actualHints").append("&lt;p&gt;"+storedHint+"&lt;/p&gt;");
+                                        storedHint = "";
+                                    }
+                                    _.each($(".actualHints code"), function(tag){ $.tmpl.type.code()(tag); });
+                                    giveAway = !giveAway;
+                                }
+                                if(hintsLeft === 0){
+                                    $("#hint").attr("disabled", true);
+                                }
+                            }
                         });
 
 
                     </div>
+                </div>
                 
-                    <p class="statements"> <var> outputKnownProof() </var></p>
-                    <div class="angleStatement">
-                        <code> \angle </code> <input type="text" maxlength="3" class="thing1"></input> <code> = \angle </code> <input type="text" maxlength="3" class="thing2"> </input> because
-                        <select class="reason">
-                            <option value="">select a reason</option>
-                            <option value="CPCTC">corresp. parts of congruent triangles are congruent</option>
-                            <option value="vertical angles">vertical angles are equal</option>
-                            <option value="alternate angles">alternate interior angles are equal</option>
-                        </select>
-                    </div>
-                    <div class="triangleStatement">
-                        <code> \bigtriangleup </code> <input type="text" maxlength="3"></input> <code> =  \bigtriangleup </code> <input type="text" maxlength="3"> </input> because 
-                        <select>
-                            <option value="">select a reason</option>
-                            <option value="SSS">side-side-side congruence</option>
-                            <option value="ASA">angle-side-angle congruence</option>
-                            <option value="SAS">side-angle-side congruence</option>
-                            <option value="AAS">angle-angle-side congruence</option>
-                        </select>
-                    </div>
+                <p class="statements"> <var> outputKnownProof() </var></p>
+                <p class="nextStatement">
+                    <code id="symbol1"></code> <input type="text" id="thing1"></input> <code> \cong </code> <code id="symbol2"></code> <input type="text" id="thing2" > </input> because 
+                    <select id="reason">
+                        <option value="">select a reason</option>
+                        <option value="SSS">side-side-side congruence</option>
+                        <option value="ASA">angle-side-angle congruence</option>
+                        <option value="SAS">side-angle-side congruence</option>
+                        <option value="AAS">angle-angle-side congruence</option>
+                        <option value="vertical angles">vertical angles are equal</option>
+                        <option value="alternate angles">alternate interior angles are equal</option>
+                        <option value="CPCTC">corresp. parts of congruent triangles are congruent</option>
+                    </select>
+                </p>
+                <div class="actualHints">
                 </div>
                 <div class="solution" data-type="custom">
                     <div class="instruction">
                         When you enter the next statement in the proof, and a valid reason, that statement will be added to the proof. When you're done, hit check answer.
                     </div>
-                    <div class="guess">[]</div>
+                    <div class="guess">1</div>
                     <div class="validator-function">
                         return isProofDone();
                     </div>
                     <div class="show-guess">
-                        
+                        return knownEqualities;
                     </div>
                 </div>
                 <div class="hints">
-                    <p>You only have two equalities, but you need three to prove two triangles congruent... What can you use to prove that an angle in one triangle is equal to an angle in the other?</p>
-                    <p> <var>nextStatementHint()</var> </p>
-
+                    <p></p>
+                    <p></p>
+                    <p></p>
                 </div>
             </div>
             <div id="shared">
@@ -583,40 +676,162 @@
                         graph.congruency.addAngles("B");
                         graph.congruency.addAngles("C");
                         graph.congruency.addAngles("D");
+
+                        for(var angle in graph.congruency.angles){
+                            graph.congruency.angles[angle].setSelectedStyle({
+                                stroke: "black",
+                                "stroke-width": 3
+                            });
+                        }
                         
                         graph.congruency.addLabel("A", "above");
                         graph.congruency.addLabel("B", "left");
                         graph.congruency.addLabel("C", "right");
                         graph.congruency.addLabel("D", "below");
 
+                        $(".hint1").hide();
+                        $(".hint2").hide();
+                        $(".hint3").hide();
+
+                        var hintCategory = "good format but wrong";
+                        var hintsLeft = 2;
+                        var giveAway = false;
+
+                        $(".nextStatement input").keyup(function(){
+                            var thing1 = $("#thing1").val().toUpperCase();
+                            var thing2 = $("#thing2").val().toUpperCase();
+                            var reason = $("#reason").val();
+
+                            if(thing1.length === 0 && thing2.length === 0){
+                                hintCategory = "good format but wrong";
+                                return;
+                            }
+
+                            var verifyTriangles = thing1.length === 3 && thing2.length === 3 ? verifyStatementArgs(thing1+"="+thing2, reason, "triangle congruence") : false;
+                            var verifyAngles = thing1.length === 3 && thing2.length === 3 ? verifyStatementArgs(thing1+"="+thing2, reason, "angle equality") : false;
+                            var verifySegments = thing1.length === 2 && thing2.length === 2 ? verifyStatementArgs(thing1+"="+thing2, reason, "segment equality") : false;
+
+                            if(verifyTriangles === true || verifyAngles === true || verifySegments === true){
+                                if($("#thing1").val() === $("#thing2").val() || $("#thing1").val() === $("#thing2").val().split("").reverse().join("")){
+
+                                }                            
+                                $(".statements").html(outputKnownProof());
+                                _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
+                                console.log("thinks statement is true " + reason);
+                                $("#thing1").val("");
+                                $("#thing2").val("");
+                                $("#reason").val("");
+                                $("#symbol1").html("");
+                                $("#symbol2").html("");
+                                if(userProofDone === true){
+                                    $(".nextStatement").hide();
+                                    $("#hint").attr("disabled", true);
+                                }
+                                else{
+                                    hintsLeft = 2;
+                                    $("#hint").val("I'd like a hint (2 hints left for this step)");
+                                    $("#hint").attr("disabled", false);
+                                    hintCategory = "good format but wrong";
+                                    giveAway = false;
+                                }
+                            }
+                            else if(verifyTriangles === false || verifyAngles === false || verifySegments === false){
+                                hintCategory = "good format but wrong";
+                            }
+                            else{
+                                hintCategory = "bad format";
+                            }
+                            console.log(hintCategory);
+                        });
+                        $("#reason").change(function(){ 
+                            <!-- var curVal = $("#reason").val();
+                            if(curVal === "SSS" || curVal === "ASA" || curVal === "SAS" || curVal === "AAS"){
+                                $("#symbol1").html(" \\triangle ");
+                                $("#symbol2").html(" \\triangle ");
+                            }
+                            else if(curVal === "vertical angles" || curVal === "alternate angles"){
+                                $("#symbol1").html(" \\angle ");
+                                $("#symbol2").html(" \\angle ");
+                            }
+                            else{
+                                $("#symbol1").html("");
+                                $("#symbol2").html("");
+                            }
+                            $.tmpl.type.code()($("#symbol1")[0]);
+                            $.tmpl.type.code()($("#symbol2")[0]); -->
+                            $(".nextStatement input").keyup(); 
+                        });
+
+                        
+                        var storedHint = "";
+                        $("#hint").click(function(){
+                            if(hintsLeft &gt; 0){
+                                hintsLeft--;
+                                if(hintCategory === "bad format"){
+                                    hintsLeft++;
+                                    var stepsLeft = hintsLeft + " hint" + (hintsLeft === 1 ? "" : "s") + " left";
+                                    $(this).val("I'd like a hint (" + stepsLeft + " for this step)");
+                                    $(this).attr("disabled", false);
+                                    $(".actualHints").append("&lt;p&gt; The things you've entered aren't segments, angles, or triangles in the figure. &lt;/p&gt;");
+                                }
+                                else{
+                                    var stepsLeft = hintsLeft + " hint" + (hintsLeft === 1 ? "" : "s") + " left";
+                                    $(this).val("I'd like a hint (" + stepsLeft + " for this step)");
+                                    $(this).attr("disabled", false);
+                                    if(!giveAway){
+                                        var nextHintSet = nextStatementHint();
+                                        $(".actualHints").append("&lt;p&gt;"+nextHintSet[0]+"&lt;/p&gt;");
+                                        storedHint = nextHintSet[1];
+                                    }
+                                    else{
+                                        $(".actualHints").append("&lt;p&gt;"+storedHint+"&lt;/p&gt;");
+                                        storedHint = "";
+                                    }
+                                    _.each($(".actualHints code"), function(tag){ $.tmpl.type.code()(tag); });
+                                    giveAway = !giveAway;
+                                }
+                                if(hintsLeft === 0){
+                                    $("#hint").attr("disabled", true);
+                                }
+                            }
+                        });
+
                     </div>
                 </div>
 
-                <p class="statements">
-                    <code> \overline{ <input>sdfjlsdfkj</input> } </code>
+                <p class="statements"> <var> outputKnownProof() </var></p>
+                <p class="nextStatement">
+                    <code id="symbol1"></code> <input type="text" id="thing1"></input> <code> \cong </code> <code id="symbol2"></code> <input type="text" id="thing2" > </input> because 
+                    <select id="reason">
+                        <option value="">select a reason</option>
+                        <option value="SSS">side-side-side congruence</option>
+                        <option value="ASA">angle-side-angle congruence</option>
+                        <option value="SAS">side-angle-side congruence</option>
+                        <option value="AAS">angle-angle-side congruence</option>
+                        <option value="vertical angles">vertical angles are equal</option>
+                        <option value="alternate angles">alternate interior angles are equal</option>
+                        <option value="CPCTC">corresp. parts of congruent triangles are congruent</option>
+                        <option value="reflexive property">reflexive property</option>
+                    </select>
                 </p>
+                <div class="actualHints">
+                </div>
                 <div class="solution" data-type="custom">
                     <div class="instruction">
-                        <p> <var> FINISHED </var> by 
-                        <select class="statement_type">
-                            <option>Side-Side-Side Congruence</option>
-                            <option>Side-Angle-Side Congruence</option>
-                            <option>Angle-Side-Angle Congruence</option>
-                            <option>Angle-Angle-Side Congruence</option>
-                        </select> </p>
+                        When you enter the next statement in the proof, and a valid reason, that statement will be added to the proof. When you're done, hit check answer.
                     </div>
-                    <div class="guess">[]</div>
+                    <div class="guess">1</div>
                     <div class="validator-function">
-                        return userProofDone;
+                        return isProofDone();
                     </div>
                     <div class="show-guess">
-                        
+                        return knownEqualities;
                     </div>
                 </div>
                 <div class="hints">
-                    <p>You only have two equalities, but you need three to prove two triangles congruent... What other fact about these two triangles can you use?</p>
-                    <p> The triangles have a shared side: <code> \overline{AD} </code> is the same length in <code> \bigtriangleup BAD</code> as it is in <code> \bigtriangleup CAD.</code></p>
-                    <p><var>nextStatementHint()</var> Using what congruence theorem?</p>
+                    <p></p>
+                    <p></p>
+                    <p></p>
                 </div>
             </div>
         </div>

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -641,31 +641,31 @@
                             start: "A",
                             end: "B",
                             clickable: true,
-                            max: 3
+                            maxState: 3
                         });
                         graph.congruency.addLine({
                             start: "B",
                             end: "D",
                             clickable: true,
-                            max: 3
+                            maxState: 3
                         });
                         graph.congruency.addLine({
                             start: "A",
                             end: "D",
                             clickable: true,
-                            max: 3
+                            maxState: 3
                         });
                         graph.congruency.addLine({
                             start: "A",
                             end: "C",
                             clickable: true,
-                            max: 3
+                            maxState: 3
                         });
                         graph.congruency.addLine({
                             start: "C",
                             end: "D",
                             clickable: true,
-                            max: 3
+                            maxState: 3
                         });
 
                         graph.congruency.addAngles("A");

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -2,7 +2,7 @@
 <html data-require="math graphie graphie-helpers graphie-geometry math-format interactive proofs congruency">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Geometry Proofs 1</title>
+    <title>Simple Geometry Proofs</title>
     <script src="../khan-exercise.js"></script>
     <style type="text/css">
         input[type=text] {
@@ -169,7 +169,6 @@
                             if(verifyTriangles === true || verifyAngles === true || verifySegments === true){
                                 $(".statements").html(outputKnownProof());
                                 _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
-                                console.log("thinks statement is true " + reason);
                                 $("#thing1").val("");
                                 $("#thing2").val("");
                                 $("#reason").val("");
@@ -193,7 +192,6 @@
                             else{
                                 hintCategory = "bad format";
                             }
-                            console.log(hintCategory);
                         });
                         $("#reason").change(function(){ 
                             <!-- var curVal = $("#reason").val();
@@ -438,7 +436,6 @@
                             if(verifyTriangles === true || verifyAngles === true || verifySegments === true){
                                 $(".statements").html(outputKnownProof());
                                 _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
-                                console.log("thinks statement is true " + reason);
                                 $("#thing1").val("");
                                 $("#thing2").val("");
                                 $("#reason").val("");
@@ -462,7 +459,6 @@
                             else{
                                 hintCategory = "bad format";
                             }
-                            console.log(hintCategory);
                         });
                         $("#reason").change(function(){ 
                             <!-- var curVal = $("#reason").val();
@@ -717,7 +713,6 @@
                                 }                            
                                 $(".statements").html(outputKnownProof());
                                 _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
-                                console.log("thinks statement is true " + reason);
                                 $("#thing1").val("");
                                 $("#thing2").val("");
                                 $("#reason").val("");
@@ -741,7 +736,6 @@
                             else{
                                 hintCategory = "bad format";
                             }
-                            console.log(hintCategory);
                         });
                         $("#reason").change(function(){ 
                             <!-- var curVal = $("#reason").val();

--- a/exercises/geometry_proofs_intro.html
+++ b/exercises/geometry_proofs_intro.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+<html data-require="math graphie graphie-helpers graphie-geometry math-format interactive proofs congruency">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Geometry Proofs 1</title>
+    <script src="../khan-exercise.js"></script>
+    <style type="text/css">
+        input[type=text] {
+            width: 30px;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+    <div class="exercise">
+        <div class="problems">
+            <div id="vertical">
+                <div class="vars">
+                    <var id="AC">new Seg("A","C")</var>
+                    <var id="CA">AC</var>
+                    <var id="AD">new Seg("A","D")</var>
+                    <var id="DA">AD</var>
+                    <var id="BE">new Seg("B","E")</var>
+                    <var id="EB">BE</var>
+                    <var id="AE">new Seg("A","E")</var>
+                    <var id="EA">AE</var>
+                    <var id="BC">new Seg("B","C")</var>
+                    <var id="CB">BC</var>
+                    <var id="BD">new Seg("B","D")</var>
+                    <var id="DB">BD</var>
+                    <var id="CD">new Seg("C","D")</var>
+                    <var id="DC">CD</var>
+                    <var id="CE">new Seg("C","E")</var>
+                    <var id="EC">CE</var>
+                    
+
+                    <var id="SEGS">[AC,CA,AE,EA,BC,CB,BD,DB,CD,DC,CE,EC]</var>
+                    
+
+                    <var id="ang1">new Ang("D","A","C", null)</var>
+                    <var id="ang2">new Ang("C","B","E", null)</var>
+                    <var id="ang3">new Ang("A","C","D", null)</var>
+                    <var id="ang4">new Ang("B","C","E", null)</var>
+                    <var id="ang5">new Ang("A","D","C", null)</var>
+                    <var id="ang6">new Ang("C","E","B", null)</var>
+                    <var id="ang7">new Ang("A","C","B", null)</var>
+                    <var id="ang8">new Ang("D","C","E", null)</var>
+
+                    <var id="ANGS">[ang1, ang2, ang3, ang4, ang5, ang6, ang7, ang8]</var>
+
+                    <var id="SUPPLEMENTARY_ANGS">[addAngs(ang3, ang7), addAngs(ang7, ang4), addAngs(ang4, ang8), addAngs(ang8, ang3)]</var>
+
+                    <var id="ALTERNATE_INTERIOR_ANGS">[]</var>
+
+                    <var id="PARALLEL_SEGS">[]</var>
+
+                    <var id="ADC">new Triang([AD, DC, CA], [ang5, ang3, ang1])</var>
+                    <var id="BEC">new Triang([BE, EC, CB], [ang6, ang4, ang2])</var>
+                    
+
+                    <var id="TRIANGLES">[ADC, BEC]</var>
+
+                    <var id="STATEMENTS">initProof(SEGS, ANGS, TRIANGLES, SUPPLEMENTARY_ANGS, ALTERNATE_INTERIOR_ANGS, 2, 0.25, "triangle")</var>
+                    <var id="KNOWN">STATEMENTS[0]</var>
+                    <var id="FINISHED">STATEMENTS[1]</var>
+
+                    <var id="HINT">"you haven't entered anything yet"</var>   
+                    <var id="HINTS_LEFT">3</var>                 
+                </div>
+                <p class="question">
+                    <p>Prove <var> FINISHED </var>.</p>
+                    <p>This figure is not drawn to scale.</p>
+                </p>
+
+                <div class="problem">
+                    <div class="graphie">
+                        init({
+                            range: [[-5, 5], [-5, 5]],
+                            scale: 40
+                        });
+                        addMouseLayer();
+                        
+                        graph.congruency = addCongruency({ y1: -0.7, y2: 10.7 });
+
+                        graph.congruency.addPoint("A", [-4, 4]);
+                        graph.congruency.addPoint("B", [4, 4]);
+                        graph.congruency.addPoint("C", [0, -(4/3)]);
+                        graph.congruency.addPoint("D", [-2, -4]);
+                        graph.congruency.addPoint("E", [2, -4]);
+
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "D",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "C",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "C",
+                            end: "D",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "C",
+                            end: "B",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "C",
+                            end: "E",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "E",
+                            end: "B",
+                            clickable: true,
+                            maxState: 3
+                        });
+
+                        graph.congruency.addAngles("A", { maxState: 3 });
+                        graph.congruency.addAngles("B", { maxState: 3 });
+                        graph.congruency.addAngles("C", { maxState: 3 });
+                        graph.congruency.addAngles("D", { maxState: 3 });
+                        graph.congruency.addAngles("E", { maxState: 3 });
+
+                        for(var angle in graph.congruency.angles){
+                            graph.congruency.angles[angle].setSelectedStyle({
+                                stroke: "black",
+                                "stroke-width": 3
+                            });
+                        }
+                        
+                        graph.congruency.addLabel("A", "left");
+                        graph.congruency.addLabel("B", "right");
+                        graph.congruency.addLabel("C", "right");
+                        graph.congruency.addLabel("D", "left");
+                        graph.congruency.addLabel("E", "right");
+
+                        $(".hint1").hide();
+                        $(".hint2").hide();
+                        $(".hint3").hide();
+
+                        var hint = "you haven't entered anything!";
+
+                        $(".nextStatement input").keyup(function(){
+                            var triangles = [];
+                            triangles[0] = $("#thing1").val();
+                            triangles[1] = $("#thing2").val();
+                            var reason = $("#reason").val();
+
+                            var verify = verifyStatementArgs(triangles[0]+"="+triangles[1], reason, "triangle congruence");
+                            if(verify.length > 0){
+                                hint = verify;
+                            }
+                            else if(!verify){
+                                hint = "you've put in triangles that are in the figure, but your reason isn't right.";
+                            }
+                            else{
+                                hint = "you've already finished! Hit the check answer button."
+                                $(".statements").html(outputKnownProof());
+                                _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
+                                $(".nextStatement").hide();
+                            }
+                            console.log(hint);
+                        });
+                        $("#reason").change(function(){ 
+                            $(".nextStatement input").keyup(); 
+                        });
+
+                        $("#hint").click(function(){
+                            console.log("custom hint");
+                            if(HINTS_LEFT === 3){
+                                $(".hint1").show();
+                            }
+                            else if(HINTS_LEFT === 2){
+                                $(".hint2").html("In the step you're working on, "+hint);
+                                $(".hint2").show();
+                            }
+                            else{
+                                $(".hint3").show();
+                            }
+                            HINTS_LEFT--;
+                        });
+
+                    </div>
+                </div>
+
+                <p class="statements"> <var> outputKnownProof() </var></p>
+                <p class="nextStatement">
+                    <code> \bigtriangleup </code> <input type="text" id="thing1"></input> <code> =  \bigtriangleup </code> <input type="text" id="thing2" > </input> because 
+                    <select id="reason">
+                        <option value="">select a reason</option>
+                        <option value="SSS">side-side-side congruence</option>
+                        <option value="ASA">angle-side-angle congruence</option>
+                        <option value="SAS">side-angle-side congruence</option>
+                        <option value="AAS">angle-angle-side congruence</option>
+                    </select>
+                </p>
+                <div class="customHints">
+                    <p class="hint1">Given the statements you have, you can prove <var> FINISHED </var> in one step. What triangle congruence postulate should you use?</p>
+                    <p class="hint2"></p>
+                    <p class="hint3">You can prove <var> FINISHED </var> by <var> finishedEqualities[finalRelation] </var>.</p>
+                </div>
+                <div class="solution" data-type="custom">
+                    <div class="instruction">
+                        When you enter the next statement in the proof, and a valid reason, that statement will be added to the proof. When you're done, hit check answer.
+                    </div>
+                    <div class="guess">[knownEqualities]</div>
+                    <div class="validator-function">
+                        return isProofDone();
+                    </div>
+                    <div class="show-guess">
+                        
+                    </div>
+                </div>
+                <div class="hints">
+                    <p></p>
+                    <p></p>
+                    <p></p>
+                </div>
+            </div>
+            <div id="alternate">
+                <div class="vars">
+                    <var id="AB">new Seg("A","B")</var>
+                    <var id="BA">AB</var>
+                    <var id="AC">new Seg("A","C")</var>
+                    <var id="CA">AC</var>
+                    <var id="AE">new Seg("A","E")</var>
+                    <var id="EA">AE</var>
+                    <var id="BC">new Seg("B","C")</var>
+                    <var id="CB">BC</var>
+                    <var id="BD">new Seg("B","D")</var>
+                    <var id="DB">BD</var>
+                    <var id="CD">new Seg("C","D")</var>
+                    <var id="DC">CD</var>
+                    <var id="CE">new Seg("C","E")</var>
+                    <var id="EC">CE</var>
+                    <var id="DE">new Seg("D","E")</var>
+                    <var id="ED">DE</var>         
+
+                    <var id="SEGS">[AB,BA,AC,CA,AE,EA,BC,CB,BD,DB,CD,DC,CE,EC,DE,ED]</var>
+
+                    <var id="ang1">new Ang("C","A","B", null)</var>
+                    <var id="ang2">new Ang("C","B","A", null)</var>
+                    <var id="ang3">new Ang("A","C","B", null)</var>
+                    <var id="ang4">new Ang("D","C","E", null)</var>
+                    <var id="ang5">new Ang("C","D","E", null)</var>
+                    <var id="ang6">new Ang("C","E","D", null)</var>
+                    <var id="ang7">new Ang("A","C","D", null)</var>
+                    <var id="ang8">new Ang("B","C","E", null)</var>
+
+                    <var id="ANGS">[ang1, ang2, ang3, ang4, ang5, ang6, ang7, ang8]</var>
+
+                    <var id="SUPPLEMENTARY_ANGS">[addAngs(ang3, ang7), addAngs(ang7, ang4), addAngs(ang4, ang8), addAngs(ang8, ang3)]</var>
+
+                    <var id="ALTERNATE_INTERIOR_ANGS">[[ang2, ang5]]</var>
+
+                    <var id="PARALLEL_SEGS">[]</var>
+
+                    <var id="ABC">new Triang([AB, BC, CA], [ang2, ang3, ang1])</var>
+                    <var id="CDE">new Triang([CD, DE, EC], [ang5, ang6, ang4])</var>
+                    
+
+                    <var id="TRIANGLES">[ABC, CDE]</var>
+
+                    <var id="STATEMENTS">initProof(SEGS, ANGS, TRIANGLES, SUPPLEMENTARY_ANGS, ALTERNATE_INTERIOR_ANGS, 2, 0.25, "triangle")</var>
+                    <var id="KNOWN">STATEMENTS[0]</var>
+                    <var id="FINISHED">STATEMENTS[1]</var>
+
+
+                    <var id="DOT_ATTRS">{ r: 0.2, fill: BLUE, stroke: "none" }</var>
+                    
+                </div>
+                <p class="question">
+                    <p>Prove <var> FINISHED </var>.</p>
+                    <p>This figure is not drawn to scale.</p>
+                </p>
+
+                <div class="problem">
+                    <div class="graphie">
+                        init({
+                            range: [[-5, 5], [-5, 5]],
+                            scale: 40
+                        });
+                        addMouseLayer();
+                        
+                        graph.congruency = addCongruency({ y1: -0.7, y2: 10.7 });
+
+                        graph.congruency.addPoint("A", [-3, 4]);
+                        graph.congruency.addPoint("B", [3, 4]);
+                        graph.congruency.addPoint("C", [0, 0]);
+                        graph.congruency.addPoint("D", [-3, -4]);
+                        graph.congruency.addPoint("E", [3, -4]);
+
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "B",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "C",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "B",
+                            end: "C",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "C",
+                            end: "D",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "C",
+                            end: "E",
+                            clickable: true,
+                            maxState: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "D",
+                            end: "E",
+                            clickable: true,
+                            maxState: 3
+                        });
+
+                        graph.congruency.addAngles("A", { maxState: 3 });
+                        graph.congruency.addAngles("B", { maxState: 3 });
+                        graph.congruency.addAngles("C", { maxState: 3 });
+                        graph.congruency.addAngles("D", { maxState: 3 });
+                        graph.congruency.addAngles("E", { maxState: 3 });
+
+                        for(var angle in graph.congruency.angles){
+                            graph.congruency.angles[angle].setSelectedStyle({
+                                stroke: "black",
+                                "stroke-width": 3
+                            });
+                        }
+                        
+                        graph.congruency.addLabel("A", "left");
+                        graph.congruency.addLabel("B", "right");
+                        graph.congruency.addLabel("C", "right");
+                        graph.congruency.addLabel("D", "left");
+                        graph.congruency.addLabel("E", "right");
+
+                        $(".triangleStatement").hide();
+
+                        $(".angleStatement input").keyup(function(){
+                            var angles = [];
+                            angles[0] = $(".angleStatement .thing1").val();
+                            angles[1] = $(".angleStatement .thing2").val();
+                            var reason = $(".angleStatement .reason").val();
+
+                            var verify = verifyStatementArgs(angles[0]+"="+angles[1], reason, "angle equality");
+                            if(verify.length > 0){
+                                hint = verify;
+                            }
+                            else if(!verify){
+                                hint = "you've put in angles that are in the figure, but your reason isn't right.";
+                            }
+                            else{
+                                hint = "you've already finished! Hit the check answer button."
+                                $(".statements").html(outputKnownProof());
+                                _.each($(".statements code"), function(tag){ $.tmpl.type.code()(tag); });
+                                $(".angleStatement").hide();
+                                $(".triangleStatement").show();
+                            }
+                            console.log(hint);
+                        });
+                        $(".angleStatement select").change(function(){ 
+                            $(".angleStatement input").keyup(); 
+                        });
+
+
+                    </div>
+                
+                    <p class="statements"> <var> outputKnownProof() </var></p>
+                    <div class="angleStatement">
+                        <code> \angle </code> <input type="text" maxlength="3" class="thing1"></input> <code> = \angle </code> <input type="text" maxlength="3" class="thing2"> </input> because
+                        <select class="reason">
+                            <option value="">select a reason</option>
+                            <option value="CPCTC">corresp. parts of congruent triangles are congruent</option>
+                            <option value="vertical angles">vertical angles are equal</option>
+                            <option value="alternate angles">alternate interior angles are equal</option>
+                        </select>
+                    </div>
+                    <div class="triangleStatement">
+                        <code> \bigtriangleup </code> <input type="text" maxlength="3"></input> <code> =  \bigtriangleup </code> <input type="text" maxlength="3"> </input> because 
+                        <select>
+                            <option value="">select a reason</option>
+                            <option value="SSS">side-side-side congruence</option>
+                            <option value="ASA">angle-side-angle congruence</option>
+                            <option value="SAS">side-angle-side congruence</option>
+                            <option value="AAS">angle-angle-side congruence</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="solution" data-type="custom">
+                    <div class="instruction">
+                        When you enter the next statement in the proof, and a valid reason, that statement will be added to the proof. When you're done, hit check answer.
+                    </div>
+                    <div class="guess">[]</div>
+                    <div class="validator-function">
+                        return isProofDone();
+                    </div>
+                    <div class="show-guess">
+                        
+                    </div>
+                </div>
+                <div class="hints">
+                    <p>You only have two equalities, but you need three to prove two triangles congruent... What can you use to prove that an angle in one triangle is equal to an angle in the other?</p>
+                    <p> <var>nextStatementHint()</var> </p>
+
+                </div>
+            </div>
+            <div id="shared">
+                <div class="vars">
+                    <var id="A">[0,6]</var>
+                    <var id="B">[-8,0]</var>
+                    <var id="C">[8,0]</var>
+                    <var id="D">[0,-6]</var>
+
+                    <var id="POINTS">["A","B","C","D"]</var>
+
+                    <var id="AB">new Seg("A","B")</var>
+                    <var id="BA">AB</var>
+                    <var id="AC">new Seg("A","C")</var>
+                    <var id="CA">AC</var>
+                    <var id="BD">new Seg("B","D")</var>
+                    <var id="DB">BD</var>
+                    <var id="CD">new Seg("C","D")</var>
+                    <var id="DC">CD</var>
+                    <var id="AD">new Seg("A","D")</var>
+                    <var id="DA">AD</var>
+                    
+
+                    <var id="SEGS">[AB,BA,AC,CA,BD,DB,CD,DC,AD,DA]</var>
+                    
+
+                    <var id="ang1">new Ang("A","B","D", null)</var>
+                    <var id="ang2">new Ang("B","A","D", null)</var>
+                    <var id="ang3">new Ang("D","A","C", null)</var>
+                    <var id="ang4">new Ang("A","C","D", null)</var>
+                    <var id="ang5">new Ang("A","D","B", null)</var>
+                    <var id="ang6">new Ang("A","D","C", null)</var>
+
+                    <var id="ANGS">[ang1, ang2, ang3, ang4, ang5, ang6]</var>
+
+                    <var id="SUPPLEMENTARY_ANGS">[]</var>
+
+                    <var id="ALTERNATE_INTERIOR_ANGS">[]</var>
+
+                    <var id="PARALLEL_SEGS">[]</var>
+
+                    <!-- <var id="PARALLEL_TO_ALTERNATE">(function() {
+                        dict = {};
+                        dict[[AB,DE]] = [[ang2, ang11], [ang3, ang10]];
+                        return dict;
+                    })</var>
+
+                    <var id="ALTERNATE_TO_PARALLEL">(function() {
+                        dict = {};
+                        dict[[ang2, ang11]] = [AB,DE];
+                        dict[[ang3, ang10]] = [AB,DE];
+                        return dict;
+                    })</var> -->
+
+                    <var id="BAD">new Triang([BA, AD, DB], [ang2, ang5, ang1])</var>
+                    <var id="CAD">new Triang([CA, AD, DC], [ang3, ang6, ang4])</var>
+                    
+
+                    <var id="TRIANGLES">[BAD, CAD]</var>
+
+                    <var id="STATEMENTS">initProof(SEGS, ANGS, TRIANGLES, SUPPLEMENTARY_ANGS, ALTERNATE_INTERIOR_ANGS, 2, 0.25, "triangle")</var>
+                    <var id="KNOWN">STATEMENTS[0]</var>
+                    <var id="FINISHED">STATEMENTS[1]</var>
+
+
+                    <var id="DOT_ATTRS">{ r: 0.2, fill: BLUE, stroke: "none" }</var>
+                    
+                </div>
+                <p class="question">
+                    <p>You are given <var> KNOWN </var>.</p>
+                    <p>Prove <var> FINISHED </var></p>
+                </p>
+
+                <div class="problem">
+                    <div class="graphie">
+                        init({
+                            range: [[-5, 5], [-5, 5]],
+                            scale: 40
+                        });
+                        addMouseLayer();
+                        
+                        graph.congruency = addCongruency({ y1: -0.7, y2: 10.7 });
+
+                        graph.congruency.addPoint("A", [0, 3]);
+                        graph.congruency.addPoint("B", [-4, 0]);
+                        graph.congruency.addPoint("C", [4, 0]);
+                        graph.congruency.addPoint("D", [0, -3]);
+
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "B",
+                            clickable: true,
+                            max: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "B",
+                            end: "D",
+                            clickable: true,
+                            max: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "D",
+                            clickable: true,
+                            max: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "A",
+                            end: "C",
+                            clickable: true,
+                            max: 3
+                        });
+                        graph.congruency.addLine({
+                            start: "C",
+                            end: "D",
+                            clickable: true,
+                            max: 3
+                        });
+
+                        graph.congruency.addAngles("A");
+                        graph.congruency.addAngles("B");
+                        graph.congruency.addAngles("C");
+                        graph.congruency.addAngles("D");
+                        
+                        graph.congruency.addLabel("A", "above");
+                        graph.congruency.addLabel("B", "left");
+                        graph.congruency.addLabel("C", "right");
+                        graph.congruency.addLabel("D", "below");
+
+                    </div>
+                </div>
+
+                <p class="statements">
+                    <code> \overline{ <input>sdfjlsdfkj</input> } </code>
+                </p>
+                <div class="solution" data-type="custom">
+                    <div class="instruction">
+                        <p> <var> FINISHED </var> by 
+                        <select class="statement_type">
+                            <option>Side-Side-Side Congruence</option>
+                            <option>Side-Angle-Side Congruence</option>
+                            <option>Angle-Side-Angle Congruence</option>
+                            <option>Angle-Angle-Side Congruence</option>
+                        </select> </p>
+                    </div>
+                    <div class="guess">[]</div>
+                    <div class="validator-function">
+                        return userProofDone;
+                    </div>
+                    <div class="show-guess">
+                        
+                    </div>
+                </div>
+                <div class="hints">
+                    <p>You only have two equalities, but you need three to prove two triangles congruent... What other fact about these two triangles can you use?</p>
+                    <p> The triangles have a shared side: <code> \overline{AD} </code> is the same length in <code> \bigtriangleup BAD</code> as it is in <code> \bigtriangleup CAD.</code></p>
+                    <p><var>nextStatementHint()</var> Using what congruence theorem?</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -197,7 +197,6 @@ function verifyStatement() {
 }
 
 function verifyStatementArgs(statement, reason, category) {
-    console.log("verifyStatementArgs with ", statement, reason, category);
     if (userProofDone) {
         //return false;
     }
@@ -289,6 +288,11 @@ function verifyStatementArgs(statement, reason, category) {
         if (seg1 == null || seg2 == null) {
             return "those segments aren't in this figure...";
         }
+        else if(seg1.equals(seg2) && reason === "reflexive property"){
+            knownEqualities[[seg1, seg2]] = "reflexive property";
+            knownEqualities[[seg2, seg1]] = "reflexive property";  
+            return true;
+        }
         else if (eqIn([seg1, seg2], knownEqualities)){
             return "that's already in the proof!";
         }
@@ -318,9 +322,9 @@ function isProofDone() {
 // give a hint as to the next statement which the user should try to prove
 function nextStatementHint() {
     var hintKeys = [];
-    // filter out all keys with value "same *" or "given"
+    // filter out all keys with value "same *" or "given," as well as those values already in the proof
     for (var eq in finishedEqualities) {
-        if (finishedEqualities[eq].substring(0, 4) != "Same" && finishedEqualities[eq] != "given") {
+        if (finishedEqualities[eq].substring(0, 4) != "Same" && finishedEqualities[eq] != "given" && !(eq in knownEqualities)) {
             hintKeys.push(eq);
         }
     }
@@ -329,6 +333,9 @@ function nextStatementHint() {
         // look for something that can be proven with the statements already known
         // that is in finishedEqualities
         var tryProving = hintKeys[KhanUtil.randRange(0, hintKeys.length - 1)];
+        console.log("trying hint for " + tryProving);
+        console.log(tryProving in knownEqualities);
+        console.log(hintKeys);
 
         // awful, terrible hacky way to deal with javascript object hashes
         if (tryProving[0] === "t") {
@@ -342,9 +349,10 @@ function nextStatementHint() {
 
             var useToProve = checkTriangleForHint(triangle1, triangle2, knownEqualities);
             if (useToProve.length > 0) {
-                return "You know that " + prettifyEquality(useToProve[0][0] + "," + useToProve[0][1])
+                return ["You know that " + prettifyEquality(useToProve[0][0] + "," + useToProve[0][1])
                 + ", " + prettifyEquality(useToProve[1][0] + "," + useToProve[1][1])
-                + ", and " + prettifyEquality(useToProve[2][0] + "," + useToProve[2][1]) + ". What can you prove from this?";
+                + ", and " + prettifyEquality(useToProve[2][0] + "," + useToProve[2][1]) + ". What can you prove from this?", 
+                "A useful thing to prove here is " + prettifyEquality(triangle1 + "," + triangle2)];
             }
         }
 
@@ -358,7 +366,8 @@ function nextStatementHint() {
 
             var useToProve = checkSegForHint(seg1, seg2, knownEqualities);
             if (useToProve.length > 0) {
-                return "You know that " + prettifyEquality(useToProve[0] + "," + useToProve[1]) + ". What segments can you prove equal from this?";
+                return ["You know that " + prettifyEquality(useToProve[0] + "," + useToProve[1]) + ". What segments can you prove equal from this?",
+                "A useful thing to prove here is " + prettifyEquality(seg1 + "," + seg2)];
             }
         }
 
@@ -373,10 +382,12 @@ function nextStatementHint() {
 
             var useToProve = checkAngForHint(ang1, ang2, knownEqualities);
             if (useToProve.length > 0 && useToProve[0] instanceof Triang) {
-                return "You know that " + prettifyEquality(useToProve[0] + "," + useToProve[1]) + ". What angles can you prove equal from this?";
+                return ["You know that " + prettifyEquality(useToProve[0] + "," + useToProve[1]) + ". What angles can you prove equal from this?",
+                "A useful thing to prove here is " + prettifyEquality(ang1 + "," + ang2)];
             }
             else if (useToProve.length > 0) {
-                return "Try using " + useToProve + " to prove some useful pair of angles equal.";
+                return ["Try using " + useToProve + " to prove some useful pair of angles equal.",
+                 "A useful thing to prove here is " + prettifyEquality(ang1 + "," + ang2)];
             }
         }
 
@@ -697,7 +708,7 @@ function checkFillBlanksReason(select, selectID) {
 }
 
 // for fill-in-the-blanks proofs, this hint function looks for the next missing reason, and generate a hint based
-// on that using nextStatementHint()
+// on that
 function getFillBlanksHint(giveAway) {
     var unsortedKeyList = _.clone(finishedEqualitiesList);
     var finishedKeys = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
@@ -1800,6 +1811,7 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
 // Checks to see if the two given segments are equal by checking to see if they belong to
 // congruent triangles.
 function checkSegEqual(seg1, seg2, reason) {
+    console.log("cse");
     //if this is already known
     if (eqIn([seg1, seg2], knownEqualities)) {
         return true;

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -402,8 +402,7 @@ function outputFinishedProof() {
             numberGivens++;
         }
     });
-    numberGivens /= 2;
-    for (var i = 0; i < finishedKeys.length; i += 2) {
+    for (var i = 0; i < finishedKeys.length; i ++) {
         if (finishedEqualities[finishedKeys[i]].substring(0, 4) != "Same") {
             if (finishedEqualities[finishedKeys[i]] === "given") {
                 numberGivens--;

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -335,9 +335,6 @@ function nextStatementHint() {
         // look for something that can be proven with the statements already known
         // that is in finishedEqualities
         var tryProving = hintKeys[KhanUtil.randRange(0, hintKeys.length - 1)];
-        console.log("trying hint for " + tryProving);
-        console.log(tryProving in knownEqualities);
-        console.log(hintKeys);
 
         // awful, terrible hacky way to deal with javascript object hashes
         if (tryProving[0] === "t") {
@@ -1829,7 +1826,6 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
 // Checks to see if the two given segments are equal by checking to see if they belong to
 // congruent triangles.
 function checkSegEqual(seg1, seg2, reason) {
-    console.log("cse");
     //if this is already known
     if (eqIn([seg1, seg2], knownEqualities)) {
         return true;
@@ -2195,12 +2191,17 @@ function sortEqualityList(equalityList, equalityObject) {
             dupCheck[equalityList[i]] = true;
         }
     }
-    var sortedEqualityList = _.clone(newEqualityList);
-    for (var i = 0; i < newEqualityList.length; i++) {
-        if (equalityObject[newEqualityList[i]] === "vertical angles are equal" || equalityObject[newEqualityList[i]] === "alternate interior angles are equal") {
-            sortedEqualityList[i - 1] = newEqualityList[i];
-            sortedEqualityList[i] = newEqualityList[i - 1];
+    if(equalityObject === finishedEqualities) {
+        var sortedEqualityList = _.clone(newEqualityList);
+        for (var i = 0; i < newEqualityList.length; i++) {
+            if (equalityObject[newEqualityList[i]] === "vertical angles are equal" || equalityObject[newEqualityList[i]] === "alternate interior angles are equal") {
+                sortedEqualityList[i - 1] = newEqualityList[i];
+                sortedEqualityList[i] = newEqualityList[i - 1];
+            }
         }
+    }
+    else{
+        var sortedEqualityList = newEqualityList;
     }
 
     return sortedEqualityList;

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -22,6 +22,7 @@ var userProofDone;
 // knownEqualities is an object with key-value pairs corresponding to statement-justification pairs
 // of statements known in the course of proof to be equal
 var knownEqualities;
+var knownEqualitiesList;
 
 // finishedEqualities denotes all the equalities that should be known, and
 // the correct reasoning, at the end of the proof
@@ -62,6 +63,7 @@ function initProof(segs, angs, triangles, supplementaryAngs, altIntAngs, depth, 
     finishedEqualitiesList = [];
 
     fixedTriangles = {};
+    knownEqualitiesList = [];
 
     SEGMENTS = segs;
     ANGLES = angs;
@@ -290,7 +292,7 @@ function verifyStatementArgs(statement, reason, category) {
         }
         else if(seg1.equals(seg2) && reason === "reflexive property"){
             knownEqualities[[seg1, seg2]] = "reflexive property";
-            knownEqualities[[seg2, seg1]] = "reflexive property";  
+            knownEqualitiesList.push([seg1, seg2]);
             return true;
         }
         else if (eqIn([seg1, seg2], knownEqualities)){
@@ -451,7 +453,8 @@ function outputFinishedProof() {
 function outputKnownProof() {
     var proofText = "<h3>Givens</h3>";
 
-    var knownKeys = sortEqualityStringList(_.keys(knownEqualities), knownEqualities);
+    var knownKeysList = sortEqualityList(knownEqualitiesList, knownEqualities);
+    var knownKeys = _.map(knownKeysList, function(key){ return key.toString(); });
 
     var numberGivens = 0;
     _.each(knownKeys, function(key) {
@@ -459,8 +462,8 @@ function outputKnownProof() {
             numberGivens++;
         }
     });
-    numberGivens /= 2;
-    for (var i = 0; i < knownKeys.length; i += 2) {
+
+    for (var i = 0; i < knownKeys.length; i ++) {
         if (knownEqualities[knownKeys[i]].substring(0, 4) != "Same") {
             if (knownEqualities[knownKeys[i]] === "given") {
                 numberGivens--;
@@ -1123,6 +1126,8 @@ function traceBack(statementKey, depth) {
         finishedEqualities[statementKey.reverse()] = "given";
         finishedEqualitiesList.push(statementKey);
         finishedEqualitiesList.push(statementKey.reverse());
+        knownEqualitiesList.push(statementKey);
+        knownEqualitiesList.push(statementKey.reverse());
 
         if (statementKey[0] instanceof Triang) {
             fixedTriangles[statementKey[0]] = true;
@@ -1470,6 +1475,8 @@ function traceBack(statementKey, depth) {
                 finishedEqualities[statementKey.reverse()] = "given";
                 finishedEqualitiesList.push(statementKey);
                 finishedEqualitiesList.push(statementKey.reverse());
+                knownEqualitiesList.push(statementKey);
+                knownEqualitiesList.push(statementKey.reverse());
             }
             // otherwise, change the labeling on the triangle so that the segments given in the
             // statement key are corresponding
@@ -1542,6 +1549,8 @@ function traceBack(statementKey, depth) {
                 finishedEqualities[statementKey.reverse()] = "given";
                 finishedEqualitiesList.push(statementKey);
                 finishedEqualitiesList.push(statementKey.reverse());
+                knownEqualitiesList.push(statementKey);
+                knownEqualitiesList.push(statementKey.reverse());
             }
             // otherwise, change the labeling on the triangle so that the angles given in the
             // statement key are corresponding
@@ -1614,6 +1623,8 @@ function setGivenOrTraceBack(keys, reason, oldKey, dep) {
                 finishedEqualities[key.reverse()] = "given";
                 finishedEqualitiesList.push(key);
                 finishedEqualitiesList.push(key.reverse());
+                knownEqualitiesList.push(key);
+                knownEqualitiesList.push(key.reverse());
 
                 if (key[0] instanceof Triang) {
                     fixedTriangles[key[0]] = true;
@@ -1632,6 +1643,8 @@ function setGivenOrTraceBack(keys, reason, oldKey, dep) {
             finishedEqualities[oldKey.reverse()] = "given";
             finishedEqualitiesList.push(oldKey);
             finishedEqualitiesList.push(oldKey.reverse());
+            knownEqualitiesList.push(oldKey);
+            knownEqualitiesList.push(oldKey.reverse());
 
             if (oldKey[0] instanceof Triang) {
                 fixedTriangles[oldKey[0]] = true;
@@ -1741,6 +1754,7 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
         if (reason === "SSS") {
             knownEqualities[[triangle1, triangle2]] = "SSS";
             knownEqualities[[triangle2, triangle1]] = "SSS";
+            knownEqualitiesList.push([triangle1, triangle2]);
             return true;
         }
     }
@@ -1754,6 +1768,7 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
             if (reason === "ASA") {
                 knownEqualities[[triangle1, triangle2]] = "ASA";
                 knownEqualities[[triangle2, triangle1]] = "ASA";
+                knownEqualitiesList.push([triangle1, triangle2]);
                 return true;
             }
         }
@@ -1767,6 +1782,7 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
             if (reason === "SAS") {
                 knownEqualities[[triangle1, triangle2]] = "SAS";
                 knownEqualities[[triangle2, triangle1]] = "SAS";
+                knownEqualitiesList.push([triangle1, triangle2]);
                 return true;
             }
         }
@@ -1782,6 +1798,7 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
             if (reason === "AAS") {
                 knownEqualities[[triangle1, triangle2]] = "AAS";
                 knownEqualities[[triangle2, triangle1]] = "AAS";
+                knownEqualitiesList.push([triangle1, triangle2]);
                 return true;
             }
         }
@@ -1796,6 +1813,7 @@ function checkTriangleCongruent(triangle1, triangle2, reason) {
             if (reason === "AAS") {
                 knownEqualities[[triangle1, triangle2]] = "AAS";
                 knownEqualities[[triangle2, triangle1]] = "AAS";
+                knownEqualitiesList.push([triangle1, triangle2]);
                 return true;
             }
         }
@@ -1828,6 +1846,7 @@ function checkSegEqual(seg1, seg2, reason) {
                 if (reason === "CPCTC" || reason === "corresponding parts of congruent triangles are congruent") {
                     knownEqualities[[seg1, seg2]] = "corresponding parts of congruent triangles are congruent";
                     knownEqualities[[seg2, seg1]] = "corresponding parts of congruent triangles are congruent";
+                    knownEqualitiesList.push([seg1, seg2]);
                     return true;
                 }
             }
@@ -1856,6 +1875,7 @@ function checkAngEqual(ang1, ang2, reason) {
                 if (reason === "CPCTC" || reason === "corresponding parts of congruent triangles are congruent") {
                     knownEqualities[[ang1, ang2]] = "corresponding parts of congruent triangles are congruent";
                     knownEqualities[[ang2, ang1]] = "corresponding parts of congruent triangles are congruent";
+                    knownEqualitiesList.push([ang1, ang2]);
                     return true;
                 }
             }
@@ -1882,6 +1902,7 @@ function checkAngEqual(ang1, ang2, reason) {
             if (reason === "vertical angles" || reason === "vertical angles are equal") {
                 knownEqualities[[ang1, ang2]] = "vertical angles are equal";
                 knownEqualities[[ang2, ang1]] = "vertical angles are equal";
+                knownEqualitiesList.push([ang1, ang2]);
                 return true;
             }
         }
@@ -1892,6 +1913,7 @@ function checkAngEqual(ang1, ang2, reason) {
         if (reason === "alternate angles" || reason === "alternate interior angles are equal") {
             knownEqualities[[ang1, ang2]] = "alternate interior angles are equal";
             knownEqualities[[ang2, ang1]] = "alternate interior angles are equal";
+            knownEqualitiesList.push([ang1, ang2]);
             return true;
         }
     }

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -197,6 +197,7 @@ function verifyStatement() {
 }
 
 function verifyStatementArgs(statement, reason, category) {
+    console.log("verifyStatementArgs with ", statement, reason, category);
     if (userProofDone) {
         //return false;
     }
@@ -240,6 +241,9 @@ function verifyStatementArgs(statement, reason, category) {
         else if (triangle1Permutation != triangle2Permutation) {
             return false;
         }
+        else if (eqIn([triangle1, triangle2], knownEqualities)){
+            return "that's already in the proof!";
+        }
         else {
             toReturn = checkTriangleCongruent(triangle1, triangle2, reason);
         }
@@ -260,7 +264,9 @@ function verifyStatementArgs(statement, reason, category) {
         if (ang1 == null || ang2 == null) {
             return "those angles aren't in this figure...";
         }
-
+        else if (eqIn([ang1, ang2], knownEqualities)){
+            return "that's already in the proof!";
+        }
         else {
             toReturn = checkAngEqual(ang1, ang2, reason);
         }
@@ -283,7 +289,9 @@ function verifyStatementArgs(statement, reason, category) {
         if (seg1 == null || seg2 == null) {
             return "those segments aren't in this figure...";
         }
-
+        else if (eqIn([seg1, seg2], knownEqualities)){
+            return "that's already in the proof!";
+        }
         else {
             toReturn = checkSegEqual(seg1, seg2, reason);
         }

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -373,7 +373,7 @@ function nextStatementHint() {
         }
 
     }
-    return "Sorry, no hint for now >:[";
+    return "Sorry, there seems to be a problem with the hint system. Please report this bug.";
 }
 
 
@@ -382,8 +382,9 @@ function nextStatementHint() {
 function outputFinishedProof() {
     var proofText = "<h3>Givens</h3>";
 
-    var unsortedKeyList = _.map(finishedEqualitiesList, function(key) { return key.toString(); });
-    var finishedKeys = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
+    var unsortedKeyList = _.clone(finishedEqualitiesList);
+    var finishedKeysList = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
+    var finishedKeys = _.map(finishedKeysList, function(key) { return key.toString(); });
 
     var possibleValids = [];
 
@@ -432,7 +433,7 @@ function outputFinishedProof() {
 function outputKnownProof() {
     var proofText = "<h3>Givens</h3>";
 
-    var knownKeys = sortEqualityList(_.keys(knownEqualities), knownEqualities);
+    var knownKeys = sortEqualityStringList(_.keys(knownEqualities), knownEqualities);
 
     var numberGivens = 0;
     _.each(knownKeys, function(key) {
@@ -478,8 +479,9 @@ function outputFillBlanksProof() {
     var blanks = 0;
     var blankStatements = 0;
 
-    var unsortedKeyList = _.map(finishedEqualitiesList, function(key) { return key.toString(); });
-    var finishedKeys = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
+    var unsortedKeyList = _.clone(finishedEqualitiesList);
+    var finishedKeysList = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
+    var finishedKeys = _.map(finishedKeysList, function(key) { return key.toString(); });
 
     var numberGivens = 0;
     _.each(finishedKeys, function(key) {
@@ -487,11 +489,10 @@ function outputFillBlanksProof() {
             numberGivens++;
         }
     });
-    numberGivens /= 2;
 
     var newEqualities = {};
 
-    for (var i = 0; i < finishedKeys.length; i += 2) {
+    for (var i = 0; i < finishedKeys.length; i++) {
         if (finishedEqualities[finishedKeys[i]].substring(0, 4) != "Same") {
             if (finishedEqualities[finishedKeys[i]] === "given") {
                 numberGivens--;
@@ -574,7 +575,7 @@ function checkFillBlanksStatement(divID) {
     // for now, hardcode these
     var equivAngles = {"BAE" : "BAC", "EAB" : "CAB", "DAE" : "DAC", "EAD" : "CAD", "ABD" : "ABC", "DBA" : "CBA", "EBD" : "EBC", "DBE" : "CBE",
                         "BEA" : "BEC", "AEB" : "CEB", "DEA" : "DEC", "AED" : "CED", "BDE" : "CDE", "EDB" : "EDC", "ADB" : "ADC", "BDA" : "CDA"};
-    var unsortedKeyList = _.map(finishedEqualitiesList, function(key) { return _.clone(key); });
+    var unsortedKeyList = _.clone(finishedEqualitiesList);
     var finishedKeys = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
 
     var components = divID.split("-");
@@ -687,7 +688,7 @@ function checkFillBlanksReason(select, selectID) {
 // for fill-in-the-blanks proofs, this hint function looks for the next missing reason, and generate a hint based
 // on that using nextStatementHint()
 function getFillBlanksHint(giveAway) {
-    var unsortedKeyList = _.map(finishedEqualitiesList, function(key) { return _.clone(key); });
+    var unsortedKeyList = _.clone(finishedEqualitiesList);
     var finishedKeys = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
 
     if (!giveAway) {
@@ -701,6 +702,17 @@ function getFillBlanksHint(giveAway) {
             var beforeEqualities = {};
             for (var i = 0; i < finishedKeys.length; i++) {
                 beforeEqualities[finishedKeys[i]] = finishedEqualities[finishedKeys[i]];
+            }
+            for (var i = 0; i < SEGMENTS.length; i++) {
+                beforeEqualities[[SEGMENTS[i], SEGMENTS[i]]] = "Same segment";
+            }
+
+            for (var i = 0; i < ANGLES.length; i++) {
+                beforeEqualities[[ANGLES[i], ANGLES[i]]] = "Same angle";
+            }
+
+            for (var i = 0; i < TRIANGLES.length; i++) {
+                beforeEqualities[[TRIANGLES[i], TRIANGLES[i]]] = "Same triangle";
             }
 
             if (components[0] === "t") {
@@ -906,7 +918,7 @@ function outputBadProof() {
 
     // now construct the proof we want to hand to the exercise
     var proofText = "<h3>Givens</h3>";
-    var knownKeys = sortEqualityList(_.keys(knownEqualities), knownEqualities);
+    var knownKeys = sortEqualityStringList(_.keys(knownEqualities), knownEqualities);
 
     var numberGivens = 0;
     _.each(knownKeys, function(key) {
@@ -1443,7 +1455,7 @@ function traceBack(statementKey, depth) {
                 var trianglePair = newTriangles[KhanUtil.randRange(0, newTriangles.length - 1)];
 
                 // there has to be a better way of doing this
-                // _indexOf doesn't work (because of === issues?)
+                // _.indexOf doesn't work (because of === issues?)
                 var index1;
                 for (var i = 0; i < trianglePair[0].segs.length; i++) {
                     if (trianglePair[0].segs[i].equals(seg1)) {
@@ -1918,7 +1930,7 @@ function checkTriangleForHint(triangle1, triangle2, equalityObject) {
             && eqIn([triangle1.angs[(i + 1) % 3], triangle2.angs[(i + 1) % 3]], equalityObject)
             && eqIn([triangle1.segs[(i + 2) % 3], triangle2.segs[(i + 2) % 3]], equalityObject)) {
             return [[triangle1.angs[i], triangle2.angs[i]],
-             [triangle1.segs[(i + 2) % 3], triangle2.segs[(i + 2) % 3]], [triangle1.segs[(i + 2) % 3], triangle2.segs[(i + 2) % 3]]];
+             [triangle1.angs[(i + 1) % 3], triangle2.angs[(i + 1) % 3]], [triangle1.segs[(i + 2) % 3], triangle2.segs[(i + 2) % 3]]];
         }
     }
 
@@ -1944,13 +1956,27 @@ function checkSegForHint(seg1, seg2, equalityObject) {
     //     return [];
     // }
 
-
     for (var i = 0; i < seg1.triangles.length; i++) {
         for (var j = 0; j < seg2.triangles.length; j++) {
+            var index1;
+            for (var k = 0; k < seg1.triangles[i][0].segs.length; k++) {
+                if (seg1.triangles[i][0].segs[k].equals(seg1)) {
+                    index1 = k;
+                }
+            }
+
+            var index2;
+            for (var k = 0; k < seg2.triangles[j][0].segs.length; k++) {
+                if (seg2.triangles[j][0].segs[k].equals(seg2)) {
+                    index2 = k;
+                }
+            }
+
             // if the segments' corresponding triangles are congruent AND they're the same part of those triangles, we add
             // to the known equalities
             if (eqIn([seg1.triangles[i][0], seg2.triangles[j][0]], equalityObject)
-                && _.indexOf(seg1, seg1.triangles[i][0].segs) === _.indexOf(seg2, seg2.triangles[j][0].segs)) {
+                && index1 === index2) {
+
                 return [seg1.triangles[i][0], seg2.triangles[j][0]];
             }
         }
@@ -1969,8 +1995,23 @@ function checkAngForHint(ang1, ang2, equalityObject) {
     // to the known
     for (var i = 0; i < ang1.triangles.length; i++) {
         for (var j = 0; j < ang2.triangles.length; j++) {
+
+            var index1;
+            for (var k = 0; k < ang1.triangles[i][0].angs.length; k++) {
+                if (ang1.triangles[i][0].angs[k].equals(ang1)) {
+                    index1 = k;
+                }
+            }
+
+            var index2;
+            for (var k = 0; k < ang2.triangles[j][0].angs.length; k++) {
+                if (ang2.triangles[j][0].angs[k].equals(ang2)) {
+                    index2 = k;
+                }
+            }
+
             if (eqIn([ang1.triangles[i][0], ang2.triangles[j][0]], equalityObject)
-                && _.indexOf(ang1, ang1.triangles[i][0].angs) === _.indexOf(ang2, ang2.triangles[j][0].angs)) {
+                && index1 === index2) {
                 return [ang1.triangles[i][0], ang2.triangles[j][0]];
             }
         }
@@ -2097,6 +2138,30 @@ function triangIn(item, object) {
 // also, since we add the vertical angles and alternate angles before the triangles they prove, we need to move these
 // forward in the list
 function sortEqualityList(equalityList, equalityObject) {
+    var dupCheck = {};
+    var newEqualityList = [];
+    for (var i = 0; i < equalityList.length; i++) {
+        if (equalityObject[equalityList[i]] === "given" && !(equalityList[i] in dupCheck || equalityList[i].reverse() in dupCheck)) {
+            newEqualityList.unshift(equalityList[i]);
+            dupCheck[equalityList[i]] = true;
+        }
+        else if(!(equalityList[i] in dupCheck || equalityList[i].reverse() in dupCheck)) {
+            newEqualityList.push(equalityList[i]);
+            dupCheck[equalityList[i]] = true;
+        }
+    }
+    var sortedEqualityList = _.clone(newEqualityList);
+    for (var i = 0; i < newEqualityList.length; i++) {
+        if (equalityObject[newEqualityList[i]] === "vertical angles are equal" || equalityObject[newEqualityList[i]] === "alternate interior angles are equal") {
+            sortedEqualityList[i - 1] = newEqualityList[i];
+            sortedEqualityList[i] = newEqualityList[i - 1];
+        }
+    }
+
+    return sortedEqualityList;
+}
+
+function sortEqualityStringList(equalityList, equalityObject) {
     var newEqualityList = [];
     for (var i = 0; i < equalityList.length; i++) {
         if (equalityObject[equalityList[i]] === "given") {

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -496,7 +496,12 @@ function outputFillBlanksProof() {
         if (finishedEqualities[finishedKeys[i]].substring(0, 4) != "Same") {
             if (finishedEqualities[finishedKeys[i]] === "given") {
                 numberGivens--;
-                proofText += "<div style=\"float:left\" class=\"" + divName(finishedKeys[i]) + "\">";
+                if(i % 3 != 2){
+                    proofText += "<div style=\"float:left\" class=\"" + divName(finishedKeys[i]) + "\">";
+                } 
+                else{
+                    proofText += "<div style=\"float:left\" class=\"" + divName(finishedKeys[i]) + "\">";
+                }
                 proofText += prettifyEquality(finishedKeys[i]);
                 if (numberGivens > 1) {
                     proofText += "<code>, \\ </code> </div>";
@@ -573,8 +578,7 @@ function outputFillBlanksProof() {
 // returns true if the statements were filled in correctly, false otherwise
 function checkFillBlanksStatement(divID) {
     // for now, hardcode these
-    var equivAngles = {"BAE" : "BAC", "EAB" : "CAB", "DAE" : "DAC", "EAD" : "CAD", "ABD" : "ABC", "DBA" : "CBA", "EBD" : "EBC", "DBE" : "CBE",
-                        "BEA" : "BEC", "AEB" : "CEB", "DEA" : "DEC", "AED" : "CED", "BDE" : "CDE", "EDB" : "EDC", "ADB" : "ADC", "BDA" : "CDA"};
+    var equivAngles = {"ADE" : "BDE", "BDF" : "BDE", "ADF" : "BDE", "BAF" : "BAC", "DAC" : "BAC", "DAF" : "BAC", "CFD" : "CFE", "AFE" : "CFE", "AFD" : "CFE"};
     var unsortedKeyList = _.clone(finishedEqualitiesList);
     var finishedKeys = sortEqualityList(unsortedKeyList.reverse(), finishedEqualities);
 

--- a/utils/proofs.js
+++ b/utils/proofs.js
@@ -2075,9 +2075,9 @@ function divName(equalityString) {
             return _.difference(equalityString.substring(12, 23).split(""), triang.toString().split("")).length === 0;
         });
 
-        return triangle1.segs[0].toString().substring(3, 5) + "-" + triangle1.segs[1].toString().substring(3, 5) + "-"
-        + triangle1.segs[2].toString().substring(3, 5) + "-" + triangle2.segs[0].toString().substring(3, 5) + "-"
-        + triangle2.segs[1].toString().substring(3, 5) + "-" + triangle2.segs[2].toString().substring(3, 5);
+        return triangle1.segs[0].toString().substring(3, 5) + " " + triangle1.segs[1].toString().substring(3, 5) + " "
+        + triangle1.segs[2].toString().substring(3, 5) + " " + triangle2.segs[0].toString().substring(3, 5) + "2 "
+        + triangle2.segs[1].toString().substring(3, 5) + "2 " + triangle2.segs[2].toString().substring(3, 5) + "2";
     }
 }
 


### PR DESCRIPTION
Removed references to the proof framework in the highlighting exercise code (no more "cannot find property segs of undefined"). 

Also fixed a bunch of problems where proofs would duplicate a statement multiple times and hints were wrong or non-existent (with the fill-in-the-blanks exercise).
