### PR TITLE
Fix drag behavior of 3D volume models in Firefox

### DIFF
--- a/exercises/volume_1.html
+++ b/exercises/volume_1.html
@@ -186,6 +186,8 @@
                     fill: "#000", opacity: 0.0
                 });
                 $(mouseTarget[0]).bind("vmousedown", function(event) {
+                    event.preventDefault();
+
                     GRAPH.lastX = event.pageX;
                     GRAPH.lastY = event.pageY;
 

--- a/exercises/volume_2.html
+++ b/exercises/volume_2.html
@@ -206,6 +206,8 @@
                         fill: "#000", opacity: 0.0
                     });
                     $(mouseTarget[0]).bind("vmousedown", function(event) {
+                        event.preventDefault();
+
                         GRAPH.lastX = event.pageX;
                         GRAPH.lastY = event.pageY;
 

--- a/exercises/volume_with_unit_cubes.html
+++ b/exercises/volume_with_unit_cubes.html
@@ -351,6 +351,8 @@
                 });
 
                 $(mouseTarget[0]).bind("vmousedown", function(event) {
+                    event.preventDefault();
+
                     GRAPH.lastX = event.pageX;
                     GRAPH.lastY = event.pageY;
 


### PR DESCRIPTION
In Firefox, trying to drag a 3D model had a high chance of the cursor turning into the "cannot drag image here" cursor, not moving the model at all (looks like it was trying to drag the rendered image).  Upon letting go of the mouse button, moving the mouse would move the model (with no buttons being held) until the next click.

This fixes that behavior.
