### PR TITLE
Fix exercise: Multi-step equations hint

### DIFF
--- a/exercises/multistep_equations_with_distribution.html
+++ b/exercises/multistep_equations_with_distribution.html
@@ -425,7 +425,7 @@
                         left side:
                     </p>
                     <p><code>\qquad\begin{eqnarray}
-                        <var>expr(["*", (A * B) - (D * F + G), X])</var> + \green{<var>A * C</var>} &amp;=&amp;
+                        <var>expr(["*", (A * B) - (D * F + G), X])</var> \green{{} + <var>A * C</var>} &amp;=&amp;
                         <var>D * E</var> \\ \\
 
                         \green{{}+<var>-A * C</var>} &amp;&amp;


### PR DESCRIPTION
Fixed this one to match the others. The operation needs to be inside the green bracket. It now shows as `3x - 4` as opposed to `3x + - 4`
