### PR TITLE
New exercise: Missing side length in rectangle-composite shapes

### DIFF
--- a/exercises/rectangle_perimeter_2.html
+++ b/exercises/rectangle_perimeter_2.html
@@ -31,7 +31,7 @@
         }
         function getSameSides(sides,answerSide) {
             return sides.filter(function(side){
-                return side.labelPos === sides[answerSide].labelPos && side.length != sides[answerSide].length;
+                return side.labelPos === sides[answerSide].labelPos && side != sides[answerSide];
             });
         }
     </script>
@@ -42,13 +42,11 @@
     <div class="problems">
         <div id="missing-side-perimeter" data-weight="2">
             <div class="vars">
-                <var id="WIDTH">randRange(5, 9)</var>
-                <var id="HEIGHT">randRange(5, 9)</var>
                 <var id="SHAPE"
-                    data-ensure="SHAPE.numSides <= 7 && SHAPE.numSides > 4">
+                    data-ensure="SHAPE.numSides <= 11 && SHAPE.numSides > 4">
                     createOddShape({
-                        width: WIDTH,
-                        height: HEIGHT
+                        width: 12,
+                        height: 10
                     })
                 </var>
                 <var id="SIDES">SHAPE.sides</var>
@@ -60,7 +58,7 @@
             </div>
             <p class="question">What is the length of side <code><var>HIDDENSIDENAME</var></code> ?</p>
             <div class="graphie" id="polygon">
-                    init({ range: [[-1, WIDTH + 1], [-1, HEIGHT + 1]] });
+                    init({ range: [[-1, 12 + 1], [-1, 10 + 1]] });
                     var shape = [];
 
                     SHAPE.sides[HIDDENSIDE].length=HIDDENSIDENAME;
@@ -77,7 +75,7 @@
 
 
     <div class="hints">
-            <div data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var></code>, and all other sides of the same orientation add up to the length of the face opposite it.
+            <div data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var></code> and all other sides of the same orientation add up to the length of the face opposite it.
                 <div data-if="OPPOSITESIDES.length === 1" class="graphie" data-update="polygon">
                     for (var i = 0; i &lt; OPPOSITESIDES.length; i++) {
                         line( OPPOSITESIDES[i].start, OPPOSITESIDES[i].end, {
@@ -93,11 +91,15 @@
                     }
                 </div>
             </div>
-            <p data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var> + <var>SAMESIDES.map(function(item){return item.length}).join('+')</var> = <var>OPPOSITESIDES[0].length</var></code></p>
-            <p data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var> = <var>ANSWER</var></code></p>
+            <p data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var> + </code><span class="hint_green"><code><var>SAMESIDES.map(function(item){return item.length}).join('+')</var></code></span> = <span class="hint_red"><code><var>OPPOSITESIDES[0].length</var></code><span></p>
+            <p data-if="OPPOSITESIDES.length === 1">What number does <code><var>HIDDENSIDENAME</var></code> have to be equal to for this sum to be correct?</p>
+            <p data-if="OPPOSITESIDES.length === 1">
+                <code>\textbf{<var>ANSWER</var>} + </code><span class="hint_green"><code><var>SAMESIDES.map(function(item){return item.length}).join('+')</var></code></span><code> = </code><span class="hint_red"><code><var>OPPOSITESIDES.map(function(item){return item.length}).join('+')</var></code></span><br>
+                <code><var>HIDDENSIDENAME</var> = <var>ANSWER</var></code>
+            </p>
             
 
-            <div data-if="OPPOSITESIDES.length > 1"> <code><var>HIDDENSIDENAME</var></code> is the sum of its opposite sides.
+            <div data-if="OPPOSITESIDES.length > 1"> <code><var>HIDDENSIDENAME</var></code><span data-if="SAMESIDES.length > 0"> + <code><var>SAMESIDES.map(function(item){return item.length}).join('+')</var></code></span> is the sum of all the sides opposite.
                 <div data-if="OPPOSITESIDES.length > 1">
                     <div class="graphie" data-update="polygon"> 
                         for (var i = 0; i &lt; OPPOSITESIDES.length; i++) {
@@ -106,14 +108,30 @@
                                 strokeWidth: 3
                             })
                         }
+                        for (var i = 0; i &lt; SAMESIDES.length; i++) {
+                            line( SAMESIDES[i].start, SAMESIDES[i].end, {
+                                stroke: KhanUtil.GREEN,
+                                strokeWidth: 3
+                            })
+                        }
                     </div>
                 </div>
             </div>
             <div data-if="OPPOSITESIDES.length > 1">
