### PR TITLE
Simplifying rational expressions 4

### DIFF
--- a/exercises/simplifying_rational_expressions_4.html
+++ b/exercises/simplifying_rational_expressions_4.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html data-require="math math-format rational-expressions">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Simplifying rational expressions 4</title>
+    <script src="../khan-exercise.js"></script>
+    <style type="text/css">
+        #solutionarea td {
+            text-align: center;
+            vertical-align: middle;
+            padding-left: 4px;
+            padding-right: 4px;
+        }
+        #solutionarea .soln-top {
+            padding-bottom: 1px;
+        }
+        #solutionarea .soln-bot {
+            padding-top: 1px;
+            border-top: 1px solid black;
+        }
+        #solutionarea .soln-dom {
+            padding-left: 3px;
+        }
+    </style>
+</head>
+<body>
+    <div class="exercise">
+        <div class="vars">
+            <var id="X">randVar()</var>
+            <var id="Y" data-ensure="X !== Y">randVar()</var>
+            
+            <var id="A">randRangeNonZero(-10, 10)</var>
+            <var id="FACTOR">new RationalExpression([[1, X], A])</var>
+
+            <var id="TERM1">new RationalExpression([[1, X], randRangeNonZero(-10, 10)])</var>
+            <var id="TERM2">
+                randRange(0, 1) ? new Term(randRangeExclude(-10, 10, [0, 1])) :
+                                  new Term(randRangeWeightedExclude(-10, 10, 1, 0.3, [0]), X)
+            </var>
+            <var id="NUMERATOR">FACTOR.multiply(TERM1).multiply(TERM2)</var>
+            <var id="NUM_FACTOR">NUMERATOR.terms[0].coefficient &gt; 0 ? NUMERATOR.factor() : NUMERATOR.factor().multiply(-1)</var>
+
+            <var id="TERM3">new RationalExpression([[1, X], randRangeNonZero(-10, 10)])</var>
+            <var id="TERM4">
+                randRange(0, 1) ? new Term(randRangeExclude(-10, 10, [0, 1])) :
+                                  new Term(randRangeWeightedExclude(-10, 10, 1, 0.3, [0]), X)
+            </var>
+            <var id="DENOMINATOR">FACTOR.multiply(TERM3).multiply(TERM4)</var>
+            <var id="DEN_FACTOR">DENOMINATOR.terms[0].coefficient &gt; 0 ? DENOMINATOR.factor() : DENOMINATOR.factor().multiply(-1)</var>
+
+            <var id="TERM_FACTOR">DEN_FACTOR.coefficient &gt; 0 ? NUM_FACTOR.getGCD(DEN_FACTOR) : NUM_FACTOR.getGCD(DEN_FACTOR).multiply(-1)</var>
+            <var id="NUM_FACTOR2">NUM_FACTOR.divide(TERM_FACTOR)</var>
+            <var id="DEN_FACTOR2">DEN_FACTOR.divide(TERM_FACTOR)</var>
+
+            <var id="NUMERATOR_SOL">TERM1.multiply(NUM_FACTOR2)</var>
+            <var id="DENOMINATOR_SOL">TERM3.multiply(DEN_FACTOR2)</var>
+        </div>
+
+        <div class="problems">
+            <div>
+
+                <p class="problem">
+                    Simplify the following expression and state the condition under which the simplification is valid.
+                    You can assume that <code><var>X</var> \neq 0</code>.
+                </p>
+                <p class="question"><code><var>Y</var> = \dfrac{<var>NUMERATOR</var>}{<var>DENOMINATOR</var>}</code></p>
+
+                <div class="solution" data-type="set">
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NUMERATOR_SOL.regex(true)</var></span>
+                        <span class="sol" data-type="regex"><var>DENOMINATOR_SOL.regex(true)</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
+                    </div>
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NUMERATOR_SOL.multiply(-1).regex(true)</var></span>
+                        <span class="sol" data-type="regex"><var>DENOMINATOR_SOL.multiply(-1).regex(true)</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
+                    </div>
+
+                    <div class="input-format">
+                        <div class="entry" data-type="multiple">
+                            <table>
+                                <tbody><tr>
+                                    <td>
+                                        <code><var>Y</var> = </code>
+                                    </td>
+                                    <td><table>
+                                        <tbody><tr>
+                                            <td class="soln-top">
+                                                <span class="sol short50">a</span>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="soln-bot">
+                                                <span class="sol short50" data-fallback="1">a</span>
+                                            </td>
+                                        </tr>
+                                    </tbody></table></td>
+                                    <td>
+                                        <code> \space <var>X</var> \neq </code><span class="sol soln-dom short32">a</span>
+                                    </td>
+                                </tr>
+                            </tbody></table>
+                        </div>
+                    </div>
+                    <div class="example">a simplifed expression, like <code>x + 2</code></div>
+                </div>
+            </div>
+        </div>
+
+
+        <div class="hints">
+            <p>First factor out the greatest common factors in the numerator and in the denominator.</p>
+
+            <p><code>\qquad <var>Y</var> = \dfrac{<var>NUM_FACTOR</var>}{<var>DEN_FACTOR</var>} \cdot
+                \dfrac{<var>NUMERATOR.divide(NUM_FACTOR)</var>}{<var>DENOMINATOR.divide(DEN_FACTOR)</var>}</code></p>
+
+            <div data-if="!TERM_FACTOR.isOne()">
+                <p>Simplify:</p>
+                <p><code>\qquad <var>Y</var> =
+                    <span data-if="!DEN_FACTOR2.isOne()">\dfrac{<var>NUM_FACTOR2</var>}{<var>DEN_FACTOR2</var>} \cdot </span>
+                    <span data-else-if="!NUM_FACTOR2.isOne()"><var>NUM_FACTOR2</var> \cdot </span>
+                    \dfrac{<var>NUMERATOR.divide(NUM_FACTOR)</var>}{<var>DENOMINATOR.divide(DEN_FACTOR)</var>}</code></p>
+            </div>
+
+            <p>Next factor the numerator and denominator.</p>
+
+            <p><code>\qquad <var>Y</var> =
+                <span data-if="!DEN_FACTOR2.isOne()">\dfrac{<var>NUM_FACTOR2</var>}{<var>DEN_FACTOR2</var>} \cdot </span>
+                <span data-else-if="!NUM_FACTOR2.isOne()"><var>NUM_FACTOR2</var> \cdot </span>
+                \dfrac{(<var>FACTOR</var>)(<var>TERM1</var>)}{(<var>FACTOR</var>)(<var>TERM3</var>)}</code></p>
+
+            <div>
+                <p>Assuming <code><var>X</var> \neq <var>-A</var></code>, we can cancel the <code><var>FACTOR</var></code>.</p>
+                <p><code>\qquad <var>Y</var> =
+                    <span data-if="!DEN_FACTOR2.isOne()">\dfrac{<var>NUM_FACTOR2</var>}{<var>DEN_FACTOR2</var>} \cdot </span>
+                    <span data-else-if="!NUM_FACTOR2.isOne()"><var>NUM_FACTOR2</var> \cdot </span>
+                    \dfrac{<var>TERM1</var>}{<var>TERM3</var>}</code></p>
+            </div>
+
+            <div>
+                <p>Therefore:</p>
+                <code>\qquad <var>Y</var> = \dfrac{
+                    <span data-if="NUM_FACTOR2.isOne()"><var>TERM1</var></span>
+                    <span data-else-if="NUM_FACTOR2.toString() === '-1'"><var>TERM1.multiply(-1)</var></span>
+                    <span data-else=""><var>NUM_FACTOR2</var>(<var>TERM1</var>)</span>}{
+                    <span data-if="DEN_FACTOR2.isOne()"><var>TERM3</var></span>
+                    <span data-else=""><var>DEN_FACTOR2</var>(<var>TERM3</var>)</span>}</code>,
+                <code><var>X</var> \neq <var>-A</var></code>
+            </div>
+
+        </div>
+    </div>
+</body>
+</html>

