### PR TITLE
Fix binding of newProblem event (fix matrix input)

### DIFF
--- a/utils/derivative-intuition.js
+++ b/utils/derivative-intuition.js
@@ -74,7 +74,7 @@ $.extend(KhanUtil, {
         // slopes to 0. This replicates the action of the user placing each point
         // at zero and applies the same "close enough" test so very small slopes
         // aren't graded wrong even if they look almost right.
-        $(Khan).one("newProblem", function() {
+        $(Exercises).one("newProblem", function() {
             $(points).each(function(index, xval) {
                 KhanUtil.setSlope(index, 0);
             });

--- a/utils/matrix-input.js
+++ b/utils/matrix-input.js
@@ -327,7 +327,7 @@ $.fn["matrix-inputLoad"] = function() {
         return;
     }
 
-    $(Khan).on("newProblem.matrix-input", function() {
+    $(Exercises).on("newProblem.matrix-input", function() {
         KhanUtil.matrixInput.init();
     });
 
@@ -345,7 +345,7 @@ $.fn["matrix-inputCleanup"] = function() {
     }
 
     KhanUtil.matrixInput.cleanup();
-    $(Khan).off("newProblem.matrix-input");
+    $(Exercises).off("newProblem.matrix-input");
     $(Khan).off("showGuess.matrix-input");
 
     KhanUtil.matrixInput.eventsAttached = false;


### PR DESCRIPTION
Trello Card# 584 "Fix matrix input. It used to support arrow keys and
show brackets around the answer. What happened?"  What happened was,
newProblem used to be triggered on $(Khan), but is now triggered on
$(Exercises).  Thus, matrix input was no longer being initialized.

This problem also affected the Derivative Intuition exercise.  Points
with actual slope very close to 0 will now once again adjust to the
correct values when the problem loads.
