### PR TITLE
Exponent properties 1

### DIFF
--- a/exercises/exponent-properties-1.html
+++ b/exercises/exponent-properties-1.html
@@ -1,33 +1,122 @@
 <!DOCTYPE html>
+
 <html data-require="math expressions">
+
     <head>
+
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <title>Exponent Properties 1</title>
+
         <script src="../khan-exercise.js"></script>
+
     </head>
+
     <body>
+
         <div class="exercise">
-            <div class="vars">
-                <var id="EXP1">0</var><!--randRange(-16,16)</var>-->
-                <var id="EXP2">randRange(-16,16)</var>
-            </div>
 
             <div class="problems">
-                <div id="problem1">
-                    <p class="question">Simplify: <code><var>expr(["dot", ["^", "a", EXP1], ["^", "a", EXP2]])</var></code></p>
-                    <p class="solution"><code><var>expr(["^", "a", EXP1+EXP2])</var></code></p>
+
+                <div id="no-coefficients">
+
+                    <div class="vars">
+
+                        <var id="BASE">"abcdefghijklmnopqrstuvwxyz".split('')[randRange(0,25)]</var>
+                        <var id="EXP1">randRange(0,9)</var>
+                        <var id="EXP2">randRange(0,9)</var>
+
+                    </div>
+
+                    <p class="question">Simplify:&nbsp;&nbsp;&nbsp;&nbsp;<code><var>expr(["dot", ["^", BASE, EXP1], ["^", BASE, EXP2]])</var></code></p>
+
+                    <p class="solution"><code><var>expr(["^", BASE, EXP1+EXP2])</var></code></p>
+
                     <ul class="choices">
-                        <li><code><var>expr(["^", "a", EXP1+EXP2+randRange(1,5)])</var></code></li>
-                        <li><code><var>expr(["^", "a", EXP1+EXP2+randRange(-5,-1)])</var></code></li>
-                        <li><code><var>expr(["^", "a", 2*(EXP1+EXP2)])</var></code></li>
-                        <li><code><var>expr(["^", "a", EXP1*EXP2])</var></code></li>
-                        <li><code><var>expr(["^", "a", EXP1-EXP2])</var></code></li>
+                        <li><code><var>expr(["^", BASE, EXP1+EXP2+randRange(1,5)])</var></code></li>
+                        <li><code><var>expr(["^", BASE, EXP1+EXP2+randRange(-5,-1)])</var></code></li>
+                        <li><code><var>expr(["^", BASE, 2*(EXP1+EXP2)])</var></code></li>
+                        <li><code><var>expr(["^", BASE, EXP1*EXP2])</var></code></li>
+                        <li><code><var>expr(["^", BASE, EXP1-EXP2])</var></code></li>
                     </ul>
+
+                    <div class="hints">
+
+                        <p><code>
+                                <var>expr(["^", BASE, EXP1])</var> = <var>exprExpandIntegerPower(BASE, EXP1)</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["^", BASE, EXP2])</var> = <var>exprExpandIntegerPower(BASE, EXP2)</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
+                                <var>expr(["dot", exprExpandIntegerPower(BASE, EXP1), exprExpandIntegerPower(BASE, EXP2)])</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
+                                <var>exprExpandIntegerPower(BASE, EXP1+EXP2)</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
+                                <var>expr(["^", BASE, EXP1+EXP2])</var>
+                        </code></p>
+
+                    </div>
+
                 </div>
