### PR TITLE
Remove our 3-layer redundant snapping

### DIFF
--- a/utils/interactive.js
+++ b/utils/interactive.js
@@ -306,21 +306,6 @@ $.extend(KhanUtil, {
                         mouseX = Math.max(10, Math.min(graph.xpixels - 10, mouseX));
                         mouseY = Math.max(10, Math.min(graph.ypixels - 10, mouseY));
 
-                        // snap to grid
-                        if (movablePoint.snapX) {
-                            mouseX = Math.round(mouseX / (graph.scale[0] * movablePoint.snapX)) * (graph.scale[0] * movablePoint.snapX);
-                        }
-                        if (movablePoint.snapY) {
-                            mouseY = Math.round(mouseY / (graph.scale[1] * movablePoint.snapY)) * (graph.scale[1] * movablePoint.snapY);
-                        }
-                        // snap mouse to grid
-                        if (movablePoint.snapX !== 0) {
-                            mouseX = Math.round(mouseX / (graph.scale[0] * movablePoint.snapX)) * (graph.scale[0] * movablePoint.snapX);
-                        }
-                        if (movablePoint.snapY !== 0) {
-                            mouseY = Math.round(mouseY / (graph.scale[1] * movablePoint.snapY)) * (graph.scale[1] * movablePoint.snapY);
-                        }
-
                         // coord{X|Y} are the scaled coordinate values
                         var coordX = mouseX / graph.scale[0] + graph.range[0][0];
                         var coordY = graph.range[1][1] - mouseY / graph.scale[1];


### PR DESCRIPTION
For some reason, we perform snapping 3 times, instead of the required 1.
This apparently leads to some problems. I'm not sure why these problems
occur, but they do, and this fixes them.

Closes 31738, 31739

@beneater
