### PR TITLE
Small tweaks to earlier graphie-geometry fix

### DIFF
--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -481,7 +481,13 @@ function Triangle(center, angles, scale, labels, points) {
 
 
     this.angleScale = function(ang) {
-        if (ang > 130) {
+        if (ang > 150) {
+            return 0.8;
+        }
+        else if (ang > 140) {
+            return 0.7;
+        }
+        else if (ang > 130) {
             return 0.6;
         }
         else if (ang > 90) {

--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -677,7 +677,7 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
 
             var tooShort = this.sideTooShort();
             if (tooShort) {
-                if (tooShort.whichSide % 2 == 0) {
+                if (tooShort.whichSide % 2 === 0) {
                     this.sideRatio -= 0.05;
                 }
                 else {
@@ -688,6 +688,7 @@ function Quadrilateral(center, angles, sideRatio, labels, size) {
     }
 
     this.sideTooShort = function() {
+        if (this.sideRatio === 1) return false;
         var shortestSide = _.min(this.sideLengths);
         var allSides = _.reduce(this.sideLengths, function(acc,n) { return acc+n; }, 0);
         return shortestSide/allSides < 0.12 && {whichSide:_.indexOf(this.sideLengths,shortestSide)};


### PR DESCRIPTION
These are some tweaks to the quad fix that was pushed a while back.  The main fix is to avoid #71833, a rare occurrence with figures of sideRatio 1.  When testing that fix I saw that obtuse angles (depending on the orientation of the figure) needed a little more room than I gave them the first time, so I added that in as well.