--- a/utils/rational-expressions.js
+++ b/utils/rational-expressions.js
@@ -21,7 +21,7 @@ $.extend(KhanUtil, {
         return permute(arr);
     },
 
-	getExpressionRegex: function(coefficient, vari, constant) {
+    getExpressionRegex: function(coefficient, vari, constant) {
         // Capture Ax + B or B + Ax, either A or B can be 0
 
         if (coefficient === 0) {
@@ -60,7 +60,7 @@ $.extend(KhanUtil, {
         }
 
         return regex;
-	},
+    },
 
     /*
     Term in an expression
@@ -93,6 +93,10 @@ $.extend(KhanUtil, {
             } else {
                 delete this.variables[vari];
             }
+        }
+
+        this.isOne = function() {
+            return this.toString() === '1';
         }
 
         // Return a new term representing this term multiplied by another term or a number
@@ -211,11 +215,15 @@ $.extend(KhanUtil, {
             }
 
             // Add variable of degree 1 in random order
-            // Won't work if there are multiple variable or variables of degree > 1
+            // Won't work if there are multiple variable
             for (var vari in this.variables) {
-                if (this.variables[vari] === 1) {
+                var degree = this.variables[vari];
+                if (degree !== 0) {
                     regex += vari;
-                }
+                    if (degree > 1) {
+                        regex += "\\s*\\^\\s*" + degree;
+                    }
+                } 
             }
 
             return regex + "\\s*";
@@ -354,23 +362,62 @@ $.extend(KhanUtil, {
             return s !== "" ? s : '0';
         };
 
-        // Returns a single regex to capture this expression.
-        // It will capture every permutations of terms so is
-        // not recommended for expressions with more than 3-4 terms
-        this.regex = function() {
-            var permutations = KhanUtil.getPermutations(this.terms);
+        // Returns a regex that captures all permutation passed in
+        this.getTermsRegex = function(permutations, start, stop) {
             var regex = "";
 
+            start = start ?  "|(?:^" + start : "|(?:^";
+            stop = stop ?  stop + "$)" : "$)";
+
             for (var p = 0; p < permutations.length; p++) {
-                regex += p ? "|(?:^" : "(?:^";
+                regex += start;
 
                 var terms = permutations[p];
                 for (var i = 0; i < terms.length; i++) {
                     regex += terms[i].regex(i);
                 }
 
-                regex += "$)";
+                regex += stop;
             }
+            return regex;
+        }
+
+        // Returns a single regex to capture this expression.
+        // It will capture every permutations of terms so is
+        // not recommended for expressions with more than 3 terms
+        // If allowFactors is true, 3(x + 4) will match 3x + 12
+        this.regex = function(allowFactors) {
+            var permutations = KhanUtil.getPermutations(this.terms);
+            var regex = this.getTermsRegex(permutations).slice(1);
+
+            if (!allowFactors) {
+                return regex;
+            }
+
+            // Generate regex factored expression
+            var factor = this.factor();
+            var divided = this.divide(factor);
+
+            if (factor.isOne() || factor.toString() === '-1') {
+                return regex;
+            }
+
+            permutations = KhanUtil.getPermutations(divided.terms);
+
+            // Factor before parentheses
+            regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
+            // Factor after parentheses
+            regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
+
+            // Factor out a negative
+            factor = factor.multiply(-1);
+            divided = divided.multiply(-1);
+            permutations = KhanUtil.getPermutations(divided.terms);
+
+            // Factor before parentheses
+            regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
+            // Factor after parentheses
+            regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
 
             return regex;
         };


### PR DESCRIPTION
Simplifying rational expression where each expression is a trinomial or difference of squares multiplied by a constant, a variable or both.

![simplifying rational expressions 4](https://f.cloud.github.com/assets/219302/798701/5c943f42-ed66-11e2-9b7e-e2f3ca0ec47e.png)

Accepts as many possible valid answers as I could think of, e.g.

7y(y−3), 7y \* (y-3), (y-3)7y, 7y(-3+y), -7y(-y+3), 7y^2 - 21y, -21y + 7y^2

Wouldn't accept y(7y - 21): answers must be fully factored or not factored. Will be useful to make dividing_polynomials_by_binomials_2.html more forgiving and fix things like #50734
