### PR TITLE
Added graphs_of_inverse_trig_functions exercise.

### DIFF
--- a/exercises/graphs_of_inverse_trig_functions.html
+++ b/exercises/graphs_of_inverse_trig_functions.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html data-require="math graphie math-format">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Graphs of inverse trig functions</title>
+    <script src="../khan-exercise.js"></script>
+    <script type="text/javascript">
+        function decFrac( num ) {
+            return KhanUtil.decimalFraction( num, true, true, true );
+        }
+    </script>
+    <style type="text/css">
+        #answer_area input[type=text] {
+            width: 25px;
+        }
+    </style>
+</head>
+<body>
+    <div class="exercise">
+        <div class="vars">
+            <var id="HSCALE">random() &lt; 0.5 ? randRange( 1, 4 ) : 1 / randRange( 1, 4 )</var>
+
+            <var id="VRANGE">3.5</var>
+            <var id="HRANGE">3.5 * PI * HSCALE</var>
+
+            <var id="PIXVSCALE">150 / VRANGE</var>
+            <var id="PIXHSCALE">250 / HRANGE</var>
+
+            <!-- this is the distance between grid lines -->
+            <var id="HSTEP">HSCALE * PI / 4</var>
+            <var id="VSTEP">0.5</var>
+
+            <!-- this is how many grid lines are between each tick mark -->
+            <var id="HTICKSTEP">2</var>
+            <var id="VTICKSTEP">1</var>
+
+            <!-- this is how many grid lines there are between each grid label -->
+            <var id="HLABELSTEP">4</var>
+            <var id="VLABELSTEP">2</var>
+
+        </div>
+
+        <div class="problems">
+            
+            <!-- test knowledge of secant and cosecant graphs-->
+            <div id="sec_csc" data-weight="2">
+				<div class="vars">
+				    <var id="FN">randFromArray( [ "sin", "cos" ] )</var>
+				    <var id="REALFN">{ "sin": "csc", "cos": "sec"}[FN] </var>
+            		<var id="FNS">{ "sin": "cosecant", "cos": "secant"}[FN]</var>
+            		<var id="PERIOD">2 * PI * HSCALE</var>
+            		<var id="FUNCS"> "1/(" + FN + "(x/" + HSCALE + "))"</var>
+				</div>
+                <div class="problem">
+                    <p><code>f(x)</code> is graphed below.</p>
+                    <div id="graph" class="graphie">
+                        graphInit({
+                            range: [ HRANGE, VRANGE ],
+                            scale: [ PIXHSCALE, PIXVSCALE ],
+                            axisArrows: "<->",
+                            gridStep: [ HSCALE * PI / 4, .5 ],
+                            tickStep: [ 2, 1 ],
+                            labelStep: [ 2, 2 ],
+                            unityLabels: true,
+                            xLabelFormat: piFraction
+                        });
+
+                        // draw sec/csc curve
+                        style({
+                            stroke: "#a3a3ff",
+                             strokeWidth: 2
+                        }, function() {
+                            plot( function( x ) {
+                                return eval( FUNCS );
+                            }, [ -HRANGE, HRANGE ] );
+                        });
+                    </div>
+                </div>
+
+                <p class="question">What is <code>f(x)</code>?</p>
+
+                <div class="solution" data-type="multiple"><div style="font-size: 11px;">
+                    <code>f(x)=</code>
+                    <!-- we make the default fn type blank so users don't think the default value of sin or cos is important, not sure if this is necessary, though -->
+                    <span class="sol" data-type="list" data-choices="['', 'csc', 'sec', 'cot']"><var>REALFN</var></span>
+                    <code>(</code><span class="sol short" data-fallback="1"><var>1 / HSCALE</var></span><code>x)</code>
+                </div></div>
+				
+				<div class="hints">
+					<p> <code> \csc(x) </code> is the inverse of <code> \sin(x) </code>, <code>\sec(x) </code> is the inverse of <code> \cos(x) </code>, and <code> \cot(x) </code> is the inverse of <code> \tan(x) </code>. </p>
+					<div data-if="FN === 'cos'" data-unwrap>
+		
+						<p>The function reaches a relative minimum at 0 (ie, <code>f(0)= 1</code>), so what kind of function is it?</p>
+		
+						<p>The cosine function, <code>\cos(x)</code>, reaches its maximum at 0, so it's inverse must reach its relative minimum at 0. Thus, <code>f(x)</code> must be a scaled version of the sec function.</p>
+		
+					</div>
+		
+					<div data-else data-unwrap>
+		
+						<p>The function has an asymptote at 0 and relative minima/ maxima in every period, so what kind of function is it?</p>
+		
+						<p>The sine function, <code>\sin(x)</code>, starts at 0 (ie, <code>\sin(0)=0</code>), so it's inverse must have an asymptote at 0. Also, the sine function has a relative minimum value and maximum value
+						in every period, so it's inverse will have minimum and maximum values too. Thus, <code>f(x)</code> must be a scaled version of the csc function.</p>
+		
+					</div>
+		
+					<div>
+						<div class="graphie" data-update="graph">
+							style({
+								stroke: "#00d505",
+								strokeWidth: 2
+							}, function() {
+								plot( function( x ) {
+									return eval( FUNCS );
+								}, [ 0, PERIOD ] );
+								line( [ 0, 0 ], [ PERIOD , 0 ], { arrows: "&lt;-&gt;" });
+							});
+						</div>
+						<p data-if="FN === 'cos'">The distance from minimum to minimum is <code><var>piFraction( PERIOD )</var></code>, so the period of <code>f(x)</code> is <code><var>piFraction( PERIOD )</var></code>.</p>
+						<p data-else>The distance between every other asymptote to <code> \infty </code> is <code><var>piFraction( PERIOD )</var></code>, so the period of <code>f(x)</code> is <code><var>piFraction( PERIOD )</var></code>.</p>
+					</div>
+		
+					<div data-if="abs( PERIOD - 2 * PI ) < 0.01" data-unwrap>
+						<p>The period of a normal <var>FNS</var> function is <code>2\pi</code>, and the period we want is <code><var>piFraction( PERIOD )</var></code>, so we don't need to worry about scaling the function horizontally.</p>
+					</div>
+		
+					<div data-else data-unwrap>
+		
+						<p>The period of a normal <var>FNS</var> function is <code>2\pi</code>, and the period we want is <code><var>piFraction( PERIOD )</var></code>, so we need to scale the <var>FNS</var> function horizontally by <code><var>decFrac( PERIOD / 2 / PI )</var></code>.</p>
+		
+						<p>To horizontally scale <code>\<var>REALFN</var>(x)</code> by <code><var>decFrac( PERIOD / 2 / PI )</var></code>, we need to substitute <code><var>decFrac( 2 * PI / PERIOD )</var>x</code> in for <code>x</code> to get <code>\<var>REALFN</var>(<var>decFrac( 2 * PI / PERIOD )</var>x)</code>.</p>
+		
+					</div>				
+		
+					<!-- the calls to plus here are to reduce things like 1cos(1x) into cos(x). it works, but it is not the most semantic way. could be improved. -->
+					<p>So the resulting function (after we perform all these manipulations) is <code><var>"\\" + REALFN + "(" + plus( toFractionTex( 1 / HSCALE ) + "x" ) + ")"</var></code>.</p>
+				</div>
+            
+           </div>
+           
+           <!-- test knowledge of cotangent graphs-->
+           <div id="cot" data-weight="1">
+           		<div class="vars">
+           		    <var id="FN">"tan"</var>
+           		    <var id="REALFN">"cot"</var>
+            		<var id="FNS">{ "tan": "cotangent"}[FN]</var>
+            		<var id="PERIOD"> PI * HSCALE</var>
+            		<var id="FUNCS"> "1/(" + FN + "(x/" + HSCALE + "))"</var>
+           		</div>
+				<div class="problem">
+                    <p><code>f(x)</code> is graphed below. Asymptotes are shown in blue.</p>
+                    <div id="graph" class="graphie">
+                        graphInit({
+                            range: [ HRANGE, VRANGE ],
+                            scale: [ PIXHSCALE, PIXVSCALE ],
+                            axisArrows: "<->",
+                            gridStep: [ HSCALE * PI / 4, .5 ],
+                            tickStep: [ 2, 1 ],
+                            labelStep: [ 2, 2 ],
+                            unityLabels: true,
+                            xLabelFormat: piFraction
+                        });
+
+                        // draw cot curve
+                        style({
+                            stroke: "#9400d3",
+                             strokeWidth: 2
+                        }, function() {
+                            plot( function( x ) {
+                                return eval( FUNCS);
+                            }, [ -HRANGE, HRANGE ] );
+                            
+                        });
+                        
+                        style({
+                        	stroke: "#00bbff",
+                        	strokeWidth: 2
+                        }, function() {
+                        	plotAsymptotes( function( x ){
+                            	return eval (FUNCS);
+                            }, [-HRANGE, HRANGE]);
+                        });
+                    </div>
+                </div>
+                
+                <p class="question">What is <code>f(x)</code>?</p>
+                
+                <div class="solution" data-type="multiple"><div style="font-size: 11px;">
+                    <code>f(x)=</code>
+                    <!-- we make the default fn type blank so users don't think the default value of sin or cos is important, not sure if this is necessary, though -->
+                    <span class="sol" data-type="list" data-choices="['', 'csc', 'sec', 'cot']"><var>REALFN</var></span>
+                    <code>(</code><span class="sol short" data-fallback="1"><var>1 / HSCALE</var></span><code>x)</code>
+                </div></div>
+				
+				<div class="hints">
+
+					<p> <code> \csc(x) </code> is the inverse of <code> \sin(x) </code>, <code>\sec(x) </code> is the inverse of <code> \cos(x) </code>, and <code> \cot(x) </code> is the inverse of <code> \tan(x) </code>. </p>
+					
+					<p> This inverse trig function has multiple 0's. This means that the original trig function must have multiple asymptotes to infinity. What is the inverse of a trig function with asymptotes? </p> 
+										
+					<p> In each period, tan(x) approaches <code> \infty </code> at one asymptote and <code> -\infty </code> at the other. 
+					Thus, its inverse, will include recurring 0's. Since this pattern appears above, <code> f(x) </code> is a cotangent function. </p>
+					
+					<div>
+						<div class="graphie" data-update="graph">
+							style({
+								stroke: "#00d505",
+								strokeWidth: 2
+							}, function() {
+								plot( function( x ) {
+									return eval( FUNCS );
+								}, [ 0, PERIOD ] );
+								line( [0, 0 ], [ PERIOD , 0 ], { arrows: "&lt;-&gt;" });
+							});
+						</div>
+						
+						<p data-if="HSCALE==1">The distance between every two asymptotes is <code> \pi</code> so the period of <code>f(x)</code> is <code> \pi </code>.
+						<p data-else> The distance between every two asymptotes is <code> <var>piFraction( PERIOD) </var></code> so the period of <code>f(x)</code> is <code> <var>piFraction(PERIOD) </var></code>
+						</p>
+					</div>
+		
+					<div data-if="abs( PERIOD - PI ) < 0.01" data-unwrap>
+		
+						<p>The period of a normal cotangent function is <code>\pi</code>, and the period we want is <code>\pi</code>, so we don't need to worry about scaling the function horizontally.</p>
+						<p> Then the desired cotangent function is <code> \cot(x) </code>. </p>
+					</div>
+		
+					<div data-else data-unwrap>
+		
+						<p>The period of a normal cotangent function is <code>\pi</code>, and the period we want is <code><var>piFraction( PERIOD )</var></code>, so we need to scale the cotangent function horizontally by <code><var>decFrac( PERIOD /  PI )</var></code>.</p>
+		
+						<p>To horizontally scale <code>\cot(x)</code> by <code><var>decFrac( PERIOD / PI )</var></code>, we need to substitute <code><var>decFrac( PI / PERIOD )</var>x</code> in for <code>x</code> to get <code>\cot(<var>decFrac(  PI / PERIOD )</var>x)</code>.</p>
+		
+					</div>
+					
+				</div>
+			</div>           
+           </div>
+            
+        </div>
+
+        
+</body>
+</html>


### PR DESCRIPTION
Added exercise to test identification of csc, sec, and cot functions. This is modeled after graphs_of_sine_and_cosine.html. I made this exercise in response to Trello card 493: https://trello.com/c/bSV0mTTd
