### PR TITLE
Avoid expressions that simplify too much

### DIFF
--- a/exercises/multiplying_and_dividing_rational_expressions_1.html
+++ b/exercises/multiplying_and_dividing_rational_expressions_1.html
@@ -23,21 +23,18 @@
 <body>
     <div class="exercise">
         <div class="vars">
-            <div data-ensure="X !== Y">
-                <var id="X">randVar()</var>
-                <var id="Y">randVar()</var>
+            <var id="X">randVar()</var>
+            <var id="Y" data-ensure="X !== Y">randVar()</var>
+
+            <div data-ensure="!(DENOMINATOR.divide(NUMERATOR))">
+                <var id="DENOMCOEFF">randRangeWeighted(1, 8, 1, 0.25)</var>
+                <var id="DENOMCONST">randRangeWeighted(-10, 10, 0, 0.25)</var>
+                <var id="DENOMINATOR">new RationalExpression([[DENOMCOEFF, X], [DENOMCONST]])</var>
+                <var id="NUMERCONST" data-ensure="DENOMCONST !== 0 || NUMERCONST !== 0">randRange(-10, 10)</var>
+                <var id="NUMERCOEFF" data-ensure="NUMERCOEFF !== 0 || NUMERCONST !== 0">randRange(-8, 8)</var>
+                <var id="NUMERATOR">new RationalExpression([[NUMERCOEFF, X], [NUMERCONST]])</var>
             </div>
-            <var id="DENOMCOEFF">randRangeWeighted(1, 8, 1, 0.25)</var>
-            <var id="DENOMCONST">randRangeWeighted(-10, 10, 0, 0.25)</var>
-            <var id="DENOMINATOR">new RationalExpression([[DENOMCOEFF, X], [DENOMCONST]])</var>
-            
-            <div data-ensure="DENOMCONST !== 0 || NUMERCONST !== 0">
-                <var id="NUMERCONST">randRange(-10, 10)</var>
-            </div>
-            <div data-ensure="NUMERCOEFF !== 0 || NUMERCONST !== 0">
-                <var id="NUMERCOEFF">randRange(-8, 8)</var>
-            </div>
-            <var id="NUMERATOR">new RationalExpression([[NUMERCOEFF, X], [NUMERCONST]])</var>
+
             <var id="CONSTANT">randRange(0, 1) ? [randRange(2, 10), 1] : [1, randRange(2, 10)]</var>
             <var id="NUMERPRODUCT">NUMERATOR.multiply(CONSTANT[0])</var>
             <var id="DENOMPRODUCT">DENOMINATOR.multiply(CONSTANT[1])</var>

--- a/exercises/simplifying_rational_expressions_4.html
+++ b/exercises/simplifying_rational_expressions_4.html
@@ -38,7 +38,7 @@
                                   new Term(randRangeWeightedExclude(-10, 10, 1, 0.3, [0]), X)
             </var>
             <var id="NUMERATOR">FACTOR.multiply(TERM1).multiply(TERM2)</var>
-            <var id="NUM_FACTOR">NUMERATOR.terms[0].coefficient &gt; 0 ? NUMERATOR.factor() : NUMERATOR.factor().multiply(-1)</var>
+            <var id="NUM_FACTOR">NUMERATOR.terms[0].coefficient &gt; 0 ? NUMERATOR.getTermsGCD() : NUMERATOR.getTermsGCD().multiply(-1)</var>
 
             <var id="TERM3">new RationalExpression([[1, X], randRangeNonZero(-10, 10)])</var>
             <var id="TERM4">
@@ -46,7 +46,7 @@
                                   new Term(randRangeWeightedExclude(-10, 10, 1, 0.3, [0]), X)
             </var>
             <var id="DENOMINATOR">FACTOR.multiply(TERM3).multiply(TERM4)</var>
-            <var id="DEN_FACTOR">DENOMINATOR.terms[0].coefficient &gt; 0 ? DENOMINATOR.factor() : DENOMINATOR.factor().multiply(-1)</var>
+            <var id="DEN_FACTOR">DENOMINATOR.terms[0].coefficient &gt; 0 ? DENOMINATOR.getTermsGCD() : DENOMINATOR.getTermsGCD().multiply(-1)</var>
 
             <var id="TERM_FACTOR">DEN_FACTOR.coefficient &gt; 0 ? NUM_FACTOR.getGCD(DEN_FACTOR) : NUM_FACTOR.getGCD(DEN_FACTOR).multiply(-1)</var>
             <var id="NUM_FACTOR2">NUM_FACTOR.divide(TERM_FACTOR)</var>

