### PR TITLE
correct hint text, fix #47106

### DIFF
--- a/exercises/rate_problems_1.html
+++ b/exercises/rate_problems_1.html
@@ -55,12 +55,12 @@
                         So he traveled <code><var>SPEED1</var> \times </code> 
                         <span data-if="T1[1] !== 1"><code>\frac{<var>T1[0]</var>}{<var>T1[1]</var>}</code></span>
                         <span data-else=""><code><var>T1[0]</var></code></span>
-                        <code> = <var>round(DIST1)</var></code>  miles by <var>vehicle(1)</var>.
+                        <code> \approx <var>round(DIST1)</var></code>  miles by <var>vehicle(1)</var>.
                     </p><p id="final-hint" data-else="">
                         So she traveled <code><var>SPEED1</var> \times </code> 
                         <span data-if="T1[1] !== 1"><code>\frac{<var>T1[0]</var>}{<var>T1[1]</var>}</code></span>
                         <span data-else=""><code><var>T1[0]</var></code></span>
-                        <code> = <var>round(DIST1)</var></code>  miles by <var>vehicle(1)</var>.
+                        <code> \approx <var>round(DIST1)</var></code>  miles by <var>vehicle(1)</var>.
                     </p>
                 </div>
             </div>
@@ -86,12 +86,12 @@
                         So he traveled <code><var>SPEED2</var> \times </code> 
                         <span data-if="T2[1] !== 1"><code>\frac{<var>T2[0]</var>}{<var>T2[1]</var>}</code></span>
                         <span data-else=""><code><var>T2[0]</var></code></span>
-                        <code> = <var>round(DIST2)</var></code> miles by <var>vehicle(2)</var>.
+                        <code> \approx <var>round(DIST2)</var></code> miles by <var>vehicle(2)</var>.
                     </p><p data-else="">
                         So she traveled <code><var>SPEED2</var> \times </code> 
                         <span data-if="T2[1] !== 1"><code>\frac{<var>T2[0]</var>}{<var>T2[1]</var>}</code></span>
                         <span data-else=""><code><var>T2[0]</var></code></span>
-                        <code> = <var>round(DIST2)</var></code> miles by <var>vehicle(2)</var>.
+                        <code> \approx <var>round(DIST2)</var></code> miles by <var>vehicle(2)</var>.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
replace _=_ with _\approx_ (≈) for rounded result in hint text
