### PR TITLE
Reduce number of data-ensure loops and variables

### DIFF
--- a/exercises/multiplying_fractions.html
+++ b/exercises/multiplying_fractions.html
@@ -7,31 +7,31 @@
 </head>
 <body>
     <div class="exercise">
-    <div class="vars" data-ensure="getGCD(A, B) === 1 && getGCD(C, D) === 1">
-        <var id="NEG1">randFromArray([1,-1])</var>
-        <var id="NEG1S">NEG1 === -1 ? "-" : ""</var>
-        <var id="A">randRange(1, 8)</var>
-        <var id="B" data-ensure="B>A">randRange(2, 9)</var>
-
-        <var id="NEG2">randFromArray([1, -1])</var>
-        <var id="NEG2S">NEG2 === -1 ? "-" : ""</var>
-        <var id="C">randRange(1, 8)</var>
-        <var id="D" data-ensure="D>C">randRange(2, 9)</var>
+    <div class="vars">
+        <div data-ensure="getGCD(A, B) === 1">
+            <var id="A">randRangeNonZero(-8, 8)</var>
+            <var id="B">randRange(abs(A) + 1, 9)</var>
+        </div>
+        <div data-ensure="getGCD(C, D) === 1">
+            <var id="C">randRange(-8, 8)</var>
+            <var id="D">randRange(abs(C) + 1, 9)</var>
+        </div>
     </div>
 
     <div class="problems">
         <div>
             <div class="question">
-                <p><code>\displaystyle <var>NEG1S</var> \frac{<var>A</var>}{<var>B</var>} \times <var>NEG2S</var> \frac{<var>C</var>}{<var>D</var>}</code></p>
+                <p><code><span data-if="A &lt; 0">-</span> \dfrac{<var>abs(A)</var>}{<var>B</var>} \times 
+                         <span data-if="C &lt; 0">-</span> \dfrac{<var>abs(C)</var>}{<var>D</var>}</code></p>
             </div>
-            <div class="solution" data-type="rational"><var>(NEG1 * A * NEG2 * C) / (B * D)</var></div>
+            <div class="solution" data-type="rational"><var>(A * C) / (B * D)</var></div>
         </div>
     </div>
 
     <div class="hints">
-        <p><code>\displaystyle {} = \frac{<var>NEG1 * A</var> \times <var>NEG2 * C</var>}{<var>B</var> \times <var>D</var>}</code></p>
-        <p><code>\displaystyle {} = \frac{<var>NEG1 * A * NEG2 * C</var>}{<var>B * D</var>}</code></p>
-        <p data-if="getGCD(NEG1 * A * NEG2 * C, B * D) !== 1 || NEG1 * NEG2 === -1"><code>\displaystyle {} = <var>fractionReduce(NEG1 * A * NEG2 * C, B * D)</var></code></p>
+        <p><code>= \dfrac{<var>A</var> \times <var>C</var>}{<var>B</var> \times <var>D</var>}</code></p>
+        <p><code>= \dfrac{<var>A * C</var>}{<var>B * D</var>}</code></p>
+        <p data-if="getGCD(A * C, B * D) !== 1 || A * C &lt; 0"><code>= <var>fractionReduce(A * C, B * D)</var></code></p>
     </div>
     </div>
 </body>

--- a/exercises/multiplying_fractions_0.5.html
+++ b/exercises/multiplying_fractions_0.5.html
@@ -7,27 +7,30 @@
 </head>
 <body>
     <div class="exercise">
-    <div class="vars" data-ensure="getGCD(A, B) === 1 && getGCD(C, D) === 1">
-        <var id="A">randRange(1, 8)</var>
-        <var id="B" data-ensure="B>A">randRange(2, 9)</var>
-
-        <var id="C">randRange(1, 8)</var>
-        <var id="D" data-ensure="D>C">randRange(2, 9)</var>
+    <div class="vars">
+        <div data-ensure="getGCD(A, B) === 1">
+            <var id="A">randRange(1, 8)</var>
+            <var id="B">randRange(A + 1, 9)</var>
+        </div>
+        <div data-ensure="getGCD(C, D) === 1">
+            <var id="C">randRange(1, 8)</var>
+            <var id="D">randRange(C + 1, 9)</var>
+        </div>
     </div>
 
     <div class="problems">
         <div>
             <div class="question">
-                <p><code>\displaystyle \frac{<var>A</var>}{<var>B</var>} \times \frac{<var>C</var>}{<var>D</var>}</code></p>
+                <p><code>\dfrac{<var>A</var>}{<var>B</var>} \times \dfrac{<var>C</var>}{<var>D</var>}</code></p>
             </div>
             <div class="solution" data-type="rational"><var>(A * C) / (B * D)</var></div>
         </div>
     </div>
 
     <div class="hints">
-        <p><code>\displaystyle {} = \frac{<var>A</var> \times <var>C</var>}{<var>B</var> \times <var>D</var>}</code></p>
-        <p><code>\displaystyle {} = \frac{<var>A * C</var>}{<var>B * D</var>}</code></p>
-        <p data-if="getGCD(A * C, B * D) !== 1"><code>\displaystyle {} = <var>fractionReduce(A * C, B * D)</var></code></p>
+        <p><code>= \dfrac{<var>A</var> \times <var>C</var>}{<var>B</var> \times <var>D</var>}</code></p>
+        <p><code>= \dfrac{<var>A * C</var>}{<var>B * D</var>}</code></p>
+        <p data-if="getGCD(A * C, B * D) !== 1"><code>= <var>fractionReduce(A * C, B * D)</var></code></p>
     </div>
     </div>
 </body>


### PR DESCRIPTION
I realise this doesn't achieve much, but it does reduce the number of data-ensure loops and tidies things up a bit. Is there any reason to use `\displaystyle` other than to make the fractions larger?