--- a/utils/rational-expressions.js
+++ b/utils/rational-expressions.js
@@ -427,6 +427,35 @@ $.extend(KhanUtil, {
         };
         this.combineLikeTerms();
 
+        // Test whether this expressions is equal to the one passed in
+        // Assumes the like terms in both expressions have been combined
+        this.isEqualTo = function(that) {
+            var n1 = this.terms.length;
+            var n2 = that.terms.length;
+
+            if (n1 !== n2) {
+                return false;
+            }
+
+            for (var i=0; i<n1; i++) {
+                var t1 = this.terms[i];
+                var found = false;
+
+                for (var j=0; j<n2; j++) {
+                    var t2 = that.terms[j]
+                    if (t1.coefficient === t2.coefficient && t1.variableString === t2.variableString) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
         this.isNegative = function() {
             return this.terms[0].coefficient < 0;
         };
@@ -438,9 +467,11 @@ $.extend(KhanUtil, {
         this.getCoefficentOfTerm = function(variable, degree) {
             var variableString = "";
 
-            if (variable !== undefined && degree !== 0) {
+            if (variable === '') {
+                variableString = '';
+            } else if (variable !== undefined && degree !== 0) {
                 degree = degree || 1;
-                variableString += variable + degree;
+                variableString = variable + degree;
             }
 
             for (var i = 0; i < this.terms.length; i++) {
@@ -514,20 +545,59 @@ $.extend(KhanUtil, {
             return new KhanUtil.RationalExpression(terms);
         };
 
-        // Return a new expression representing this one divided by a term or number
-        // Note you cannot divide by another expression
-        this.divide = function(term) {
-            var terms = [];
+        // Return a new expression representing this one divided by another expression
+        // Assumes this expression can be factored to remove the one passed in
+        this.divide = function(expression) {
+            if (expression instanceof KhanUtil.RationalExpression) {
+                if (this.terms.length === 1) {
+                    return this.divideByTerm(expression.terms[0]);
+                }
 
-            for (var i = 0; i < this.terms.length; i++) {
-                terms.push(this.terms[i].divide(term));
+                var factors1 = this.factor();
+                var factors2 = expression.factor();
+
+                if (factors1[1].isEqualTo(factors2[1])) {
+                    var value = factors1[0].divide(factors2[0]);
+                    return new KhanUtil.RationalExpression([value]);
+                } else if (factors1[1].isEqualTo(factors2[1].multiply(-1))) {
+                    var value = factors1[0].divide(factors2[0]).multiply(-1);
+                    return new KhanUtil.RationalExpression([value]);
+                } else {
+                    // Cannot divide by this expression
+                    // Can be used to check whether expression have a common factor
+                    return false;
+                }
+
+            } else {
+                var terms = [];
+
+                for (var i = 0; i < this.terms.length; i++) {
+                    terms.push(this.terms[i].divide(expression));
+                }
+
+                return new KhanUtil.RationalExpression(terms);
+            }
+        };
+
+        // Return a Term object representing the greatest common factor between this expression and another
+        this.getGCD = function(that) {
+            var t1 = this.getTermsGCD();
+            var GCD;
+
+            if (that instanceof KhanUtil.Term) {
+                GCD = t1.getGCD(that);
+            } else {
+                GCD = t1.getGCD(that.getTermsGCD());
             }
 
-            return new KhanUtil.RationalExpression(terms);
+            if (GCD.coefficient < 0) {
+                GCD.coefficient *= -1;
+            }
+            return GCD
         };
 
         // Return a Term object representing the greatest common divisor of all the terms in this expression
-        this.factor = function() {
+        this.getTermsGCD = function() {
             var GCD = this.terms[0];
 
             for (var i=0; i<this.terms.length; i++) {
@@ -541,22 +611,13 @@ $.extend(KhanUtil, {
             return GCD;
         };
 
-        // Return a Term object representing the greatest common factor between this expression and another
-        this.getGCD = function(that) {
-            var t1 = this.factor();
-            var GCD;
-
-            if (that instanceof KhanUtil.Term) {
-                GCD = t1.getGCD(that);
-            } else {
-                GCD = t1.getGCD(that.factor());
-            }
-
-            if (GCD.coefficient < 0) {
-                GCD.coefficient *= -1;
-            }
-            return GCD
-        };
+        // Factor out the GCD of all terms and return [GCD, remaining expression]
+        // e.g. 6x + 4x^2 => [2x, 3 + 2x]
+        this.factor = function() {
+            var gcd = this.getTermsGCD();
+            var factor = this.divide(gcd);
+            return [gcd, factor];
+        }
 
         this.toString = function() {
             if (this.terms.length === 0) {
@@ -573,9 +634,9 @@ $.extend(KhanUtil, {
 
         // Return a string of the factored expression
         this.toStringFactored = function(parenthesise) {
-            var f = this.factor();
+            var factors = this.factor();
 
-            if (this.terms.length === 1 || f.toString() === '1') {
+            if (this.terms.length === 1 || factors[0].isOne()) {
                 if (parenthesise) {
                    return "(" + this.toString() + ")";
                 } else {
@@ -583,11 +644,9 @@ $.extend(KhanUtil, {
                 }
             }
 
-            var s = (f.toString() === '-1') ? '-' : f.toString();
-            var divided = this.divide(f);
+            var s = (factors[0].toString() === '-1') ? '-' : factors[0].toString();
+            s += "(" + factors[1].toString() + ")";
 
-            var s = (f.toString() === '-1') ? '-' : f.toString();
-            s += "(" + divided.toString() + ")";
             return s;
         };
 
@@ -637,128 +696,32 @@ $.extend(KhanUtil, {
             // Generate regex factored expression
             // If GCD is 1, will accept parenthesised expression
             // e.g. p - 5 will accept (p - 5)
-            var factor = this.factor();
-            var divided = this.divide(factor);
-            permutations = KhanUtil.getPermutations(divided.terms);
+            var factors = this.factor();
+            permutations = KhanUtil.getPermutations(factors[1].terms);
 
-            if (factor.toString() === '1') {
+            if (factors[0].isOne()) {
                 regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*");
-            } else if (factor.toString() === '-1') {
+            } else if (factors[0].toString() === '-1') {
                 regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
             } else {
-                // Factor before parentheses
-                regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-                // Factor after parentheses
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
+                regex += this.getTermsRegex(permutations, factors[0].regex() + "\\*?\\s*\\(", "\\)\\s*");
             }
 
             // Factor out a negative
-            factor = factor.multiply(-1);
-            divided = divided.multiply(-1);
-            permutations = KhanUtil.getPermutations(divided.terms);
+            factors[0] = factors[0].multiply(-1);
+            factors[1] = factors[1].multiply(-1);
+            permutations = KhanUtil.getPermutations(factors[1].terms);
 
-            if (factor.toString === '1') {
+            if (factors[0].isOne()) {
                 regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*");
-            } else if (factor.toString === '-1') {
+            } else if (factors[0].toString === '-1') {
                 regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
             } else {
-                // Factor before parentheses
-                regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-                // Factor after parentheses
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
+                regex += this.getTermsRegex(permutations, factors[0].regex() + "\\*?\\s*\\(", "\\)\\s*");
             }
-
-            // Generate regex factored expression
-            // If GCD is 1, will accept parenthesised expression
-            // e.g. p - 5 will accept (p - 5)
-            var factor = this.factor();
-            var divided = this.divide(factor);
-            permutations = KhanUtil.getPermutations(divided.terms);
-
-            if (factor.toString() === '1') {
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*");
-            } else if (factor.toString() === '-1') {
-                regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
-            } else {
-                // Factor before parentheses
-                regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-                // Factor after parentheses
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
-            }
-
-            // Factor out a negative
-            factor = factor.multiply(-1);
-            divided = divided.multiply(-1);
-            permutations = KhanUtil.getPermutations(divided.terms);
-
-            if (factor.toString === '1') {
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*");
-            } else if (factor.toString === '-1') {
-                regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
-            } else {
-                // Factor before parentheses
-                regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-                // Factor after parentheses
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
-            }
-
-            // Factor out a negative
-            factor = factor.multiply(-1);
-            divided = divided.multiply(-1);
-            permutations = KhanUtil.getPermutations(divided.terms);
-
-            if (factor.toString === '1') {
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*");
-            } else if (factor.toString === '-1') {
-                regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
-            } else {
-                // Factor before parentheses
-                regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-                // Factor after parentheses
-                regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
-            }
+   
             return regex;
         }
-
-        // Returns a single regex to capture this expression.
-        // It will capture every permutations of terms so is
-        // not recommended for expressions with more than 3 terms
-        // If allowFactors is true, 3(x + 4) will match 3x + 12
-        this.regex = function(allowFactors) {
-            var permutations = KhanUtil.getPermutations(this.terms);
-            var regex = this.getTermsRegex(permutations).slice(1);
-
-            if (!allowFactors) {
-                return regex;
-            }
-
-            // Generate regex factored expression
-            var factor = this.factor();
-            var divided = this.divide(factor);
-
-            if (factor.isOne() || factor.toString() === '-1') {
-                return regex;
-            }
-
-            permutations = KhanUtil.getPermutations(divided.terms);
-
-            // Factor before parentheses
-            regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-            // Factor after parentheses
-            regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
-
-            // Factor out a negative
-            factor = factor.multiply(-1);
-            divided = divided.multiply(-1);
-            permutations = KhanUtil.getPermutations(divided.terms);
-
-            // Factor before parentheses
-            regex += this.getTermsRegex(permutations, factor.regex() + "\\*?\\s*\\(", "\\)\\s*");
-            // Factor after parentheses
-            regex += this.getTermsRegex(permutations, "\\s*\\(", "\\)\\s*\\*?" + factor.regex());
-
-            return regex;
-        };
     }
 
 });

--- a/utils/test/rational_expressions.html
+++ b/utils/test/rational_expressions.html
@@ -195,10 +195,10 @@
         start();
     });
 
-    asyncTest("factor expression", 3, function() {
-        strictEqual(e1.factor().toString(), "4", "single digit");
-        strictEqual(e4.factor().toString(), "2", "digit factor");
-        strictEqual(e5.factor().toString(), "2x", "term factor");
+    asyncTest("expression term GCD", 3, function() {
+        strictEqual(e1.getTermsGCD().toString(), "4", "single digit");
+        strictEqual(e4.getTermsGCD().toString(), "2", "digit factor");
+        strictEqual(e5.getTermsGCD().toString(), "2x", "term factor");
         start();
     });
 
@@ -217,6 +217,22 @@
         start();
     });
 
+    asyncTest("coefficient of term", 4, function() {
+        strictEqual(e3.getCoefficentOfTerm('x'), 1, "coefficient of positive term");
+        strictEqual(e4.getCoefficentOfTerm('x'), -12, "coefficient of negative term");
+        strictEqual(e4.getCoefficentOfTerm('x2'), 0, "coefficient of non-existant term");
+        strictEqual(e5.getCoefficentOfTerm('x2y3'), 0, "coefficient of multi-variable term");
+        start();
+    });
+
+    asyncTest("evaluation expression", 4, function() {
+        strictEqual(e1.evaluate(3), 4, "constant expression");
+        strictEqual(e2.evaluate(3), -32, "evaluate positive");
+        strictEqual(e3.evaluate(-3), 2, "evaluate negative");
+        strictEqual(e4.evaluate({x: 3, y: 2}), 112, "evaluate multiple");
+        start();
+    });
+
     asyncTest("expression regex", 14, function() {
         checkRegex(e1.regex(), "4", true, "digit right answer is right");
         checkRegex(e1.regex(), "-4", false, "digit wrong answer is wrong");
@@ -228,7 +244,7 @@
         checkRegex(e2.regex(), "(-12x+4)", false, "right answer parenthesised is wrong (?)");
         checkRegex(e2.regex(true), "4(-3x+1)", true, "factored positive is right");
         checkRegex(e2.regex(true), "-4(3x-1)", true, "factored negative is right");
-        checkRegex(e2.regex(true), "(-3x+1)4", true, "factor following is right");
+        checkRegex(e2.regex(true), "(-3x+1)4", false, "factor following is wrong");
         checkRegex(e2.regex(true), "4(1-3x)", true, "factored reversed is right");
         checkRegex(e3.regex(true), "x + 5", true, "coefficient of one ignored is right");
         checkRegex(e3.regex(true), "1x + 5", false, "coefficient of one included is wrong (?)");
@@ -244,6 +260,12 @@
         checkRegex(e4.regex(), "4 - 12x + 2x^2y^3", true, "right answer CBA is right");
         checkRegex(e4.regex(true), "2(x^2y^3 - 6x + 2)", true, "right answer variables factored is right");
         checkRegex(e4.regex(), "2y^3x^2 - 12x + 4", true, "right answer variables reversed is right");
+        start();
+    });
+
+    asyncTest("isEqual", 2, function() {
+        strictEqual(e1.isEqualTo(new KhanUtil.RationalExpression([4])), true, "single digit equal to single digit");
+        strictEqual(e2.isEqualTo(e1.add(t3)), true, "expression equal to sum of terms");
         start();
     });
 


### PR DESCRIPTION
Fix merging issues from #49514 caused by me renaming functions and ensure rational-expressions.js is completely up to date. Also add more unit tests for new functions. Update simplifying_rational_expressions_4.html which I think/hope is the only exercise to use the old function name.
