### PR TITLE
Parallel-line indicators in graphie-helpers

### DIFF
--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<em><!DOCTYPE html>
 <html data-require="math graphie graphie-helpers graphie-geometry math-format">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -33,11 +33,13 @@
                         init({
                             range: [ [-1, 12 ], [ -8, -1 ] ]
                         })
-                        var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(0, 1 ) + 0.5, "", 3 );
+                        var sideRatio = randRange(0, 1 ) + 0.5;
+                        var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, sideRatio, "", 3 );
                         q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
                         q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
 
                         q.draw();
+                        q.drawTicks([2,0,2,0]);
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();
                     </div>
@@ -80,8 +82,24 @@
                     <p>Opposite angles of a parallelogram are equal.</p>
                     <p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
                 </div>
+                <div class="question">
+                    <div class="graphie">
+                        init({
+                            range: [ [-1, 12 ], [ -8, -1 ] ]
+                        })
+                        var sideRatio = randRange(0, 1 ) + 0.5;
+                        var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, sideRatio, "", 3 );
+                        q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
+                        q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
+
+                        q.draw();
+                        q.drawTicks([2,1,2,1]);
+                        q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
+                        q.drawLabels();
+                    </div>
+                </div>
             </div>
-            <div id="parallelogram2" data-type="trapezoid">
+            <div id="parallelogram2" data-type="parallelogram1">
                 <div class="vars">
                     <var id="ANGLES">randomQuadAngles.parallelogram()</var>
                     <var id="SHOWN_POS">ANSWER_POS % 2 === 0 ? ( ANSWER_POS + 1 ) : ( ANSWER_POS - 1 )</var>
@@ -108,6 +126,7 @@
                         q.boxOut( [ [ [ 12, -10 ], [ 12, 10 ] ] ], [ -0.7, 0 ] );
 
                         q.draw();
+                        q.drawTicks([2,1,2,1]);
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();
                     </div>
@@ -142,8 +161,23 @@
                     <p>Angles between the non-equal sides of a kite are equal.</p>
                     <p>Therefore, the angle x is also <code><var>ANGLES[ SHOWN_POS ]</var></code></p>
                 </div>
+                <div class="question">
+                    <div class="graphie">
+                        init({
+                            range: [ [-1, 13 ], [ -8, -1 ] ]
+                        })
+                        var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, 1, "", 3 );
+                        q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
+                        q.boxOut( [ [ [ 12, -10 ], [ 12, 10 ] ] ], [ -0.7, 0 ] );
+
+                        q.draw();
+                        q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
+                        q.drawLabels();
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </body>
 </html>
+</em>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -39,7 +39,7 @@
                         q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
 
                         q.draw();
-                        q.drawTicks([2,0,2,0]);
+                        q.drawParallelMarks([2,0,2,0]);
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();
                     </div>
@@ -93,7 +93,7 @@
                         q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
 
                         q.draw();
-                        q.drawTicks([2,1,2,1]);
+                        q.drawParallelMarks([2,1,2,1]);
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();
                     </div>
@@ -126,7 +126,7 @@
                         q.boxOut( [ [ [ 12, -10 ], [ 12, 10 ] ] ], [ -0.7, 0 ] );
 
                         q.draw();
-                        q.drawTicks([2,1,2,1]);
+                        q.drawParallelMarks([2,1,2,1]);
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();
                     </div>

--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -1,4 +1,4 @@
-<em><!DOCTYPE html>
+<!DOCTYPE html>
 <html data-require="math graphie graphie-helpers graphie-geometry math-format">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -180,4 +180,3 @@
     </div>
 </body>
 </html>
-</em>

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -690,7 +690,7 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
 
     area = 0.5 * vectorProduct([this.points[0], this.points[2]], [this.points[3], this.points[1]]);
 
-	this.drawTicks = function(ticks) {
+	this.drawParallelMarks = function(ticks) {
 		/*
 		This function draws T tick marks on side S, where inputs to this function are the
 		number of ticks for each side 0..3
@@ -699,11 +699,9 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
 			q = Quadrilateral(...);
 			...
 			q.drawTicks([2,1,2,1]); // proper markings for a parallelogram - opposite sides have same # of ticks.
-		
-		TODO(?) factor out a function that draws some # of ticks on a single segment, then loop 4 times over that. Give this functionality to all other polygons?
 		*/
 		for(var i = 0; i < ticks.length; i++){
-			drawCenteredTickMarks(this.sides[i], ticks[i], 0.1, 0.4);
+			drawCenteredArrows(this.sides[i], ticks[i], 0.1, 0.4, 150);
 		}
 	}
 }

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -690,6 +690,22 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
 
     area = 0.5 * vectorProduct([this.points[0], this.points[2]], [this.points[3], this.points[1]]);
 
