### PR TITLE
Improve consistency of rational expression module

### DIFF
--- a/exercises/adding_and_subtracting_rational_expressions_3.html
+++ b/exercises/adding_and_subtracting_rational_expressions_3.html
@@ -28,7 +28,7 @@
             <var id="Y" data-ensure="X !== Y">randVar()</var>
 
             <var id="EXPR1">new RationalExpression([[randRangeWeightedExclude(-10, 10, 1, 0.4, [0]),X], randRangeNonZero(-10, 10)])</var>
-            <div data-ensure="getGCD(TERM1.coefficient, TERM2.coefficient) === 1">
+            <div data-ensure="TERM1.getGCD(TERM2).toString() === '1'">
                 <var id="TERM1">new Term(randRangeNonZero(-10, 10))</var>
                 <var id="TERM2">new Term(randRange(1, 10))</var>
             </div>
@@ -97,12 +97,12 @@
 
        <div class="solution" data-type="set">
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>NUMERSOL.regex(!(NUMERSOL instanceof Term))</var></span>
-                <span class="sol" data-type="regex"><var>DENOMSOL.regex(!(DENOMSOL instanceof Term))</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.regex(true)</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex(!(NUMERSOL instanceof Term))</var></span>
-                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex(!(DENOMSOL instanceof Term))</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex(true)</var></span>
             </div>
 
             <div class="input-format">

--- a/exercises/multiplying_and_dividing_rational_expressions_3.html
+++ b/exercises/multiplying_and_dividing_rational_expressions_3.html
@@ -126,13 +126,13 @@
 
         <div class="solution" data-type="set">
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.regex() + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.regex() + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.regex()</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.regex()</var></span>
                 <span class="sol" data-type="rational"><var>-CONSTANT/COEFFICIENT</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.multiply(-1).regex() + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.multiply(-1).regex() + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex()</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex()</var></span>
                 <span class="sol" data-type="rational"><var>-CONSTANT/COEFFICIENT</var></span>
             </div>
 
@@ -146,12 +146,12 @@
                             <td><table>
                                 <tbody><tr>
                                     <td class="soln-top">
-                                        <span class="sol short50">a</span>
+                                        <span class="sol short32">a</span>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="soln-bot">
-                                        <span class="sol short50" data-fallback="1">a</span>
+                                        <span class="sol short32" data-fallback="1">a</span>
                                     </td>
                                 </tr>
                             </tbody></table></td>

--- a/exercises/multiplying_and_dividing_rational_expressions_4.html
+++ b/exercises/multiplying_and_dividing_rational_expressions_4.html
@@ -168,26 +168,26 @@
 
         <div class="solution" data-type="set">
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.regex(true)</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
                 <span class="sol" data-type="number"><var>SOL</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.regex(true)</var></span>
                 <span class="sol" data-type="number"><var>SOL</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.multiply(-1).regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.multiply(-1).regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex(true)</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
                 <span class="sol" data-type="number"><var>SOL</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.multiply(-1).regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.multiply(-1).regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex(true)</var></span>
                 <span class="sol" data-type="number"><var>SOL</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
             </div>

--- a/exercises/multiplying_and_dividing_rational_expressions_5.html
+++ b/exercises/multiplying_and_dividing_rational_expressions_5.html
@@ -125,26 +125,26 @@
 
         <div class="solution" data-type="set">
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.regex(true)</var></span>
                 <span class="sol" data-type="number"><var>-A</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.regex(true)</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
                 <span class="sol" data-type="number"><var>-A</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.multiply(-1).regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.multiply(-1).regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex(true)</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
                 <span class="sol" data-type="number"><var>-A</var></span>
             </div>
             <div class="set-sol" data-type="multiple">
-                <span class="sol" data-type="regex"><var>'^' + NUMERSOL.multiply(-1).regex(true) + '$'</var></span>
-                <span class="sol" data-type="regex"><var>'^' + DENOMSOL.multiply(-1).regex(true) + '$'</var></span>
+                <span class="sol" data-type="regex"><var>NUMERSOL.multiply(-1).regex(true)</var></span>
+                <span class="sol" data-type="regex"><var>DENOMSOL.multiply(-1).regex(true)</var></span>
                 <span class="sol" data-type="number"><var>-A</var></span>
                 <span class="sol" data-type="number"><var>-B</var></span>
             </div>

--- a/exercises/multiplying_and_dividing_rational_expressions_5.html
+++ b/exercises/multiplying_and_dividing_rational_expressions_5.html
@@ -260,7 +260,10 @@
                 </code></p>
             </div>
 
-            <p><code><var>Y</var> = \dfrac{<var>NUMERSOL.toStringFactored()</var>}{<var>DENOMSOL.toStringFactored()</var>}</code></p>
+            <p><code>
+                <var>Y</var> = \dfrac{<var>NUMERSOL.toStringFactored()</var>}{<var>DENOMSOL.toStringFactored()</var>};
+                <var>X</var> \neq <var>-A</var>; <var>X</var> \neq <var>-B</var>
+            </code></p>
 
         </div>
     </div>

