### PR TITLE
One last graphie-geometry fix

### DIFF
--- a/utils/graphie-geometry.js
+++ b/utils/graphie-geometry.js
@@ -786,7 +786,7 @@ var randomQuadAngles = {
         rhombus: function() {
             var angA, angB;
             do {
-                angA = KhanUtil.randRange(30, 160);
+                angA = KhanUtil.randRange(30, 150);
                 angB = 180 - angA;
             }while (Math.abs(angA - angB) < 5);
             return [angA, angB, angA, angB];
@@ -795,7 +795,7 @@ var randomQuadAngles = {
         parallelogram: function() {
             var angA, angB;
             do {
-                angA = KhanUtil.randRange(30, 160);
+                angA = KhanUtil.randRange(30, 150);
                 angB = 180 - angA;
             } while (angA === angB);
             return [angA, angB, angA, angB];
@@ -804,9 +804,9 @@ var randomQuadAngles = {
         trapezoid: function() {
             var angA, angB, angC, angD;
             do {
-                angA = KhanUtil.randRange(30, 160);
+                angA = KhanUtil.randRange(30, 150);
                 angB = 180 - angA;
-                angC = KhanUtil.randRange(30, 160);
+                angC = KhanUtil.randRange(30, 150);
                 angD = 180 - angC;
             } while (Math.abs(angA - angC) < 6 || angA + angC === 180);
             return [angA, angC, angD, angB];
@@ -815,7 +815,7 @@ var randomQuadAngles = {
         isoscelesTrapezoid: function() {
             var angC, angD;
             do {
-                angC = KhanUtil.randRange(30, 160);
+                angC = KhanUtil.randRange(30, 150);
                 angD = 180 - angC;
             } while (angC === angD);
             return [angC, angC, angD, angD];


### PR DESCRIPTION
Fixes #72560

After noticing and fixing the kite bug, other reports started coming in about a wider problem.
Isolated relevant functions, ran a couple thousand times.  Happens when one angle is near
max bounds (160), another is near min bounds (20), and the other two are near 90.

It is at those angles when the quad simply can't generate a line long enough to avoid failing
sideTooShort.  Since the minimum length in sideTooShort was chosen by finding the shortest
side length such that labels wouldn't overlap, making the test easier to pass would just let
things overlap again.  So the minimum angle is what needs to increase here.  

Looked at the angle generating code, and saw randRange(30,160) instead of (20,160), which 
makes it look like 30 degrees was the intended minimum anyway.  Switching to a 30 degree
minimum angle fixes the lock-up problem, also mitigates the previous labels-for-very-obtuse-
angles-overlap-with-nearest-line problem (what @600046d66ca007329d27c7d69c885031cb70e0bd was all about).

Tested the fix by generating all 6 random quads 2,000,000 times each without issue.
