### PR TITLE
Multistep equations with distribution - fix solving step

### DIFF
--- a/exercises/multistep_equations_with_distribution.html
+++ b/exercises/multistep_equations_with_distribution.html
@@ -98,7 +98,7 @@
                         <var>A</var> &amp;=&amp;
                         \blue{<var>expr(["+", ["*", B, X], ["*", C * D, X]])</var>} + <var>C * E</var> \\ \\
                         <var>A</var> &amp;=&amp;
-                        \blue{<var>expr(["*", B + C * D, X])</var>} + <var>B * C</var>
+                        \blue{<var>expr(["*", B + C * D, X])</var>} + <var>C * E</var>
                         \end{eqnarray}
                     </code></p>
                 </div>


### PR DESCRIPTION
"Combine the X terms" should not change "C \* E" (copy & paste bug)