+	this.drawTicks = function(ticks) {
+		/*
+		This function draws T tick marks on side S, where inputs to this function are the
+		number of ticks for each side 0..3
+		In other words, to put 1 tick on sides 1 and 3, and 2 ticks on sides 0 and 2:
+
+			q = Quadrilateral(...);
+			...
+			q.drawTicks([2,1,2,1]); // proper markings for a parallelogram - opposite sides have same # of ticks.
+		
+		TODO(?) factor out a function that draws some # of ticks on a single segment, then loop 4 times over that. Give this functionality to all other polygons?
+		*/
+		for(var i = 0; i < ticks.length; i++){
+			drawCenteredTickMarks(this.sides[i], ticks[i], 0.1, 0.4);
+		}
+	}
 }
 
 

--- a/utils/graphie-helpers.js
+++ b/utils/graphie-helpers.js
@@ -259,6 +259,47 @@ function drawCenteredTickMarks(line, nticks, spacing, size){
 	}
 }
 
+function drawCenteredArrows(line, nticks, spacing, size, angle){
+	var graph = KhanUtil.currentGraph;
+	
+	// get endpoints for this side
+	var ptA = line[0],
+		ptB = line[1];
+
+	// ensure that AB is pointing more east than west (so that the arrows for parallel lines point in the same direction)
+	if(ptA[0] > ptB[0]){
+		var tmp = ptA;
+		ptA = ptB;
+		ptB = tmp;
+	}
+	
+		// get midpoint
+	var	ptC = [(ptA[0]+ptB[0])/2, (ptA[1]+ptB[1])/2],
+		// length
+		len = Math.sqrt((ptA[0]-ptB[0])*(ptA[0]-ptB[0]) + (ptA[1]-ptB[1])*(ptA[1]-ptB[1]));
+		// unit vector from A to B
+		ux = (ptB[0]-ptA[0])/len,
+		uy = (ptB[1]-ptA[1])/len;
+	
+	var effectLength = (nticks - 1) * spacing;
+	var radians = Math.PI * angle / 180;
+	var pointToTailShift = size / (2 * Math.tan(radians / 2));
+	// loop over tick marks
+	for(var j = 0; j < nticks; j++){
+		// compute center of this arrow based on spacing and total number
+		var cx = ptC[0] + ux * (j*spacing - effectLength/2);
+		var cy = ptC[1] + uy * (j*spacing - effectLength/2);
+		
+		// draw arrow mark pointing along the original line
+		var halfwidth  = size * uy / 2,
+		    halfheight = size * ux / 2;
+		graph.path([
+			[cx - halfwidth, cy + halfheight],
+			[cx + pointToTailShift*ux, cy+pointToTailShift*uy],
+			[cx + halfwidth, cy - halfheight]]);
+	}
+}
+
 function ParallelLines(x1, y1, x2, y2, distance) {
     var lowerIntersection;
     var upperIntersection;

--- a/utils/graphie-helpers.js
+++ b/utils/graphie-helpers.js
@@ -230,6 +230,35 @@ function updateFocusDirectrix(deltaX, deltaY, deltaK) {
     redrawParabola(true);
 }
 
+function drawCenteredTickMarks(line, nticks, spacing, size){
+	var graph = KhanUtil.currentGraph;
+	
+	// get endpoints for this side
+	var ptA = line[0],
+		ptB = line[1],
+		// get midpoint
+		ptC = [(ptA[0]+ptB[0])/2, (ptA[1]+ptB[1])/2],
+		// length
+		len = Math.sqrt((ptA[0]-ptB[0])*(ptA[0]-ptB[0]) + (ptA[1]-ptB[1])*(ptA[1]-ptB[1]));
+		// unit vector from A to B
+		ux = (ptB[0]-ptA[0])/len,
+		uy = (ptB[1]-ptA[1])/len;
+		
+	var effectLength = (nticks - 1) * spacing;
+	// loop over tick marks
+	for(var j = 0; j < nticks; j++){
+		// compute center of this tick based on spacing and total number
+		var cx = ptC[0] + ux * (j*spacing - effectLength/2);
+		var cy = ptC[1] + uy * (j*spacing - effectLength/2);
+		// draw tick mark perpendicular to the original side: (-y,x) orientation
+		var halfwidth  = size * uy / 2,
+		    halfheight = size * ux / 2;
+		graph.path([
+			[cx - halfwidth, cy + halfheight],
+			[cx + halfwidth, cy - halfheight]]);
+	}
+}
+
 function ParallelLines(x1, y1, x2, y2, distance) {
     var lowerIntersection;
     var upperIntersection;


### PR DESCRIPTION
This fixes a bug from the Trello boards: https://trello.com/c/zrCN2NlG/590-indicate-that-trapezoids-are-really-trapezoids-in-quadrilateral-angles

PS - I only started looking at khan-exercises this morning, and I'm not sure how to indicate that this bug's state has changed on Trello..
