### PR TITLE
Bug fix for GH-71250

### DIFF
--- a/exercises/views_of_a_function.html
+++ b/exercises/views_of_a_function.html
@@ -181,21 +181,18 @@
                     var correct = 0;
                     var xs = [];
 
-                    var validator = Khan.answerTypes.predicate.createValidatorFunctional(function(guess, maxError) {
-                        if (abs(FUNC(guess[0]) - guess[1]) &lt; maxError) {
-                            console.log(guess[0] + " " + guess[1]);
-                            correct += 1;
-                            xs.push(guess[0]);
-                            return true;
-                        }
-                        return false;
-                    }, {forms: 'point', maxError: CORRECTOFFSET});
-
                     for (var i = 0; i &lt; 8; ++i) {
                         if ($.trim(guess[i][0]) !== "" &amp;&amp;
                             $.trim(guess[i][1]) !== "") {
                             attempted += 1;
-                            validator(guess[i]);
+
+                            var x = parseFloat(guess[i][0]),
+                                y = parseFloat(guess[i][1]);
+
+                            if (abs(FUNC(x) - y) &lt; CORRECTOFFSET) {
+                                correct += 1;
+                                xs.push(x);
+                            }
                         }
                     }
 

--- a/exercises/views_of_a_function.html
+++ b/exercises/views_of_a_function.html
@@ -183,7 +183,6 @@
 
                     var validator = Khan.answerTypes.predicate.createValidatorFunctional(function(guess, maxError) {
                         if (abs(FUNC(guess[0]) - guess[1]) &lt; maxError) {
-                            console.log(guess[0] + " " + guess[1]);
                             correct += 1;
                             xs.push(guess[0]);
                             return true;

--- a/exercises/views_of_a_function.html
+++ b/exercises/views_of_a_function.html
@@ -181,18 +181,24 @@
                     var correct = 0;
                     var xs = [];
 
-                    for (var i = 0; i &lt; 8; ++i) {
+                    var i = 0;
+                    var validatePoint = Khan.answerTypes.predicate.createValidatorFunctional(function(x, maxError) {
+                        var validateY = Khan.answerTypes.predicate.createValidatorFunctional(function(y, maxError) {
+                            if (abs(FUNC(x) - y) &lt; maxError) {
+                                correct += 1;
+                                xs.push(x);
+                                return true;
+                            }
+                        }, {forms: 'decimal', maxError: maxError});
+                        return validateY(guess[i][1]);
+                    }, {forms: 'decimal', maxError: CORRECTOFFSET});
+
+                    for (i = 0; i &lt; 8; ++i) {
                         if ($.trim(guess[i][0]) !== "" &amp;&amp;
                             $.trim(guess[i][1]) !== "") {
                             attempted += 1;
+                            validatePoint(guess[i][0]);
 
-                            var x = parseFloat(guess[i][0]),
-                                y = parseFloat(guess[i][1]);
-
-                            if (abs(FUNC(x) - y) &lt; CORRECTOFFSET) {
-                                correct += 1;
-                                xs.push(x);
-                            }
                         }
                     }
 

--- a/exercises/views_of_a_function.html
+++ b/exercises/views_of_a_function.html
@@ -190,7 +190,8 @@
                                 return true;
                             }
                         }, {forms: 'decimal', maxError: maxError});
-                        return validateY(guess[i][1]);
+                        var result = validateY(guess[i][1]);
+                        return result.correct;
                     }, {forms: 'decimal', maxError: CORRECTOFFSET});
 
                     for (i = 0; i &lt; 8; ++i) {
@@ -198,7 +199,6 @@
                             $.trim(guess[i][1]) !== "") {
                             attempted += 1;
                             validatePoint(guess[i][0]);
-
                         }
                     }
 
@@ -208,13 +208,11 @@
 
                     xs = KhanUtil.sortNumbers(xs);
                     var different = 1;
-
                     for (var i = 0; i &lt; correct - 1; ++i) {
                         if (xs[i + 1] - xs[i] &gt;= 0.5) {
                             different += 1;
                         }
                     }
-
                     return different === attempted;
                 </div>
             </div>

--- a/exercises/views_of_a_function.html
+++ b/exercises/views_of_a_function.html
@@ -181,18 +181,21 @@
                     var correct = 0;
                     var xs = [];
 
+                    var validator = Khan.answerTypes.predicate.createValidatorFunctional(function(guess, maxError) {
+                        if (abs(FUNC(guess[0]) - guess[1]) &lt; maxError) {
+                            console.log(guess[0] + " " + guess[1]);
+                            correct += 1;
+                            xs.push(guess[0]);
+                            return true;
+                        }
+                        return false;
+                    }, {forms: 'point', maxError: CORRECTOFFSET});
+
                     for (var i = 0; i &lt; 8; ++i) {
                         if ($.trim(guess[i][0]) !== "" &amp;&amp;
                             $.trim(guess[i][1]) !== "") {
                             attempted += 1;
-
-                            var x = parseFloat(guess[i][0]),
-                                y = parseFloat(guess[i][1]);
-
-                            if (abs(FUNC(x) - y) &lt; CORRECTOFFSET) {
-                                correct += 1;
-                                xs.push(x);
-                            }
+                            validator(guess[i]);
                         }
                     }
 

