### PR TITLE
Fixes for rendering angle labels and quads

### DIFF
--- a/exercises/quadrilateral_angles.html
+++ b/exercises/quadrilateral_angles.html
@@ -33,9 +33,9 @@
                         init({
                             range: [ [-1, 12 ], [ -8, -1 ] ]
                         })
-                        var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, randRange(0, 1 ) + 0.5, "", 3 );
-                        q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
-                        q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
+                        var q = new Quadrilateral( [ 2, -7 ],  ANGLES, randRange( 0, 1 ) + 0.5, "", 3 );
+                        q.boxOut( [ [ [ -0.5, -10 ], [ -0.5, 10 ] ] ], [ 0.1, 0 ] );
+                        q.boxOut( [ [ [ 11.5, -10 ], [ 11.5, 10 ] ] ], [ -0.1, 0 ] );
 
                         q.draw();
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
@@ -101,11 +101,11 @@
                 <div class="question">
                     <div class="graphie">
                         init({
-                            range: [ [-1, 13 ], [ -8, -1 ] ]
+                            range: [ [-1, 12 ], [ -8, -1 ] ]
                         })
-                        var q = new Quadrilateral( [ 3.5, -7 ],  ANGLES, 1, "", 3 );
-                        q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
-                        q.boxOut( [ [ [ 12, -10 ], [ 12, 10 ] ] ], [ -0.7, 0 ] );
+                        var q = new Quadrilateral( [ 2, -7 ],  ANGLES, 1, "", 3 );
+                        q.boxOut( [ [ [ -0.5, -10 ], [ -0.5, 10 ] ] ], [ 0.1, 0 ] );
+                        q.boxOut( [ [ [ 11.5, -10 ], [ 11.5, 10 ] ] ], [ -0.1, 0 ] );
 
                         q.draw();
                         q.labels = { "angles" : ANG_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };

--- a/exercises/quadrilateral_types.html
+++ b/exercises/quadrilateral_types.html
@@ -20,11 +20,11 @@
                 <div class="question">
                     <div class="graphie">
                         init({
-                            range: [ [-2, 12 ], [ -8, -1 ] ]
+                            range: [ [-1, 12 ], [ -8, -1 ] ]
                         })
                         var q = new Quadrilateral( [ 2, -7 ],  ANGLES, randRange( 0, 1 ) + 0.5, 3 );
-                        q.boxOut( [ [ [ -1, -10 ], [ -1, 10 ] ] ], [ 0.7, 0 ] );
-                        q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
+                        q.boxOut( [ [ [ -0.5, -10 ], [ -0.5, 10 ] ] ], [ 0.1, 0 ] );
+                        q.boxOut( [ [ [ 11.5, -10 ], [ 11.5, 10 ] ] ], [ -0.1, 0 ] );
                         q.draw();
                         q.labels = { "angles" : ANGLE_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();
@@ -93,8 +93,8 @@
                             range: [ [-1, 12 ], [ -8, -1 ] ]
                         })
                         var q = new Quadrilateral( [ 2, -7 ],  ANGLES, 1, 3 );
-                        q.boxOut( [ [ [ 11, -10 ], [ 11, 10 ] ] ], [ -0.7, 0 ] );
-                        q.boxOut( [ [ [ 0, -10 ], [ 0, 10 ] ] ], [ 0.7, 0 ] );
+                        q.boxOut( [ [ [ 11.5, -10 ], [ 11.5, 10 ] ] ], [ -0.1, 0 ] );
+                        q.boxOut( [ [ [ -0.5, -10 ], [ -0.5, 10 ] ] ], [ 0.1, 0 ] );
                         q.draw();
                         q.labels = { "angles" : ANGLE_LABELS, "sides" : $.map( $.map( q.sides, lineLength ), function( x ){ return localeToFixed(x, 1); } ) };
                         q.drawLabels();

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -648,7 +648,7 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
 
     this.generatePoints = function() {
         var once = false;
-        while ((! once) || this.isCrossed()) {
+        while ((! once) || this.isCrossed() || this.sideTooShort()) {
             var len = Math.sqrt(2 * this.scale * this.scale * this.sideRatio * this.sideRatio - 2 * this.sideRatio * this.scale * this.scale * this.sideRatio * this.cosines[3]);
             once = true;
             var tX = [0, this.scale * this.sideRatio * this.cosines[0] , len * Math.cos((this.angles[0] - (180 - this.angles[3]) / 2) * Math.PI / 180), this.scale, this.scale + Math.cos((180 - this.angles[1]) * Math.PI / 180)];
@@ -664,14 +664,30 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
             this.sideLengths = $.map(this.sides, lineLength);
             this.niceSideLengths = $.map(this.sideLengths, function(x) { return parseFloat(x.toFixed(1)); });
 
-            if (vectorProduct([this.points[0], this.points[1]], [this.points[0], this.points[2]]) > 0 || this.sideLengths[2] < 0.09) {
+            if (vectorProduct([this.points[0], this.points[1]], [this.points[0], this.points[2]]) > 0) {
                 this.sideRatio -= 0.3;
             }
 
             if (vectorProduct([this.points[0], this.points[3]], [this.points[0], this.points[2]]) < 0) {
                 this.sideRatio += 0.3;
             }
+
+            var tooShort = this.sideTooShort();
+            if (tooShort) {
+                if (tooShort.whichSide % 2 == 0) {
+                    this.sideRatio -= 0.05;
+                }
+                else {
+                    this.sideRatio += 0.05;
+                }
+            }
         }
+    }
+
+    this.sideTooShort = function() {
+        var shortestSide = _.min(this.sideLengths);
+        var allSides = _.reduce(this.sideLengths, function(acc,n) { return acc+n; }, 0);
+        return shortestSide/allSides < 0.12 && {whichSide:this.sideLengths.indexOf(shortestSide)};
     }
 
     this.isCrossed = function() {

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -481,13 +481,16 @@ function Triangle(center, angles, scale, labels, points) {
 
 
     this.angleScale = function(ang) {
-        if (ang > 90) {
+        if (ang > 130) {
+            return 0.6;
+        }
+        else if (ang > 90) {
             return 0.5;
         }
         else if (ang > 40) {
             return 0.6;
         }
-        else if (ang < 25) {
+        else if (ang > 25) {
             return 0.7;
         }
         return 0.8;


### PR DESCRIPTION
Several changes aimed at drawing quads correctly in the exercises that use them.  So it's about fixing:

Overlapping angle labels (#68799)
Them (rarely) getting drawn partly off-screen (discovered while fixing the above)
And a general fix for all angles, where obtuse angles around 155 degrees would clip into the closest lines.