--- a/utils/rational-expressions.js
+++ b/utils/rational-expressions.js
@@ -265,7 +265,13 @@ $.extend(KhanUtil, {
 
         // Return a regex that will capture this term
         // If includeSign is true, then 4x is captured by +4x
-        this.regex = function(includeSign) {
+        this.regex = function() {
+            return '^' + this.regexForExpression() + '$';
+        };
+
+        // Return a regex that will capture this term
+        // If includeSign is true, then 4x is captured by +4x
+        this.regexForExpression = function(includeSign) {
             if (this.coefficient === 0) {
                 return '';
             }
@@ -312,25 +318,8 @@ $.extend(KhanUtil, {
                 regex += degree > 1 ? vari + "\\s*\\^\\s*" + degree : vari;
             }
 
-
-
-            // Add variable of degree 1 in random order
-            // Only captures one order if there are multiple variables
-
-            /*
-            for (var vari in this.variables) {
-                var degree = this.variables[vari];
-                if (degree !== 0) {
-                    regex += vari;
-                    if (degree > 1) {
-                        regex += "\\s*\\^\\s*" + degree;
-                    }
-                }
-            }
-            */
-
             return regex + '\\s*';
-        };
+        }
 
     },
 
@@ -642,7 +631,7 @@ $.extend(KhanUtil, {
 
                 var terms = permutations[p];
                 for (var i = 0; i < terms.length; i++) {
-                    regex += terms[i].regex(i);
+                    regex += terms[i].regexForExpression(i);
                 }
 
                 regex += stop;
@@ -673,7 +662,7 @@ $.extend(KhanUtil, {
             } else if (factors[0].toString() === '-1') {
                 regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
             } else {
-                regex += this.getTermsRegex(permutations, factors[0].regex() + "\\*?\\s*\\(", "\\)\\s*");
+                regex += this.getTermsRegex(permutations, factors[0].regexForExpression() + "\\*?\\s*\\(", "\\)\\s*");
             }
 
             // Factor out a negative
@@ -686,7 +675,7 @@ $.extend(KhanUtil, {
             } else if (factors[0].toString === '-1') {
                 regex += this.getTermsRegex(permutations, "\\s*[-\\u2212]\\s*\\(", "\\)\\s*");
             } else {
-                regex += this.getTermsRegex(permutations, factors[0].regex() + "\\*?\\s*\\(", "\\)\\s*");
+                regex += this.getTermsRegex(permutations, factors[0].regexForExpression() + "\\*?\\s*\\(", "\\)\\s*");
             }
    
             return regex;

--- a/utils/test/rational_expressions.html
+++ b/utils/test/rational_expressions.html
@@ -131,11 +131,12 @@
         start();
     });
 
-    asyncTest("term regex", 7, function() {
+    asyncTest("term regex", 8, function() {
         checkRegex(t1.regex(), "4", true, "right answer is right");
         checkRegex(t1.regex(), "-4", false, "wrong answer is wrong");
+        checkRegex(t1.regex(), "4x", false, "wrong answer is wrong");
         checkRegex(t1.regex(), "  4 ", true, "right answer with spaces is right");
-        checkRegex(t1.regex(true), " + 4 ", true, "right answer leading sign is right");
+        checkRegex(t1.regex(true), "4", true, "ignore passed in true");
         checkRegex(t3.regex(), "-12x", true, "right answer is right");
         checkRegex(t3.regex(), " 1 2 x ", false, "wrong answer with spaces is wrong");
         checkRegex(t4.regex(), "12x^2", true, "right answer is right");
@@ -248,6 +249,8 @@
         checkRegex(e2.regex(true), "4(1-3x)", true, "factored reversed is right");
         checkRegex(e3.regex(true), "x + 5", true, "coefficient of one ignored is right");
         checkRegex(e3.regex(true), "1x + 5", false, "coefficient of one included is wrong (?)");
+
+        console.log(e2.regex(true));
         start();
     });
 

--- a/utils/test/rational_expressions.html
+++ b/utils/test/rational_expressions.html
@@ -249,8 +249,6 @@
         checkRegex(e2.regex(true), "4(1-3x)", true, "factored reversed is right");
         checkRegex(e3.regex(true), "x + 5", true, "coefficient of one ignored is right");
         checkRegex(e3.regex(true), "1x + 5", false, "coefficient of one included is wrong (?)");
-
-        console.log(e2.regex(true));
         start();
     });
 


### PR DESCRIPTION
Using .regex() will now work with Term and RationalExpression objects with and without true.

Fix adding_and_subtracting_rational_expressions_3.html and a few other exercises so it works with the new system. I've updated the rational expression unit tests and checked everything passes. I've tried the changed exercises and some other rational expression exercises multiple times and they seem to work, so fingers crossed. Apologies for the problems. I should never have started using the Term object for single term expressions.