--- a/exercises/views_of_a_function.html
+++ b/exercises/views_of_a_function.html
@@ -183,6 +183,7 @@
 
                     var validator = Khan.answerTypes.predicate.createValidatorFunctional(function(guess, maxError) {
                         if (abs(FUNC(guess[0]) - guess[1]) &lt; maxError) {
+                            console.log(guess[0] + " " + guess[1]);
                             correct += 1;
                             xs.push(guess[0]);
                             return true;

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -543,6 +543,24 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                     return [];
                 },
 
+                // 2-d graph coordinate (point) in array format [x, y]
+                point: function(value, precision) {
+                    if ($.isArray(value) && value.length === 2) {
+                        var x = forms.decimal(value[0]);
+                        var y = forms.decimal(value[1]);
+                        return [
+                            {
+                                value: [x[0].value, y[0].value],
+                                exact: [x[0].exact, y[0].exact]
+                            },
+                            {
+                                value: [x[1].value, y[1].value],
+                                exact: [x[1].exact, y[1].exact]
+                            },
+                        ]
+                    }
+                    return [];
+                },
                 // Decimal numbers -- compare entered text rounded to
                 // 'precision' Reciprical of the precision against the correct
                 // answer. We round to 1/1e10 by default, which is healthily
@@ -603,7 +621,13 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                 var fallback =
                     options.fallback != null ? "" + options.fallback : "";
 
-                guess = $.trim(guess) || fallback;
+                if ($.isArray(guess)) {
+                    guess = $.map(guess, function(n, i) {
+                        return $.trim(n) || fallback;
+                    });
+                } else {
+                    guess = $.trim(guess) || fallback;
+                }
                 var ret = false;
 
                 // iterate over all the acceptable forms, and if one of the
@@ -1787,7 +1811,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
      *
      *     no functions specified: f(x+y) == fx + fy
      *     with "f" as a function: f(x+y) != fx + fy
-     * 
+     *
      * Comparison options:
      * same-form (e.g. data-same-form)
      *     If present, the answer must match the solution's structure in
@@ -1795,32 +1819,32 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
      *     are ignored, but all other changes will trigger a rejection. Useful
      *     for requiring a particular form of an equation, or if the answer
      *     must be factored.
-     *     
+     *
      *     example question:    Factor x^2 + x - 2
      *     example solution:    (x-1)(x+2)
      *     accepted answers:    (x-1)(x+2), (x+2)(x-1), ---(-x-2)(-1+x), etc.
      *     rejected answers:    x^2+x-2, x*x+x-2, x(x+1)-2, (x-1)(x+2)^1, etc.
      *     rejection message:   Your answer is not in the correct form
-     *     
+     *
      * simplify (e.g. data-simplify)
      *     If present, the answer must be fully expanded and simplified. Use
      *     carefully - simplification is hard and there may be bugs, or you
      *     might not agree on the definition of "simplified" used. You will
      *     get an error if the provided solution is not itself fully expanded
      *     and simplified.
-     *     
+     *
      *     example question:    Simplify ((n*x^5)^5) / (n^(-2)*x^2)^-3
      *     example solution:    x^31 / n
      *     accepted answers:    x^31 / n, x^31 / n^1, x^31 * n^(-1), etc.
      *     rejected answers:    (x^25 * n^5) / (x^(-6) * n^6), etc.
      *     rejection message:   Your answer is not fully expanded and simplified
-     *     
+     *
      * Rendering options:
      * times (e.g. data-times)
      *     If present, explicit multiplication (such as between numbers) will
      *     be rendered with a cross/x symbol (TeX: \times) instead of the usual
      *     center dot (TeX: \cdot).
-     *     
+     *
      *     normal rendering:    2 * 3^x -> 2 \cdot 3^{x}
      *     but with "times":    2 * 3^x -> 2 \times 3^{x}
      */

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -543,24 +543,6 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                     return [];
                 },
 
-                // 2-d graph coordinate (point) in array format [x, y]
-                point: function(value, precision) {
-                    if ($.isArray(value) && value.length === 2) {
-                        var x = forms.decimal(value[0]);
-                        var y = forms.decimal(value[1]);
-                        return [
-                            {
-                                value: [x[0].value, y[0].value],
-                                exact: [x[0].exact, y[0].exact]
-                            },
-                            {
-                                value: [x[1].value, y[1].value],
-                                exact: [x[1].exact, y[1].exact]
-                            },
-                        ]
-                    }
-                    return [];
-                },
                 // Decimal numbers -- compare entered text rounded to
                 // 'precision' Reciprical of the precision against the correct
                 // answer. We round to 1/1e10 by default, which is healthily
@@ -621,13 +603,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                 var fallback =
                     options.fallback != null ? "" + options.fallback : "";
 
-                if ($.isArray(guess)) {
-                    guess = $.map(guess, function(n, i) {
-                        return $.trim(n) || fallback;
-                    });
-                } else {
-                    guess = $.trim(guess) || fallback;
-                }
+                guess = $.trim(guess) || fallback;
                 var ret = false;
 
                 // iterate over all the acceptable forms, and if one of the
@@ -1811,7 +1787,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
      *
      *     no functions specified: f(x+y) == fx + fy
      *     with "f" as a function: f(x+y) != fx + fy
-     *
+     * 
      * Comparison options:
      * same-form (e.g. data-same-form)
      *     If present, the answer must match the solution's structure in
@@ -1819,32 +1795,32 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
      *     are ignored, but all other changes will trigger a rejection. Useful
      *     for requiring a particular form of an equation, or if the answer
      *     must be factored.
-     *
+     *     
      *     example question:    Factor x^2 + x - 2
      *     example solution:    (x-1)(x+2)
      *     accepted answers:    (x-1)(x+2), (x+2)(x-1), ---(-x-2)(-1+x), etc.
      *     rejected answers:    x^2+x-2, x*x+x-2, x(x+1)-2, (x-1)(x+2)^1, etc.
      *     rejection message:   Your answer is not in the correct form
-     *
+     *     
      * simplify (e.g. data-simplify)
      *     If present, the answer must be fully expanded and simplified. Use
      *     carefully - simplification is hard and there may be bugs, or you
      *     might not agree on the definition of "simplified" used. You will
      *     get an error if the provided solution is not itself fully expanded
      *     and simplified.
-     *
+     *     
      *     example question:    Simplify ((n*x^5)^5) / (n^(-2)*x^2)^-3
      *     example solution:    x^31 / n
      *     accepted answers:    x^31 / n, x^31 / n^1, x^31 * n^(-1), etc.
      *     rejected answers:    (x^25 * n^5) / (x^(-6) * n^6), etc.
      *     rejection message:   Your answer is not fully expanded and simplified
-     *
+     *     
      * Rendering options:
      * times (e.g. data-times)
      *     If present, explicit multiplication (such as between numbers) will
      *     be rendered with a cross/x symbol (TeX: \times) instead of the usual
      *     center dot (TeX: \cdot).
-     *
+     *     
      *     normal rendering:    2 * 3^x -> 2 \cdot 3^{x}
      *     but with "times":    2 * 3^x -> 2 \times 3^{x}
      */


### PR DESCRIPTION
Here is a bug fix for GH-71250: `[views of a function] localised decimal mark not recognised`

I saw this bug listed on the Trello board and decided to take a crack at it.

I tested the fix against the following problem seeds:
- http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/views_of_a_function.html?debug&problem=equation-to-table&seed=115
- http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/views_of_a_function.html?debug&problem=table-to-graph&seed=108

Seed 108 is there problem type where you drag the points on the graph based on table coordinates.

For Seed 115, I tested the `equation-to-table` problem type using the following test cases.

**Case 1: Expect correct (passed)**
x = 2,0 and y = 5,0
x = 4.0 and y = 5.0
x = 6 and y = 1
x = 8 and y = -7,0
x = 4.5 and y = 4.375

**Case 2: Expect correct (passed)**
x = 2,0 and y = 5,0
x = 4.0 and y = 5.0
x = 6 and y = 1
x = 8 and y = -7,0
x = 4,5 and y = 4,375

**Case 3 (Mixed decimal/comma x y pairs): Expect correct (passed)**
x = 2,0 and y = 5,0
x = 4.0 and y = 5.0
x = 6 and y = 1
x = 8 and y = -7,0
x = 4.5 and y = 4,375

**Case 4 (Less than 5 points given): Expect wrong (passed)**
x = 2,0 and y = 5,0
x = 4.0 and y = 5.0
x = 6 and y = 1
x = 4,5 and y = 4,375

**Case 5 (Duplicate points): Expect wrong (passed)**
x = 2,0 and y = 5,0
x = 4.0 and y = 5.0
x = 6 and y = 1
x = 4.5 and y = 4.375
x = 4.0 and y = 5.0

---

Not the best implementation, but it was the simplest I could I think of.

Trouble that I ran into:
- I ended up adding a `point` form to the `forms` object. The point form accepts an array pair of points `[x,y]`. I could not figure out how to validate values that depended on another. 
- I was not sure how to add the `point` form without adding it directly to the private forms object. Hope that's ok.
- The problem required a minimum of five points, but I could not figure out how to validate the set of points as a whole. I ended up validating each pair individually.
