### PR TITLE
Allow empty for ordering exercises

### DIFF
--- a/exercises/ordering_fractions.html
+++ b/exercises/ordering_fractions.html
@@ -112,7 +112,11 @@
                     </div>
                     <div class="guess">SORTER.getContent()</div>
                     <div class="validator-function">
-                        return guess.join( "," ) === NUMS_SORT_TEX;
+                        if (SORTER.hasAttempted) {
+                            return guess.join( "," ) === NUMS_SORT_TEX;
+                        } else {
+                            return '';
+                        }
                     </div>
                     <div class="show-guess">
                         SORTER.setContent( guess );

--- a/exercises/ordering_improper_fractions_and_mixed_numbers.html
+++ b/exercises/ordering_improper_fractions_and_mixed_numbers.html
@@ -135,7 +135,13 @@
                         Drag the fractions or mixed numbers to the left or the right so they are in order from least to greatest
                     </div>
                     <div class="guess">SORTER.getContent()</div>
-                    <div class="validator-function">return guess.join( "," ) === NUMS_SORT_TEX;</div>
+                    <div class="validator-function">
+                        if (SORTER.hasAttempted) {
+                            return guess.join( "," ) === NUMS_SORT_TEX;
+                        } else {
+                            return '';
+                        }
+                    </div>
                     <div class="show-guess">SORTER.setContent( guess );</div>
                 </div>
 

--- a/exercises/ordering_negative_numbers.html
+++ b/exercises/ordering_negative_numbers.html
@@ -79,7 +79,11 @@
                     </div>
                     <div class="guess">SORTER.getContent()</div>
                     <div class="validator-function">
-                        return guess.join( "," ) === NUMS_SORT_TEX;
+                        if (SORTER.hasAttempted) {
+                            return guess.join( "," ) === NUMS_SORT_TEX;
+                        } else {
+                            return '';
+                        }
                     </div>
                     <div class="show-guess">
                         SORTER.setContent( guess );

--- a/exercises/ordering_numbers.html
+++ b/exercises/ordering_numbers.html
@@ -99,7 +99,11 @@
                     </div>
                     <div class="guess">SORTER.getContent()</div>
                     <div class="validator-function">
-                        return guess.join( "," ) === NUMS_SORT_TEX;
+                        if (SORTER.hasAttempted) {
+                            return guess.join( "," ) === NUMS_SORT_TEX;
+                        } else {
+                            return '';
+                        }
                     </div>
                     <div class="show-guess">
                         SORTER.setContent( guess );

--- a/utils/interactive.js
+++ b/utils/interactive.js
@@ -57,6 +57,8 @@ $.extend(KhanUtil, {
         var sorter = {};
         var list;
 
+        sorter.hasAttempted = false;
+
         sorter.init = function(element) {
             list = $("[id=" + element + "]").last();
             var container = list.wrap("<div>").parent();
@@ -89,6 +91,7 @@ $.extend(KhanUtil, {
                         $(document).bind("vmousemove vmouseup", function(event) {
                             event.preventDefault();
                             if (event.type === "vmousemove") {
+                                sorter.hasAttempted = true;
                                 $(tile).offset({
                                     left: event.pageX - click.left,
                                     top: event.pageY - click.top
@@ -447,7 +450,7 @@ $.extend(KhanUtil.Graphie.prototype, {
 
                 var sPath = [
                     addPoints(sMidpoint, sOffsetVector, sHeightVector),
-                    addPoints(sMidpoint, sOffsetVector, 
+                    addPoints(sMidpoint, sOffsetVector,
                               reverseVector(sHeightVector))
                 ];
 
@@ -1768,7 +1771,7 @@ $.extend(KhanUtil.Graphie.prototype, {
                         if (!_.any(_.pluck(points, "dragging"))) {
                             _.each(points, function(point) {
                                 point.visibleShape.animate(point.normalStyle, 50);
-                            });                            
+                            });
                         }
                     }
 
@@ -1857,7 +1860,7 @@ $.extend(KhanUtil.Graphie.prototype, {
                             KhanUtil.dragging = false;
                             if (!polygon.highlight) {
                                 polygon.visibleShape.animate(polygon.normalStyle, 50);
-                                
+
                                 _.each(points, function(point) {
                                     point.visibleShape.animate(point.normalStyle, 50);
                                 });


### PR DESCRIPTION
Here is bug fix one of the checklist items in this Trello card:  listed in the following Trello Card: https://trello.com/c/KBqG0gEw/579-exercises-shouldn-t-accept-blank-answers

The card mentioned `ordering_negative_numbers`. But I found that this issue also applied to `ordering_fractions`,  `ordering_improper_fractions_and_mixed_numbers`, and `ordering_numbers`.

A few notes:
- End up adding a flag to check if the tile has been dragged and moved. If a tile has not been moved then the exercise is counted as "empty".
  - In terms of being "moved", it's counted as moved even if the user drags the tile back to its initial spot.
  - It will not count as a being "moved" if they the tile is just clicked.
- I ended up repeating the conditional code in the validator div for each exercise. Not the best solution, but I wasn't sure where to extract that code. I considered putting it inside the sorter object, but that didn't make too much sense.

My test cases for each exercise:
- Click "Check Answer". Should be counted as "empty" (passed)
- Click tile and drag tile. Should be counted as incorrect (passed)
- Drag tiles to correct order. Should be counted as correct (passed)
- Continue to next problem and click "Check Answer". Should be counted as "empty" (passed)
- Click tile and drag tile. Should be counted as incorrect (passed)
- Drag tiles to correct order. Should be counted as correct (passed)