+
+                <div id="coefficients">
+
+                     <div class="vars">
+
+                        <var id="BASE">"abcdefghijklmnopqrstuvwxyz".split('')[randRange(0,25)]</var>
+                        <var id="EXP1">randRange(0,9)</var>
+                        <var id="EXP2">randRange(0,9)</var>
+                        <var id="COEF1" data-ensure"COEF1 !== 0">randRange(-9,9)</var>
+                        <var id="COEF2" data-ensure"COEF2 !== 0">randRange(-9,9)</var>
+
+                    </div>
+
+                    <p class="question">Simplify:&nbsp;&nbsp;&nbsp;&nbsp;<code><var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var></code></p>
+
+                    <p class="solution"><code><var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2]])</var></code></p>
+
+                    <ul class="choices">
+                        <li><code><var>expr(["*", COEF1+COEF2, ["^", BASE, EXP1+EXP2+randRange(1,5)]])</var></code></li>
+                        <li><code><var>expr(["*", COEF1*COEF2+randRange(-1,1), ["^", BASE, EXP1+EXP2+randRange(1,5)]])</var></code></li>
+                        <li><code><var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2+randRange(-5,1)]])</var></code></li>
+                        <li><code><var>expr(["*", COEF1*COEF2, ["^", BASE, 2*EXP1+EXP2]])</var></code></li>
+                        <li><code><var>expr(["*", COEF1-COEF2, ["^", BASE, EXP1-EXP2]])</var></code></li>
+                    </ul>
+
+                    <div class="hints">
+
+                        <p><code>
+                                <var>expr(["*", COEF1, ["^", BASE, EXP1]])</var> = <var>expr(["*", COEF1, exprExpandIntegerPower(BASE, EXP1)])</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["*", COEF2, ["^", BASE, EXP2]])</var> = <var>expr(["*", COEF2, exprExpandIntegerPower(BASE, EXP2)])</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP2]], ["*", COEF2, ["^", BASE, EXP1]]])</var> = 
+                                <var>expr(["dot", ["*", COEF1, exprExpandIntegerPower(BASE, EXP1)], ["*", COEF2, exprExpandIntegerPower(BASE, EXP2)]])</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP2]], ["*", COEF2, ["^", BASE, EXP1]]])</var> = 
+                                <var>expr(["*", COEF1*COEF2, ["dot", exprExpandIntegerPower(BASE, EXP1), exprExpandIntegerPower(BASE, EXP2)]])</var>
+                        </code></p>
+                        <p><code>
+                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
+                                <var>expr(["^", BASE, EXP1+EXP2])</var>
+                        </code></p>
+
+                    </div>
+
+                </div>
+
             </div>
 
-            <div class="hints">
-                <!-- Any hints to show to the student. -->
-            </div>
         </div>
+
     </body>
+
 </html>

--- a/exercises/exponent-properties-1.html
+++ b/exercises/exponent-properties-1.html
@@ -76,7 +76,7 @@
 
                     </div>
 
-                    <p class="question">Simplify:&nbsp;&nbsp;&nbsp;&nbsp;<code><var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var></code></p>
+                    <p class="question">Simplify:&nbsp;&nbsp;&nbsp;&nbsp;<code><var>expr(["*", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var></code></p>
 
                     <p class="solution"><code><var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2]])</var></code></p>
 
@@ -97,16 +97,16 @@
                                 <var>expr(["*", COEF2, ["^", BASE, EXP2]])</var> = <var>expr(["*", COEF2, exprExpandIntegerPower(BASE, EXP2)])</var>
                         </code></p>
                         <p><code>
-                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP2]], ["*", COEF2, ["^", BASE, EXP1]]])</var> = 
+                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var> = 
                                 <var>expr(["dot", ["*", COEF1, exprExpandIntegerPower(BASE, EXP1)], ["*", COEF2, exprExpandIntegerPower(BASE, EXP2)]])</var>
                         </code></p>
                         <p><code>
-                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP2]], ["*", COEF2, ["^", BASE, EXP1]]])</var> = 
+                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var> = 
                                 <var>expr(["*", COEF1*COEF2, ["dot", exprExpandIntegerPower(BASE, EXP1), exprExpandIntegerPower(BASE, EXP2)]])</var>
                         </code></p>
                         <p><code>
-                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
-                                <var>expr(["^", BASE, EXP1+EXP2])</var>
+                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var> = 
+                                <var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2]])</var>
                         </code></p>
 
                     </div>

--- a/exercises/exponent-properties-1.html
+++ b/exercises/exponent-properties-1.html
@@ -22,20 +22,20 @@
                     <div class="vars">
 
                         <var id="BASE">randVar()</var>
-                        <var id="EXP1">randRange(0,9)</var>
-                        <var id="EXP2">randRange(1,1)</var>
-                        <var id="COEF1">randRangeNonZero(-9,9)</var>
-                        <var id="COEF2">randRangeNonZero(-9,9)</var>
+                        <var id="EXP1">randRange(2,9)</var>
+                        <var id="EXP2">randRange(2,9)</var>
+                        <var id="COEF1">randRange(2,9)</var>
+                        <var id="COEF2">randRange(2,9)</var>
 
                     </div>
 
