### PR TITLE
"fix" for utils/expressions/"^" rule not displaying zero exponent expressions

### DIFF
--- a/utils/expressions.js
+++ b/utils/expressions.js
@@ -273,9 +273,7 @@ $.extend(KhanUtil, {
         },
 
         "^": function(base, pow) {
-            if (pow === 0) {
-                return "";
-            } else if (pow === 1) {
+            if (pow === 1) {
                 return KhanUtil.expr(base);
             }
 


### PR DESCRIPTION
It's currently not possible to express expressions with zero exponents:

```
expr(["^", "a", 0]) 
```

results in <code>""</code>. I suppose I could put the zero in quotes, but that doesn't help with variables, right?

It seems clear that the "if pow === 0" check was put in there for a reason, so I'm fairly confident that my "fix" is in conflict with something else (hence the quotes).
