### PR TITLE
Update randVar()

### DIFF
--- a/exercises/combining_like_terms_1.html
+++ b/exercises/combining_like_terms_1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-require="math expressions">
+<html data-require="math math-format expressions">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Combining like terms 1</title>
@@ -8,7 +8,7 @@
 <body>
 <div class="exercise">
     <div class="vars">
-        <var id="X">randFromArray("abkmnptx")</var>
+        <var id="X">randVar()</var>
         <var id="A">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 12))</var>
         <var id="B" data-ensure="abs( A ) !== abs( B )">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 12))</var>
         <var id="C">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 20))</var>

--- a/exercises/combining_like_terms_2.html
+++ b/exercises/combining_like_terms_2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-require="math expressions">
+<html data-require="math math-format expressions">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Combining like terms 2</title>
@@ -11,7 +11,7 @@
 
 <div class="exercise" data-weight="6">
     <div class="vars" data-ensure="E * A + F * B !== 0 && E * C + F * D !== 0 && A + (F * B) !== 0">
-        <var id="X">randFromArray("abkmnpvx")</var>
+        <var id="X">randVar()</var>
         <var id="A">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 12))</var>
         <var id="B" data-ensure="abs( A ) !== abs( B )">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 12))</var>
         <var id="C">randRangeNonZero(-1, 1) * randRange(1, randRange(1, 20))</var>

--- a/exercises/multistep_equations_with_distribution.html
+++ b/exercises/multistep_equations_with_distribution.html
@@ -27,11 +27,14 @@
             prob9       A(Bx + C) = D(E + Fx)
     </div>
 
+    <div class="vars">
+        <var id="X">randVar()</var>
+    </div>
+
     <div class="problems">
         <div id="prob1"> <!-- A = Bx + C(Dx + E) -->
             <div class="vars" data-ensure="(B + C * D !== 0) &&
                     (A - C * E !== 0) && (B + C * D !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">randRangeNonZero(-10, 10)</var>
                 <var id="B">randRangeNonZero(-10, 10)</var>
                 <var id="C">
@@ -149,7 +152,6 @@
         <div id="prob2"> <!-- A = B(C + Dx) + Ex -->
             <div class="vars" data-ensure="(B * D + E !== 0) &&
                     (A - B * C) && (B * D + E)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">randRangeNonZero(-10, 10)</var>
                 <var id="B">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
@@ -272,7 +274,6 @@
             <div class="vars" data-ensure="D * F + G !== 0 &&
                     ((A * B) - (D * F + G)) !== 0 &&
                     ((A * B) - (D * F + G)) !== 1">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
                 </var>
@@ -466,7 +467,6 @@
             <div class="vars" data-ensure="(F - B * D !== 0) &&
                     (A + B * C - E !== 0) &&
                     (A + B * C - E !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">randRangeNonZero(-8, 8)</var>
                 <var id="B">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
@@ -618,7 +618,6 @@
 
         <div id="prob5"> <!-- A + Bx = C(Dx + E) -->
             <div class="vars" data-ensure="(B - C * D !== 0) && (B - C * D !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">randRangeNonZero(-8, 8)</var>
                 <var id="B">randRangeNonZero(-10, 10)</var>
                 <var id="C">
@@ -752,7 +751,6 @@
         <div id="prob6"> <!-- Ax + B(C + Dx) = E -->
             <div class="vars" data-ensure="(A + B * D !== 0) &&
                     (E - B * C !== 0) && (A + B * D !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">randRangeNonZero(-8, 8)</var>
                 <var id="B">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
@@ -866,7 +864,6 @@
 
         <div id="prob7"> <!-- A(Bx + C) = Dx + E -->
             <div class="vars" data-ensure="(A * B - D !== 0) && (A * B - D !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
                 </var>
@@ -1001,7 +998,6 @@
         <div id="prob8"> <!-- A(B + Cx) + D = E + Fx -->
             <div class="vars" data-ensure="(A * B - F !== 0) &&
                     (A * C + D !== 0) && (E - A * C - D !== 0) && (A * B - F !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
                 </var>
@@ -1149,7 +1145,6 @@
 
         <div id="prob9"> <!-- A(Bx + C) = D(E + Fx) -->
             <div class="vars" data-ensure="(A * B - D * F !== 0) && (A * B - D * F !== 1)">
-                <var id="X">randFromArray("abkmnpvx")</var>
                 <var id="A">
                     randRangeWeightedExclude(-6, 4, -1, 0.4, [0, 1])
                 </var>

--- a/exercises/one_step_equations.html
+++ b/exercises/one_step_equations.html
@@ -15,7 +15,7 @@
         <p><code>\qquad 10 = 5 + x</code></p>
     </div>
     <div class="vars" data-ensure="A !== B">
-        <var id="X">randFromArray("abkmnpvx")</var>
+        <var id="X">randVar()</var>
         <var id="A">randRangeNonZero(-30, 30)</var>
         <var id="B">randRangeNonZero(-30, 30)</var>
     </div>

--- a/exercises/one_step_equations_0.5.html
+++ b/exercises/one_step_equations_0.5.html
@@ -8,7 +8,7 @@
 <body>
 <div class="exercise">
     <div class="vars">
-        <var id="X">randFromArray("abkmnpvxy")</var>
+        <var id="X">randVar()</var>
         <var id="Y">randRangeNonZero( -20, 19 )</var>
         <var id="Z">randRange( Y + 1, 20 )</var>
         <var id="Y_SIGN">Y &lt; 0 ? "-" : "+"</var>

--- a/utils/math-format.js
+++ b/utils/math-format.js
@@ -454,7 +454,7 @@ $.extend(KhanUtil, {
     },
 
     randVar: function() {
-        return KhanUtil.randFromArray(["x", "k", "y", "a", "n", "r", "p", "u", "v"]);
+        return KhanUtil.randFromArray(["a", "k", "n", "p", "q", "r", "t", "x", "y", "z"]);
     },
 
     eulerFormExponent: function(angle) {


### PR DESCRIPTION
Redoing #43394

Ensure exercises use randVar() in math-format (is there a reason for it being in math-format rather than just math?) when generating variable names. Ensure variable names don't include u or v, which could be confused.

Part of me thinks students ought to be able to distinguish u and v, but then again, the exercises are meant to test their mathematical ability, not their ability to read the Latin alphabet.

Deals with #43236 and #43385.