-                <p><code><var>HIDDENSIDENAME</var> = <var>OPPOSITESIDES.map(function(item){return item.length}).join('+')</var>
-                </code></p>
+                <p><code><var>HIDDENSIDENAME</var></code><span data-if="SAMESIDES.length > 0"> + <span class="hint_green"><code>
+                    <var>SAMESIDES.map(function(item){return item.length}).join('+')</var></code></span></span></code> = 
+                    <span class="hint_red"><code>
+                        <var>OPPOSITESIDES.map(function(item){return item.length}).join('+')</var>
+                    </code></span>
+                </p>
+                <p data-if="OPPOSITESIDES.length > 1">
+                    What number does <code><var>HIDDENSIDENAME</var></code> have to be equal to for this sum to be correct?
+                </p>
             </div>
-            <p data-if="OPPOSITESIDES.length > 1"><code><var>HIDDENSIDENAME</var> = <var>ANSWER</var></code></p>
+            <p data-if="OPPOSITESIDES.length > 1">
+                <code>\textbf{<var>ANSWER</var>}<span data-if="SAMESIDES.length > 0"> + </code><span class="hint_green"><code><var>SAMESIDES.map(function(item){return item.length}).join('+')</var></code></span> = <span class="hint_red"><code><var>OPPOSITESIDES.map(function(item){return item.length}).join('+')</var></code></span><br>
+                <code><var>HIDDENSIDENAME</var> = <var>ANSWER</var></code>
+            </p>
         </div>
     </div>
 </div>

--- a/exercises/rectangle_perimeter_2.html
+++ b/exercises/rectangle_perimeter_2.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html data-require="math angles graphie graphie-geometry graphie-helpers math-format">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Rectangle Perimeter 2</title>
+    <script src="../khan-exercise.js"></script>
+    <script type="text/javascript">
+        function getOppositeSides(sides,answerSide) {
+            switch (sides[answerSide].labelPos) {
+                case "left":
+                    return sides.filter(function(side){
+                        return side.labelPos === "right";
+                    });
+                    break;
+                case "right":
+                    return sides.filter(function(side){
+                        return side.labelPos === "left";
+                    });
+                    break;
+                case "above":
+                    return sides.filter(function(side){
+                        return side.labelPos === "below";
+                    });
+                    break;
+                case "below":
+                    return sides.filter(function(side){
+                        return side.labelPos === "above";
+                    });
+                break;
+            }
+        }
+        function getSameSides(sides,answerSide) {
+            return sides.filter(function(side){
+                return side.labelPos === sides[answerSide].labelPos && side.length != sides[answerSide].length;
+            });
+        }
+    </script>
+</head>
+
+<body>
+<div class="exercise">
+    <div class="problems">
+        <div id="missing-side-perimeter" data-weight="2">
+            <div class="vars">
+                <var id="WIDTH">randRange(5, 9)</var>
+                <var id="HEIGHT">randRange(5, 9)</var>
+                <var id="SHAPE"
+                    data-ensure="SHAPE.numSides <= 7 && SHAPE.numSides > 4">
+                    createOddShape({
+                        width: WIDTH,
+                        height: HEIGHT
+                    })
+                </var>
+                <var id="SIDES">SHAPE.sides</var>
+                <var id="HIDDENSIDENAME">randVar()</var>
+                <var id="HIDDENSIDE">randRange(0,SIDES.length-1)</var>
+                <var id="ANSWER">SHAPE.sides[HIDDENSIDE].length</var>
+                <var id="OPPOSITESIDES">getOppositeSides(SIDES,HIDDENSIDE)</var>
+                <var id="SAMESIDES">getSameSides(SIDES,HIDDENSIDE)</var>
+            </div>
+            <p class="question">What is the length of side <code><var>HIDDENSIDENAME</var></code> ?</p>
+            <div class="graphie" id="polygon">
+                    init({ range: [[-1, WIDTH + 1], [-1, HEIGHT + 1]] });
+                    var shape = [];
+
+                    SHAPE.sides[HIDDENSIDE].length=HIDDENSIDENAME;
+                    
+                    SHAPE.labelSides();
+
+                    _.each(SHAPE.sides, function(side) {
+                        path([side.start, side.end], {stroke: BLUE});
+                    });
+            </div>
+            <p class="solution" data-type="decimal"><var>ANSWER</var></p>
+        </div>
+        </div>
+
+
+    <div class="hints">
+            <div data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var></code>, and all other sides of the same orientation add up to the length of the face opposite it.
+                <div data-if="OPPOSITESIDES.length === 1" class="graphie" data-update="polygon">
+                    for (var i = 0; i &lt; OPPOSITESIDES.length; i++) {
+                        line( OPPOSITESIDES[i].start, OPPOSITESIDES[i].end, {
+                            stroke: KhanUtil.RED,
+                            strokeWidth: 3
+                        })
+                    }
+                    for (var i = 0; i &lt; SAMESIDES.length; i++) {
+                        line( SAMESIDES[i].start, SAMESIDES[i].end, {
+                            stroke: KhanUtil.GREEN,
+                            strokeWidth: 3
+                        })
+                    }
+                </div>
+            </div>
+            <p data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var> + <var>SAMESIDES.map(function(item){return item.length}).join('+')</var> = <var>OPPOSITESIDES[0].length</var></code></p>
+            <p data-if="OPPOSITESIDES.length === 1"><code><var>HIDDENSIDENAME</var> = <var>ANSWER</var></code></p>
+            
+
+            <div data-if="OPPOSITESIDES.length > 1"> <code><var>HIDDENSIDENAME</var></code> is the sum of its opposite sides.
+                <div data-if="OPPOSITESIDES.length > 1">
+                    <div class="graphie" data-update="polygon"> 
+                        for (var i = 0; i &lt; OPPOSITESIDES.length; i++) {
+                            line( OPPOSITESIDES[i].start, OPPOSITESIDES[i].end, {
+                                stroke: KhanUtil.RED,
+                                strokeWidth: 3
+                            })
+                        }
+                    </div>
+                </div>
+            </div>
+            <div data-if="OPPOSITESIDES.length > 1">
+                <p><code><var>HIDDENSIDENAME</var> = <var>OPPOSITESIDES.map(function(item){return item.length}).join('+')</var>
+                </code></p>
+            </div>
+            <p data-if="OPPOSITESIDES.length > 1"><code><var>HIDDENSIDENAME</var> = <var>ANSWER</var></code></p>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -892,12 +892,21 @@ $.extend(KhanUtil, {
                     length: leftStart - y,
                     labelPos: "left"
                 });
