### PR TITLE
Warn about using X for * in expressions via "Almost Right" message

### DIFF
--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1996,6 +1996,18 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                 // An unsuccessful parse doesn't count as wrong
                 if (!answer.parsed) return "";
 
+                // Using X as * is "almost right", so pass message about that
+                var xUsedAsMultOp = function(inputStr) {
+                    if (!_.contains(inputStr, "x")) {
+                        return false;
+                    }
+                    var multTestInput = inputStr.replace(/x/gi,"*");
+                    var multTest = KAS.parse(multTestInput, options);
+                    if (!multTest.parsed) return false;
+                    return KAS.compare(multTest.expr, solution, options).equal;
+                };
+                if (xUsedAsMultOp(guess)) return "Use *, not x, for multiplication.";
+
                 var result = KAS.compare(answer.expr, solution, options);
 
                 if (result.equal) {


### PR DESCRIPTION
I ended up making this two ways and am submitting both for perusal.

This one gives feedback via the "almost right" interface.  It's significantly smaller and nicer than the other option, but can only warn and give feedback after it counts the answer as wrong.

The other option uses the same interface as the "I didn't understand that" parser message, and was made specifically to avoid counting the answer as wrong, but is a good bit uglier than the first choice.

By the way, testing this functionality isn't straightforward because the exercises this is useful for aren't in the repo.  I tested by setting options.simplify = false; right after the options declaration for expression answers, around line 1825 in answer-types.js.  This lets you pull up the exercise adding_and_subtracting_complex_numbers and test by typing in answers unsimplified that make use of x for *. E.g. 1+ix1, for 1+i
