### PR TITLE
Cipher decryption slider fix

### DIFF
--- a/exercises/caesar_cipher_decryption.html
+++ b/exercises/caesar_cipher_decryption.html
@@ -71,7 +71,7 @@
 
                         for ( var i = 0; i &lt;= UPPER_BOUND; i+=1 ) {
                             myLabels[i].remove();
-                            myLabels[i] = label( [ i , -0.53 ],  "abcdefghijklmnopqrstuvwxyz"[(i+x) % 26], "center", false);
+                            myLabels[i] = label( [ i , -0.53 ],  "abcdefghijklmnopqrstuvwxyz"[abs((i-x)+26) % 26], "center", false);
                         }
 
                         return [ min( max( LOWER_BOUND, x ), UPPER_BOUND * indent ), y ];

--- a/exercises/caesar_cipher_decryption.html
+++ b/exercises/caesar_cipher_decryption.html
@@ -73,7 +73,7 @@
                             myLabels[i].remove();
                             myLabels[i] = label( [ i , -0.53 ],  "abcdefghijklmnopqrstuvwxyz"[abs((i-x)+26) % 26], "center", false);
                         }
-
+                        forceLabelTypeset();
                         return [ min( max( LOWER_BOUND, x ), UPPER_BOUND * indent ), y ];
                     };
                 </div>

--- a/exercises/caesar_cipher_decryption.html
+++ b/exercises/caesar_cipher_decryption.html
@@ -26,7 +26,7 @@
                     </p><p data-else="">
                         <var>person(2)</var> is expecting to recieve an encrypted message with the name of one of her classmates.
                         She knows the message will be encrypted with a <strong>Caesar cipher</strong> using a shift of <code><var>SHIFT</var></code>.
-                        When she returns to his desk, she finds a piece of paper with the following message on it:
+                        When she returns to her desk, she finds a piece of paper with the following message on it:
                     </p>
                     <p><strong><var>C</var></strong></p>
                     <p>Help <var>person(2)</var> crack the code, by typing the decrypted message in the answer box using all lowercase letters.</p>

--- a/exercises/limits_2.html
+++ b/exercises/limits_2.html
@@ -6,7 +6,6 @@
     <script src="../khan-exercise.js"></script>
 </head>
 <body>
-<<<<<<< HEAD
 	<div class="exercise">
 		<div class="problems">
 			<div id="n-eq-d" data-weight="3">


### PR DESCRIPTION
Fixed the slider for the Caesar Cipher Decryption exercise. Decryption slider needed to be left shifted, while encryption exercises are right shifted. 

Response to bug report: #48175