-                shape.sides.push({
-                    start: [prevLeft, y],
-                    end: [left, y],
-                    length: Math.abs(left - prevLeft),
-                    labelPos: "center"
-                });
+                if (left < prevLeft) {
+                    shape.sides.push({
+                        start: [prevLeft, y],
+                        end: [left, y],
+                        length: Math.abs(left - prevLeft),
+                        labelPos: "above"
+                    });
+                } else {
+                    shape.sides.push({
+                        start: [prevLeft, y],
+                        end: [left, y],
+                        length: Math.abs(left - prevLeft),
+                        labelPos: "below"
+                    });
+                }
                 // record where the next vertical side on the left starts
                 leftStart = y;
             }
@@ -911,12 +920,21 @@ $.extend(KhanUtil, {
                     length: rightStart - y,
                     labelPos: "right"
                 });
-                shape.sides.push({
-                    start: [prevRight, y],
-                    end: [right, y],
-                    length: Math.abs(right - prevRight),
-                    labelPos: "center"
-                });
+                if (right > prevRight) {
+                    shape.sides.push({
+                        start: [prevRight, y],
+                        end: [right, y],
+                        length: Math.abs(right - prevRight),
+                        labelPos: "above"
+                    });
+                } else {
+                    shape.sides.push({
+                        start: [prevRight, y],
+                        end: [right, y],
+                        length: Math.abs(right - prevRight),
+                        labelPos: "below"
+                    }); 
+                }
                 // record where the next vertical side on the right starts
                 rightStart = y;
             }


### PR DESCRIPTION
In reference to [Trello card #519](https://trello.com/c/SlWTMayL), I've knocked together the second exercise type suggested. I'm not entirely sure of the value of the first (calculating area) as 'area_1' covers it in a way that while is simpler, promotes the process students will undertake anyway.

Grep tells me I'm the only one who is using the createOddShape().labelSides() so my fix here doesn't break anything. I think it is an improvement aesthetically—and I'm relying on it as a cheap way of working out opposite sides.

I'm not sure if this may be better placed merged in with 'perimeter_1'.
