### PR TITLE
Include domain in rational expression question

### DIFF
--- a/exercises/simplifying_rational_expressions_3.html
+++ b/exercises/simplifying_rational_expressions_3.html
@@ -18,9 +18,6 @@
             padding-top: 1px;
             border-top: 1px solid black;
         }
-        #solutionarea .soln-dom {
-            padding-left: 4px;
-        }
     </style>
 </head>
 <body>
@@ -54,33 +51,35 @@
                 <div class="solution" data-type="set">
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
-                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
                         <span class="sol" data-type="number"><var>-A</var></span>
+                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
                     </div>
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
-                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
                         <span class="sol" data-type="number"><var>-A</var></span>
+                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
                     </div>
 
                     <div class="input-format">
                         <div class="entry" data-type="multiple">
                             <table>
                                 <tr>
-                                    <td rowspan="2" class="soln-name">
+                                    <td rowspan="2">
                                         <code><var>Y</var> = </code>
                                     </td>
                                     <td class="soln-top">
-                                        <span class="sol short50">a</span>
+                                        <span class="sol short40">a</span>
+                                    </td>
+                                    <td rowspan="2">;
+                                        <code> \space <var>X</var> \neq </code><span class="sol soln-dom short32">a</span>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="soln-bot">
-                                        <span class="sol short50" data-fallback="1">a</span>
+                                        <span class="sol short40" data-fallback="1">a</span>
                                     </td>
                                 </tr>
                             </table>
-                            <div class="soln-dom"><code><var>X</var> \neq </code> <span class="sol soln-dom short50">a</span></div>
                         </div>
                     </div>
                     <div class="example">a simplifed expression, like <code>x + 2</code></div>
@@ -103,33 +102,35 @@
                 <div class="solution" data-type="set">
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
-                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
                         <span class="sol" data-type="number"><var>-A</var></span>
+                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
                     </div>
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
-                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
                         <span class="sol" data-type="number"><var>-A</var></span>
+                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
                     </div>
 
                     <div class="input-format">
                         <div class="entry" data-type="multiple">
                             <table>
                                 <tr>
-                                    <td rowspan="2" class="soln-name">
+                                    <td rowspan="2">
                                         <code><var>Y</var> = </code>
                                     </td>
                                     <td class="soln-top">
-                                        <span class="sol short50">a</span>
+                                        <span class="sol short32">a</span>
+                                    </td>
+                                    <td rowspan="2">;
+                                        <code> \space <var>X</var> \neq </code><span class="sol soln-dom short32">a</span>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="soln-bot">
-                                        <span class="sol short50" data-fallback="1">a</span>
+                                        <span class="sol short32" data-fallback="1">a</span>
                                     </td>
                                 </tr>
                             </table>
-                        <div class="soln-dom"><code><var>X</var> \neq </code> <span class="sol soln-dom short50">a</span></div>
                         </div>
                     </div>
                     <div class="example">a simplifed expression, like <code>x + 2</code></div>
@@ -165,16 +166,16 @@
                         <div class="entry" data-type="multiple">
                             <table>
                                 <tr>
-                                    <td rowspan="2" class="soln-name">
+                                    <td rowspan="2">
                                         <code><var>Y</var> = </code>
                                     </td>
                                     <td class="soln-top">
-                                        <span class="sol short50">a</span>
+                                        <span class="sol short32">a</span>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="soln-bot">
-                                        <span class="sol short50" data-fallback="1">a</span>
+                                        <span class="sol short32" data-fallback="1">a</span>
                                     </td>
                                 </tr>
                             </table>

--- a/exercises/simplifying_rational_expressions_3.html
+++ b/exercises/simplifying_rational_expressions_3.html
@@ -18,6 +18,9 @@
             padding-top: 1px;
             border-top: 1px solid black;
         }
+        #solutionarea .soln-dom {
+            padding-left: 3px;
+        }
     </style>
 </head>
 <body>