-                    <p class="question">
-                        Simplify the following expression:<br><br>
-                        <code>(\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}})(\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}})</code>
-                    </p>
+                    <div class="question">
+                        <p>Simplify the following expression:</p>
+                        <p><code>(<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>})(<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>})</code></p>
+                    </div>
 
                     <p class="solution" data-type="multiple">
-                        <span class="sol short20" data-forms="integer"><var>COEF1*COEF2</var></span><code><var>BASE</var></code><span class="sol exp short20" data-forms="integer"><var>EXP1+EXP2</var></span>
+                        <span class="sol short20" data-forms="integer"><var>COEF1*COEF2</var></span> <code><var>BASE</var></code> <span class="sol exp short20" data-forms="integer"><var>EXP1+EXP2</var></span>
                     </p>
 
                     <div class="hints">
@@ -61,9 +61,8 @@
                             </code></p>
                         </div>
 
-                        <p><code>
-                            (\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}})(\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}})=
-                            \color{green}{<var>COEF1</var> \cdot <var>exprExpandIntegerPower(BASE, EXP1)</var>}\cdot\color{#D55704}{<var>COEF2</var> \cdot <var>exprExpandIntegerPower(BASE, EXP2)</var>}=
+                        <p class='final-answer'><code>
+                            \hphantom{(\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}})(\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}})}=
                             <var>COEF1*COEF2</var><var>BASE</var>^{<var>EXP1+EXP2</var>}
                         </code></p>
 

--- a/exercises/exponent-properties-1.html
+++ b/exercises/exponent-properties-1.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html data-require="math expressions">
+<html data-require="math math-format expressions">
 
     <head>
 
@@ -21,92 +21,50 @@
 
                     <div class="vars">
 
-                        <var id="BASE">"abcdefghijklmnopqrstuvwxyz".split('')[randRange(0,25)]</var>
+                        <var id="BASE">randVar()</var>
                         <var id="EXP1">randRange(0,9)</var>
-                        <var id="EXP2">randRange(0,9)</var>
+                        <var id="EXP2">randRange(1,1)</var>
+                        <var id="COEF1">randRangeNonZero(-9,9)</var>
+                        <var id="COEF2">randRangeNonZero(-9,9)</var>
 
                     </div>
 
-                    <p class="question">Simplify:&nbsp;&nbsp;&nbsp;&nbsp;<code><var>expr(["dot", ["^", BASE, EXP1], ["^", BASE, EXP2]])</var></code></p>
+                    <p class="question">
+                        Simplify the following expression:<br><br>
+                        <code>(\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}})(\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}})</code>
+                    </p>
 
-                    <p class="solution"><code><var>expr(["^", BASE, EXP1+EXP2])</var></code></p>
-
-                    <ul class="choices">
-                        <li><code><var>expr(["^", BASE, EXP1+EXP2+randRange(1,5)])</var></code></li>
-                        <li><code><var>expr(["^", BASE, EXP1+EXP2+randRange(-5,-1)])</var></code></li>
-                        <li><code><var>expr(["^", BASE, 2*(EXP1+EXP2)])</var></code></li>
-                        <li><code><var>expr(["^", BASE, EXP1*EXP2])</var></code></li>
-                        <li><code><var>expr(["^", BASE, EXP1-EXP2])</var></code></li>
-                    </ul>
+                    <p class="solution" data-type="multiple">
+                        <span class="sol short20" data-forms="integer"><var>COEF1*COEF2</var></span><code><var>BASE</var></code><span class="sol exp short20" data-forms="integer"><var>EXP1+EXP2</var></span>
+                    </p>
 
                     <div class="hints">
 
