### PR TITLE
Fix radio answer-types in IE8

### DIFF
--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1090,7 +1090,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                 }
                 // Wrap each of the choices in elements and add a radio button
                 choice.contents()
-                    .wrapAll('<li><label><span class="value">')
+                    .wrapAll('<li><label><span class="value"></span></label></li>')
                     .parent()
                     .before(
                         $('<input type="radio" name="solution">')


### PR DESCRIPTION
Apparently you need to close tags within jQuery's wrapAll function, so having them removed broke this in IE8.

@beneater
