### PR TITLE
Fixes a random seed of zero being ignored

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -812,8 +812,11 @@ var Khan = (function() {
     }
 
     // Seed the random number generator with the user's hash
-    randomSeed = localMode && parseFloat(Khan.query.seed) || userCRC32 ||
-            (new Date().getTime() & 0xffffffff);
+    if (localMode && Khan.query.seed) {
+        randomSeed = parseFloat(Khan.query.seed);
+    } else {
+        randomSeed = userCRC32 || (new Date().getTime() & 0xffffffff);
+    }
 
     if (localMode) {
         var lang = Khan.query.lang || "en-US";


### PR DESCRIPTION
This was caused by zero being interpreted as false.
Hurray loose typing! Hurray Javascript! :D

You can see the problem behavior by loading up any exercise in sandcastle, e.g
http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/reading_pictographs_2.html?seed=0
and repeatedly reloading the page.

Discovered this from another reported issue, so zeroes as seeds _do_ happen.
