### PR TITLE
Feature Suggestion: Notepad

### DIFF
--- a/css/khan-exercise.css
+++ b/css/khan-exercise.css
@@ -144,6 +144,45 @@ body.debug .graphie { outline: 1px dashed #fdd; }
 }
 
 #scratchpad-not-available { display: none; }
+
+#notepad {
+    background: rgba(244, 241, 156, 0.5);
+    border: 1px solid #ccc;
+    -webkit-box-shadow: 0 0 3px #ccc;
+    -moz-box-shadow: 0 0 3px #ccc;
+    box-shadow: 0 0 3px #ccc;
+    cursor: move;
+    display: none;
+    line-height: 1;
+    margin-left: -250px;
+    margin-top: 50px;
+    position: absolute;
+    padding: 15px;
+    z-index: 1000;
+    left: 50%;
+    top: 0;
+    margin-top: 100px;
+    width: 350px;
+    margin-left: -190px;
+}
+
+#notepad textarea {
+    background: transparent;
+    border: none;
+    -moz-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    color: #444;
+    font-size: 14px;
+    outline: none;
+    resize: none;
+    width: 100%;
+    z-index: 2;
+}
+
+#notepad-not-available { display: none; }
+
 #extras .report-issue-link { float: right; font-size: 11px; }
 
 #tester-info.info-box { background: #f2e4bf; }

--- a/exercises/khan-exercise.html
+++ b/exercises/khan-exercise.html
@@ -17,6 +17,9 @@
     <span id="warning-bar-close">(<a href="">close</a>)</span>
 </div>
 <div id="problem-and-answer">
+    <div id="notepad">
+        <textarea rows="10"></textarea>
+    </div>
     <form id="answerform" name="answerform">
         <div id="problemarea">
             <div id="scratchpad"><div></div></div>

--- a/exercises/khan-site.html
+++ b/exercises/khan-site.html
@@ -44,6 +44,9 @@
                                             <li> <a href="" id="scratchpad-show" style="">Show scratchpad</a>
                                                 <span id="scratchpad-not-available" style="display: none;">Scratchpad not available</span>
                                             </li>
+                                            <li> <a href="" id="notepad-show" style="">Show notepad</a>
+                                                <span id="notepad-not-available">Notepad not available</span>
+                                            </li>
                                             <li class="debug-mode"> <a href="?debug">Debug mode</a></li>
                                             <li> <a href="" id="problem-permalink">Problem permalink</a></li>
                                         </ul>
@@ -75,7 +78,7 @@
             </div>
         </div>
     </footer>
-    
+
 
 </div>
 </body>

--- a/interface.js
+++ b/interface.js
@@ -115,6 +115,13 @@ function problemTemplateRendered() {
         }
     });
 
+    // Notepad toggle
+    $("#notepad-show").click(function(e) {
+        e.preventDefault();
+        Khan.notepad.toggle();
+        Khan.notepad.focus();
+    });
+
     // These shouldn't interfere...
     $(PerseusBridge).trigger("problemTemplateRendered");
     $(Khan).trigger("problemTemplateRendered");
@@ -242,6 +249,10 @@ function handleAttempt(data) {
         $("#positive-reinforcement").show();
         $("#skip-question-button").prop("disabled", true);
         $("#opt-out-button").prop("disabled", true);
+
+        // Hide and clear notepad.
+        Khan.notepad.hide();
+        Khan.notepad.clear();
     } else {
         // Wrong answer. Enable all the input elements
 

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -481,6 +481,67 @@ var Khan = (function() {
             }
         },
 
+        notepad: (function() {
+            var disabled = false, wasVisible, pad;
+
+            var actions = {
+                disable: function() {
+                    wasVisible = actions.isVisible();
+                    actions.hide();
+
+                    $("#notepad-show").hide();
+                    $("#notepad-not-available").show();
+                    disabled = true;
+                },
+
+                enable: function() {
+                    if (wasVisible) {
+                        actions.show();
+                        wasVisible = false;
+                    }
+
+                    $("#notepad-show").show();
+                    $("#notepad-not-available").hide();
+                    $("#notepad").draggable();
+                    disabled = false;
+                },
+
+                isVisible: function() {
+                    return $("#notepad").is(":visible");
+                },
+
+                show: function() {
+                    if (actions.isVisible()) {
+                        return;
+                    }
+                    $("#notepad").show();
+                    $("#notepad-show").text($._("Hide notepad"));
+                },
+
+                hide: function() {
+                    if (!actions.isVisible()) {
+                        return;
+                    }
+
+                    $("#notepad").hide();
+                    $("#notepad-show").text($._("Show notepad"));
+                },
+
+                toggle: function() {
+                    actions.isVisible() ? actions.hide() : actions.show();
+                },
+
+                focus: function() {
+                    $("#notepad textarea").focus();
+                },
+
+                clear: function() {
+                    $("#notepad textarea").val('');
+                }
+            };
+            return actions;
+        })(),
+
         scratchpad: (function() {
             var disabled = false, wasVisible, pad;
 
@@ -1150,6 +1211,7 @@ var Khan = (function() {
 
         // Enable scratchpad (unless the exercise explicitly disables it later)
         Khan.scratchpad.enable();
+        Khan.notepad.enable();
 
         // Allow passing in a random seed
         if (typeof seed !== "undefined") {


### PR DESCRIPTION
Not really a pull request, but more of a feature suggestion. I did create a basic demo that hopefully gives an idea of what I have in mind. You should be aware that I only tested in Chrome.

I'm lazy, so when I'm working through certain problems I tend to try to them in my head since I don't feel like grabbing a pen and notebook. Or I don't want to open up notepad or Evernote keep swapping windows on my Laptop.

I tried the scratchpad, but it's not easy to use with a trackpad or mouse for writing out equations. The scratchpad used to have a way to type, but it looks like it is gone now. If I remember correctly, It was kind of awkward to use.

My suggestion is to create a separate "notepad" option. The notepad will just be basic text area pops up and can be dragged around. I also added some transparency so that the problem area is still somewhat visible.

Writing equations in plain text is definitely not ideal though. I considered integrating MathJax, but that seems too tedious and requires people learning the syntax.

Again just a suggestion. In general I'd just like a convenient way to work out equations. I don't think a notepad option is the ideal solution. But it is the simplest.

![screen shot 2013-09-19 at 2 17 29 am](https://f.cloud.github.com/assets/539889/1172027/e85000fc-2114-11e3-81a2-6dd26247fe22.png)