@@ -85,6 +88,15 @@
                     <div class="example">a simplifed expression, like <code>x + 2</code></div>
                 </div>
 
+                <div class="hints" data-apply="appendContents">
+                    <div>
+                        <p>The original expression has <code>(<var>X</var> + <var>A</var>)</code> in the denominator, 
+                        so is not defined when <code><var>X</var> = <var>-A</var></code>.</p>
+                        We must therefore include this condition with the simplified expression:</p>
+                        <code><var>Y</var> = \dfrac{<var>FACTOR1</var>}{<var>FACTOR2</var>}; \space
+                        <var>X</var> \neq <var>-A</var></code>
+                    </div>
+                </div>
             </div>
 
             <div id="top-constant">
@@ -119,7 +131,7 @@
                                         <code><var>Y</var> = </code>
                                     </td>
                                     <td class="soln-top">
-                                        <span class="sol short32">a</span>
+                                        <span class="sol short40">a</span>
                                     </td>
                                     <td rowspan="2">;
                                         <code> \space <var>X</var> \neq </code><span class="sol soln-dom short32">a</span>
@@ -127,7 +139,7 @@
                                 </tr>
                                 <tr>
                                     <td class="soln-bot">
-                                        <span class="sol short32" data-fallback="1">a</span>
+                                        <span class="sol short40" data-fallback="1">a</span>
                                     </td>
                                 </tr>
                             </table>
@@ -136,6 +148,15 @@
                     <div class="example">a simplifed expression, like <code>x + 2</code></div>
                 </div>
 
+                <div class="hints" data-apply="appendContents">
+                    <div>
+                        <p>The original expression has <code>(<var>X</var> + <var>A</var>)</code> in the denominator, 
+                        so is not defined when <code><var>X</var> = <var>-A</var></code>.</p>
+                        We must therefore include this condition with the simplified expression:</p>
+                        <code><var>Y</var> = \dfrac{<var>FACTOR1</var>}{<var>FACTOR2</var>}; \space
+                        <var>X</var> \neq <var>-A</var></code>
+                    </div>
+                </div>
             </div>
 
             <div id="bottom-constant">
@@ -184,8 +205,18 @@
                     <div class="example">a simplifed expression, like <code>x + 2</code></div>
                 </div>
 
+            <div class="hints" data-apply="appendContents">
+                <div data-if="FACTOR2 < -1">
+                    <p>To remove the negative denominator, multiply the numerator and denominator by -1:</p>
+                    <div><code><var>Y</var> = \dfrac{-<var>X</var> + <var>-B</var>}{<var>-C</var>}</code></div>
+                </div>
+                <div data-if="FACTOR2 === -1">
+                    <p>Dividing by -1 is the same thing as multiplying by -1, so the answer is:</p>
+                    <div><code><var>Y</var> = -<var>X</var> + <var>-B</var></code></div>
+                </div>
             </div>
-            
+
+            </div>
         </div>
 
         <p class="problem">Simplify the following expression and state the domain:</p>
@@ -209,15 +240,6 @@
                 <div data-else>
                     <code><var>Y</var> = \dfrac{<var>FACTOR1</var>}{<var>FACTOR2</var>}</code>
                 </div>
-            </div>
-
-            <div data-if="FACTOR2 < -1">
-                <p>To remove the negative denominator, multiply the numerator and denominator by -1:</p>
-                <div><code><var>Y</var> = \dfrac{-<var>X</var> + <var>-B</var>}{<var>-C</var>}</code></div>
-            </div>
-            <div data-if="FACTOR2 === -1">
-                <p>Dividing by -1 is the same thing as multiplying by -1, so the answer is:</p>
-                <div><code><var>Y</var> = -<var>X</var> + <var>-B</var></code></div>
             </div>
 
         </div>

--- a/exercises/simplifying_rational_expressions_3.html
+++ b/exercises/simplifying_rational_expressions_3.html
@@ -18,6 +18,9 @@
             padding-top: 1px;
             border-top: 1px solid black;
         }
