### PR TITLE
Fix issue #33473, allow white space in expressions involving subtraction

### DIFF
--- a/exercises/combining_like_terms_1.html
+++ b/exercises/combining_like_terms_1.html
@@ -14,12 +14,12 @@
         <var id="C">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 20))</var>
         <var id="D" data-ensure="abs( C ) !== abs( D )">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 12))</var>
         <var id="TERM_AX">
-            "(?:" + (A &lt; 0 ? "[-\\u2212]" : "") + abs(A)
+            "(?:" + (A &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(A)
             + (A === 1 ? "|" : "" ) + (A === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>
         <var id="TERM_AX_BX">
-            "(?:" + ((A + B) &lt; 0 ? "[-\\u2212]" : "") + abs(A + B)
+            "(?:" + ((A + B) &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(A + B)
             + (A + B === 1 ? "|" : "" ) + (A + B === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>

--- a/exercises/combining_like_terms_1.html
+++ b/exercises/combining_like_terms_1.html
@@ -29,7 +29,7 @@
     <div class="problems">
         <div id="ax_bx">
             <div class="vars">
-                <var id="SOLUTIONS">[TERM_AX_BX]</span>
+                <var id="SOLUTIONS">[TERM_AX_BX]</var>
             </div>
             <p class="question">
                 Simplify the following expression:

--- a/exercises/combining_like_terms_2.html
+++ b/exercises/combining_like_terms_2.html
@@ -19,27 +19,27 @@
         <var id="E" data-ensure="E !== 1">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 10))</var>
         <var id="F" data-ensure="F !== 1">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 10))</var>
         <var id="TERM_AX">
-            "(?:" + (A &lt; 0 ? "[-\\u2212]" : "") + abs(A)
+            "(?:" + (A &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(A)
             + (A === 1 ? "|" : "" ) + (A === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>
         <var id="TERM_FBX">
-            "(?:" + ((F * B) &lt; 0 ? "[-\\u2212]" : "") + abs(F * B)
+            "(?:" + ((F * B) &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(F * B)
             + (F * B === 1 ? "|" : "" ) + (F * B === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>
         <var id="TERM_AX_BX">
-            "(?:" + ((A + B) &lt; 0 ? "[-\\u2212]" : "") + abs(A + B)
+            "(?:" + ((A + B) &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(A + B)
             + (A + B === 1 ? "|" : "" ) + (A + B === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>
         <var id="TERM_AX_FBX">
-            "(?:" + ((A + F * B) &lt; 0 ? "[-\\u2212]" : "") + abs(A + F * B)
+            "(?:" + ((A + F * B) &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(A + F * B)
             + (A + F * B === 1 ? "|" : "" ) + (A + F * B === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>
         <var id="TERM_EAX_FBX">
-            "(?:" + ((E * A + F * B) &lt; 0 ? "[-\\u2212]" : "") + abs(E * A + F * B)
+            "(?:" + ((E * A + F * B) &lt; 0 ? "[-\\u2212]\\s*" : "") + abs(E * A + F * B)
             + (E * A + F * B === 1 ? "|" : "" ) + (E * A + F * B === -1 ?
             "|[-\\u2212]" : "") + ")\\s*" + X
         </var>

--- a/exercises/factoring_difference_of_squares_3.html
+++ b/exercises/factoring_difference_of_squares_3.html
@@ -16,11 +16,11 @@
                     <var id="SQUARE">A * A</var>
                     <var id="CONSTANT">-B * B</var>
                     <var id="TERM1">F</var>
-                    <var id="TERM1N">"[-\\u2212]" + F</var>
+                    <var id="TERM1N">"[-\\u2212]\\s*" + F</var>
                     <var id="TERM2">"\\(\\s*" + A + "\\s*[xX]\\s*\\+\\s*" + B + "\\s*\\)"</var>
-                    <var id="TERM2N">"\\(\\s*[-\\u2212]" + A + "\\s*[xX]\\s*[-\\u2212]\\s*" + B + "\\s*\\)"</var>
+                    <var id="TERM2N">"\\(\\s*[-\\u2212]\\s*" + A + "\\s*[xX]\\s*[-\\u2212]\\s*" + B + "\\s*\\)"</var>
                     <var id="TERM3">"\\(\\s*" + A + "\\s*[xX]\\s*[-\\u2212]\\s*" + B + "\\s*\\)"</var>
-                    <var id="TERM3N">"\\(\\s*[-\\u2212]" + A + "\\s*[xX]\\s*\\+\\s*" + B + "\\s*\\)"</var>
+                    <var id="TERM3N">"\\(\\s*[-\\u2212]\\s*" + A + "\\s*[xX]\\s*\\+\\s*" + B + "\\s*\\)"</var>
                 </div>
                 <div>
                     <p class="question">

--- a/exercises/factoring_linear_binomials.html
+++ b/exercises/factoring_linear_binomials.html
@@ -28,7 +28,7 @@
                         toSentenceTex(getFactors(abs(B)))
                     </var>
                     <var id="TERM1">GCD</var>
-                    <var id="TERM1N">"[-\\u2212]" + GCD</var>
+                    <var id="TERM1N">"[-\\u2212]\\s*" + GCD</var>
                     <var id="TERM2">"(?:" + (A &lt; 0 ? "[-\\u2212]" : "") + abs(A / GCD) + (A / GCD === 1 ? "|" : "" ) + (A / GCD === -1 ? "|[-\\u2212]" : "") + ")\\s*x"</var>
                     <var id="TERM2N">"(?:" + (A &gt; 0 ? "[-\\u2212]" : "") + abs(A / GCD) + (A / GCD === -1 ? "|" : "" ) + (A / GCD === 1 ? "|[-\\u2212]" : "") + ")\\s*x"</var>
                     <var id="TERM3">(B &lt; 0 ? "[-\\u2212]" : "\\+") + "\\s*" + abs(B / GCD)</var>


### PR DESCRIPTION
13-2v or 13 -2v was being accepted, but 13 - 2v was not.
https://github.com/Khan/khan-exercises/issues/33473
