### PR TITLE
Fraction support for Converting Between Point-Slope and Standard Form

### DIFF
--- a/exercises/converting_between_point_slope_and_standard_form.html
+++ b/exercises/converting_between_point_slope_and_standard_form.html
@@ -38,9 +38,14 @@
                     [ $( '#solution_x' ).val(), $( '#solution_y' ).val(), $( '#solution_m' ).val() ]
                 </div>
                 <div class="validator-function">
-                    var answer_x = guess[ 0 ];
-                    var answer_y = guess[ 1 ];
-                    var answer_slope = guess[ 2 ];
+                     var toDecimal = function(inputString) {
+                        if (inputString.indexOf('/') >= 0) return inputString.split('/')[0] / inputString.split('/')[1];
+                        else                               return inputString;
+                    }
+                
+                    var answer_x = toDecimal( guess[ 0 ] );
+                    var answer_y = toDecimal( guess[ 1 ] );
+                    var answer_slope = toDecimal( guess[ 2 ] );
                     return abs( ( ( C - A * answer_x ) / B ) - answer_y ) &lt; 0.001 &amp;&amp; abs( answer_slope - SLOPE ) &lt; 0.001;
                 </div>
                 <div class="show-guess-solutionarea">


### PR DESCRIPTION
Adds basic support for fractions in the Converting Between Point-Slope and Standard Form exercise.

It could be nice to generalize the fraction parser in the `number` function in answer-types.js and move it into the Math utilities library so it can be called from a custom validation function like this one.