+        #solutionarea .soln-dom {
+            padding-left: 4px;
+        }
     </style>
 </head>
 <body>
@@ -45,7 +48,43 @@
                     <var id="POSITIVEDENOMINATOR">getExpressionRegex(1, X, C)</var>
                     <var id="NEGATIVENUMERATOR">getExpressionRegex(-1, X, -B)</var>
                     <var id="NEGATIVEDENOMINATOR">getExpressionRegex(-1, X, -C)</var>
+                    <var id="DOMAIN">-C</var>
                 </div>
+
+                <p class="problem">Simplify the following expression and state the domain:</p>
+
+                <div class="solution" data-type="set">
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
+                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
+                    </div>
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
+                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
+                    </div>
+                    <div class="input-format">
+                        <div class="entry" data-type="multiple">
+                            <table>
+                                <tr>
+                                    <td rowspan="2" class="soln-name">
+                                        <code><var>Y</var> = </code>
+                                    </td>
+                                    <td class="soln-top">
+                                        <span class="sol short50">a</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="soln-bot">
+                                        <span class="sol short50" data-fallback="1">a</span>
+                                    </td>
+                                </tr>
+                            </table>
+                        <div class="soln-dom"><code><var>X</var> \neq </code> <span class="sol soln-dom short50">a</span></div>
+                        </div>
+                    </div>
+                    <div class="example">a simplifed expression, like <code>x + 2</code></div>
+                </div>
+
             </div>
 
             <div id="top-constant">
@@ -59,6 +98,41 @@
                     <var id="NEGATIVENUMERATOR">getExpressionRegex(0, X, -B)</var>
                     <var id="NEGATIVEDENOMINATOR">getExpressionRegex(-1, X, -C)</var>
                 </div>
+
+                <p class="problem">Simplify the following expression and state the domain:</p>
+
+                <div class="solution" data-type="set">
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
+                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
+                    </div>
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
+                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
+                    </div>
+                    <div class="input-format">
+                        <div class="entry" data-type="multiple">
+                            <table>
+                                <tr>
+                                    <td rowspan="2" class="soln-name">
+                                        <code><var>Y</var> = </code>
+                                    </td>
+                                    <td class="soln-top">
+                                        <span class="sol short50">a</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="soln-bot">
+                                        <span class="sol short50" data-fallback="1">a</span>
+                                    </td>
+                                </tr>
+                            </table>
+                        <div class="soln-dom"><code><var>X</var> \neq </code> <span class="sol soln-dom short50">a</span></div>
+                        </div>
+                    </div>
+                    <div class="example">a simplifed expression, like <code>x + 2</code></div>
+                </div>
+
             </div>
 
             <div id="bottom-constant">
@@ -72,43 +146,44 @@
                     <var id="NEGATIVENUMERATOR">getExpressionRegex(-1, X, -B)</var>
                     <var id="NEGATIVEDENOMINATOR">getExpressionRegex(0, X, -C)</var>
                 </div>
-            </div>
-        </div>
 
-        <p class="problem">Simplify the following expression:</p>
-        <p class="question"><code><var>Y</var> = \dfrac{<var>NUMERATOR</var>}{<var>DENOMINATOR</var>}</code></p>
-
-        <div class="solution" data-type="set">
-            <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
-                <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
-            </div>
-            <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
-                <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
-            </div>
-            <div class="input-format">
-                <div class="entry" data-type="multiple">
-                    <table>
-                        <tr>
-                            <td rowspan="2" class="soln-name">
-                                <code><var>Y</var> = </code>
-                            </td>
-                            <td class="soln-top">
-                                <span class="sol short50">a</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="soln-bot">
-                                <span class="sol short50" data-fallback="1">a</span>
-                            </td>
-                        </tr>
-                    </table>
+                <p class="problem">Simplify the following expression:</p>
+               
+                <div class="solution" data-type="set">
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
+                        <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
+                    </div>
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
+                        <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
+                    </div>
+                    <div class="input-format">
+                        <div class="entry" data-type="multiple">
+                            <table>
+                                <tr>
+                                    <td rowspan="2" class="soln-name">
+                                        <code><var>Y</var> = </code>
+                                    </td>
+                                    <td class="soln-top">
+                                        <span class="sol short50">a</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="soln-bot">
+                                        <span class="sol short50" data-fallback="1">a</span>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="example">a simplifed expression, like <code>x + 2</code></div>
                 </div>
