### PR TITLE
Accept inexact answers for area computations using z-scores.

### DIFF
--- a/exercises/mean_median_and_mode.html
+++ b/exercises/mean_median_and_mode.html
@@ -69,7 +69,7 @@
                     <div class="number-list"><code><var>INTEGER_LIST</var></code></div>
                 </div>
 
-                <p class="solution"><var>MEAN</var></p>
+                <p class="solution" data-inexact data-max-error="0.01"><var>MEAN</var></p>
 
                 <div class="hints">
                     <p>To find the mean, add all the numbers and then divide by the number of numbers.</p>

--- a/exercises/z_scores_2.html
+++ b/exercises/z_scores_2.html
@@ -69,7 +69,7 @@
             <div class="fake_row reading" data-each="ROWS as i, row">
                 <span><var>row</var></span><span data-each="ZGRID[i] as j, zgrid"><var>zgrid</var></span>
             </div>
-            <div class="solution" data-forms="percent">
+            <div class="solution" data-inexact data-max-error="0.01" data-forms="percent">
                 <span><var>roundTo(2, ANSWER * 100)</var></span>
             </div>
 

--- a/exercises/z_scores_3.html
+++ b/exercises/z_scores_3.html
@@ -106,7 +106,7 @@
             <div class="fake_row reading" data-each="ROWS as i, row">
                 <span><var>row</var></span><span data-each="ZGRID[i] as j, zgrid"><var>zgrid</var></span>
             </div>
-            <div class="solution" data-forms="percent">
+            <div class="solution" data-inexact data-max-error="0.01" data-forms="percent">
                 <span><var>roundTo( 2, ANSWER * 100 )</var></span>
             </div>
 


### PR DESCRIPTION
In math and statistics courses, many students are taught to use graphing calculators or other
technology, rather than tables, to compute areas under the normal curve.  These will differ
in the last digit frequently from the approximate z-tables, leading to incorrectly reported errors in
the exercises.
This fixes the issue by accepting the correctly rounded technology produced answer.