-                        <p><code>
-                                <var>expr(["^", BASE, EXP1])</var> = <var>exprExpandIntegerPower(BASE, EXP1)</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["^", BASE, EXP2])</var> = <var>exprExpandIntegerPower(BASE, EXP2)</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
-                                <var>expr(["dot", exprExpandIntegerPower(BASE, EXP1), exprExpandIntegerPower(BASE, EXP2)])</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
-                                <var>exprExpandIntegerPower(BASE, EXP1+EXP2)</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["dot", ["^", BASE, EXP2], ["^", BASE, EXP1]])</var> = 
-                                <var>expr(["^", BASE, EXP1+EXP2])</var>
-                        </code></p>
+                        <div>
+                            <p>When multiplying two terms with the same base, add the exponents:</p>
+                            <p><code>(\color{green}{x^n})(\color{#D55704}{x^m}) = x^{(\color{green}{n}+\color{#D55704}{m})}</code></p>
+                        </div>
 
-                    </div>
+                        <div>
+                            <p>Try expanding the terms:</p>
+                            <p>
+                                <code>\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}}</code> is the same as <code>\color{green}{<var>COEF1</var> \cdot <var>exprExpandIntegerPower(BASE, EXP1)</var>}</code><br>
+                                <code>\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}}</code> is the same as <code>\color{#D55704}{<var>COEF2</var> \cdot <var>exprExpandIntegerPower(BASE, EXP2)</var>}</code>
+                            </p>
+                        </div>
 
-                </div>
-
-                <div id="coefficients">
-
-                     <div class="vars">
-
-                        <var id="BASE">"abcdefghijklmnopqrstuvwxyz".split('')[randRange(0,25)]</var>
-                        <var id="EXP1">randRange(0,9)</var>
-                        <var id="EXP2">randRange(0,9)</var>
-                        <var id="COEF1" data-ensure"COEF1 !== 0">randRange(-9,9)</var>
-                        <var id="COEF2" data-ensure"COEF2 !== 0">randRange(-9,9)</var>
-
-                    </div>
-
-                    <p class="question">Simplify:&nbsp;&nbsp;&nbsp;&nbsp;<code><var>expr(["*", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var></code></p>
-
-                    <p class="solution"><code><var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2]])</var></code></p>
-
-                    <ul class="choices">
-                        <li><code><var>expr(["*", COEF1+COEF2, ["^", BASE, EXP1+EXP2+randRange(1,5)]])</var></code></li>
-                        <li><code><var>expr(["*", COEF1*COEF2+randRange(-1,1), ["^", BASE, EXP1+EXP2+randRange(1,5)]])</var></code></li>
-                        <li><code><var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2+randRange(-5,1)]])</var></code></li>
-                        <li><code><var>expr(["*", COEF1*COEF2, ["^", BASE, 2*EXP1+EXP2]])</var></code></li>
-                        <li><code><var>expr(["*", COEF1-COEF2, ["^", BASE, EXP1-EXP2]])</var></code></li>
-                    </ul>
-
-                    <div class="hints">
+                        <div>
+                            <p>Multiply them:</p>
+                            <p><code>
+                                (\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}})(\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}})=
+                                \color{green}{<var>COEF1</var> \cdot <var>exprExpandIntegerPower(BASE, EXP1)</var>} \cdot \color{#D55704}{<var>COEF2</var> \cdot <var>exprExpandIntegerPower(BASE, EXP2)</var>}
+                            </code></p>
+                        </div>
 
                         <p><code>
-                                <var>expr(["*", COEF1, ["^", BASE, EXP1]])</var> = <var>expr(["*", COEF1, exprExpandIntegerPower(BASE, EXP1)])</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["*", COEF2, ["^", BASE, EXP2]])</var> = <var>expr(["*", COEF2, exprExpandIntegerPower(BASE, EXP2)])</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var> = 
-                                <var>expr(["dot", ["*", COEF1, exprExpandIntegerPower(BASE, EXP1)], ["*", COEF2, exprExpandIntegerPower(BASE, EXP2)]])</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var> = 
-                                <var>expr(["*", COEF1*COEF2, ["dot", exprExpandIntegerPower(BASE, EXP1), exprExpandIntegerPower(BASE, EXP2)]])</var>
-                        </code></p>
-                        <p><code>
-                                <var>expr(["dot", ["*", COEF1, ["^", BASE, EXP1]], ["*", COEF2, ["^", BASE, EXP2]]])</var> = 
-                                <var>expr(["*", COEF1*COEF2, ["^", BASE, EXP1+EXP2]])</var>
+                            (\color{green}{<var>COEF1</var><var>BASE</var>^{<var>EXP1</var>}})(\color{#D55704}{<var>COEF2</var><var>BASE</var>^{<var>EXP2</var>}})=
+                            \color{green}{<var>COEF1</var> \cdot <var>exprExpandIntegerPower(BASE, EXP1)</var>}\cdot\color{#D55704}{<var>COEF2</var> \cdot <var>exprExpandIntegerPower(BASE, EXP2)</var>}=
+                            <var>COEF1*COEF2</var><var>BASE</var>^{<var>EXP1+EXP2</var>}
                         </code></p>
 
                     </div>

--- a/exercises/exponent-properties-1.html
+++ b/exercises/exponent-properties-1.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html data-require="math expressions">
+    <head>
+        <title>Exponent Properties 1</title>
+        <script src="../khan-exercise.js"></script>
+    </head>
+    <body>
+        <div class="exercise">
+            <div class="vars">
+                <var id="EXP1">0</var><!--randRange(-16,16)</var>-->
+                <var id="EXP2">randRange(-16,16)</var>
+            </div>
+
+            <div class="problems">
+                <div id="problem1">
+                    <p class="question">Simplify: <code><var>expr(["dot", ["^", "a", EXP1], ["^", "a", EXP2]])</var></code></p>
+                    <p class="solution"><code><var>expr(["^", "a", EXP1+EXP2])</var></code></p>
+                    <ul class="choices">
+                        <li><code><var>expr(["^", "a", EXP1+EXP2+randRange(1,5)])</var></code></li>
+                        <li><code><var>expr(["^", "a", EXP1+EXP2+randRange(-5,-1)])</var></code></li>
+                        <li><code><var>expr(["^", "a", 2*(EXP1+EXP2)])</var></code></li>
+                        <li><code><var>expr(["^", "a", EXP1*EXP2])</var></code></li>
+                        <li><code><var>expr(["^", "a", EXP1-EXP2])</var></code></li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="hints">
+                <!-- Any hints to show to the student. -->
+            </div>
+        </div>
+    </body>
+</html>

--- a/utils/expressions.js
+++ b/utils/expressions.js
@@ -273,7 +273,10 @@ $.extend(KhanUtil, {
         },
 
         "^": function(base, pow) {
-            if (pow === 1) {
+            if (pow === 0) {
+                return "";
+            }
+            else if (pow === 1) {
                 return KhanUtil.expr(base);
             }
 

--- a/utils/expressions.js
+++ b/utils/expressions.js
@@ -273,9 +273,7 @@ $.extend(KhanUtil, {
         },
 
         "^": function(base, pow) {
-            if (pow === 0) {
-                return "";
-            } else if (pow === 1) {
+            if (pow === 1) {
                 return KhanUtil.expr(base);
             }
 

--- a/utils/expressions.js
+++ b/utils/expressions.js
@@ -487,7 +487,24 @@ $.extend(KhanUtil, {
         ret.unshift(expr[0]);
 
         return ret;
+    },
+
+    exprExpandIntegerPower: function(base, pow) {
+        if (pow === 0) {
+            return "1";
+        }
+        var negativePower = false;
+        if (pow < 0) {
+            pow = -pow;
+            negativePower = true;
+        }
+        var expression = new Array(pow+1).join(base).split('').join('&middot;');
+        if (negativePower) {
+            expression = KhanUtil.expr(["frac", 1, expression]);
+        }
+        return expression;
     }
+
 });
 
 KhanUtil.computeOperators["frac"] = KhanUtil.computeOperators["/"];

--- a/utils/expressions.js
+++ b/utils/expressions.js
@@ -491,7 +491,7 @@ $.extend(KhanUtil, {
 
     exprExpandIntegerPower: function(base, pow) {
         if (pow === 0) {
-            return "1";
+            return 1;
         }
         var negativePower = false;
         if (pow < 0) {


### PR DESCRIPTION
Here's an exercise for the not-yet-exercised video "Exponent properties 1".

I've added a function to expressions.js that expands integer power expressions. I'm new to the code, so if you can recommend a better place for this, I'm all ears!

Also, it strikes me that the auto-paren insertion is a little aggressive. Things become pretty paren-y pretty fast. Is there a better way of dealing with this in the code already? If not, would you guys be interested in a patch that changed it so that parens were inserted manually and not automatically? Something like <code>expr(["*", 2, ["paren", ["+", "A", "B"]]])</code> yielding <code>2(A+B)</code> ?

If so, I'd be happy to implement it, but I imagine it would alter all of the existing exercises, which seems like a lot of work to fix!

If not, is there a standard means of using some kind of latex-like language inside your framework? Apologies if I missed such information in the docs.

Anyway, sweet framework! I look forward to using it more! :)