-            </div>
 
-            <p class="example">a simplifed expression, like <code>x + 2</code></p>
+            </div>
         </div>
+
+        <p class="question"><code><var>Y</var> = \dfrac{<var>NUMERATOR</var>}{<var>DENOMINATOR</var>}</code></p>
 
         <div class="hints">
             <p>First factor the expressions in the numerator and denominator.</p>
@@ -122,7 +197,7 @@
 
             <div>
                 <p>Dividing both the numerator and denominator by <code>(<var>X</var> + <var>A</var>)</code> gives:</p>
-                <div data-if="C === 1">
+                <div data-if="FACTOR2 === 1">
                     <code><var>Y</var> = \dfrac{<var>FACTOR1</var>}{<var>FACTOR2</var>}</code> or more simply, <code><var>Y</var> = <var>FACTOR1</var></code>
                 </div>
                 <div data-else>

--- a/exercises/simplifying_rational_expressions_3.html
+++ b/exercises/simplifying_rational_expressions_3.html
@@ -51,17 +51,18 @@
                     <var id="DOMAIN">-C</var>
                 </div>
 
-                <p class="problem">Simplify the following expression and state the domain:</p>
-
                 <div class="solution" data-type="set">
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
                         <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
                     </div>
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
                         <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
                     </div>
+
                     <div class="input-format">
                         <div class="entry" data-type="multiple">
                             <table>
@@ -79,7 +80,7 @@
                                     </td>
                                 </tr>
                             </table>
-                        <div class="soln-dom"><code><var>X</var> \neq </code> <span class="sol soln-dom short50">a</span></div>
+                            <div class="soln-dom"><code><var>X</var> \neq </code> <span class="sol soln-dom short50">a</span></div>
                         </div>
                     </div>
                     <div class="example">a simplifed expression, like <code>x + 2</code></div>
@@ -99,17 +100,18 @@
                     <var id="NEGATIVEDENOMINATOR">getExpressionRegex(-1, X, -C)</var>
                 </div>
 
-                <p class="problem">Simplify the following expression and state the domain:</p>
-
                 <div class="solution" data-type="set">
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>POSITIVENUMERATOR</var></span>
                         <span class="sol" data-type="regex"><var>POSITIVEDENOMINATOR</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
                     </div>
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
                         <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
                     </div>
+
                     <div class="input-format">
                         <div class="entry" data-type="multiple">
                             <table>
@@ -158,6 +160,7 @@
                         <span class="sol" data-type="regex"><var>NEGATIVENUMERATOR</var></span>
                         <span class="sol" data-type="regex"><var>NEGATIVEDENOMINATOR</var></span>
                     </div>
+
                     <div class="input-format">
                         <div class="entry" data-type="multiple">
                             <table>
@@ -181,8 +184,10 @@
                 </div>
 
             </div>
+            
         </div>
 
+        <p class="problem">Simplify the following expression and state the domain:</p>
         <p class="question"><code><var>Y</var> = \dfrac{<var>NUMERATOR</var>}{<var>DENOMINATOR</var>}</code></p>
 
         <div class="hints">


### PR DESCRIPTION
I've added a new solution box to the question whenever you divide by an expression so you have to include the domain condition as part of your answer.

It's formatted using a table isn't isn't ideal especially as tabbing from one box to another goes in an unintuitive order, but it seemed better than creating a lot more divs and trying to line them up.

I still can't get rid of the old merge as part of my pull request.
