### PR TITLE
Add Locale info to issue reports

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -580,13 +580,14 @@ var Khan = (function() {
         getIssueInfo: function() {
             var path = exerciseFile + "?seed=" + problemSeed + "&problem=" +
                         problemID,
-                pathlink = "[" + path + (exercise.data("name") !== exerciseId ? " (" + exercise.data("name") + ")" : "") + "](http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/" + path + "&debug)",
-                historyLink = "[Answer timeline](" + "http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/" + path + "&debug&activity=" + encodeURIComponent(JSON.stringify(Exercises.userActivityLog)).replace(/\)/g, "\\)") + ")",
-                locale = "Locale: " + icu.getLocale(),
+                locale = icu.getLocale(),
+                pathlink = "[" + path + (exercise.data("name") !== exerciseId ? " (" + exercise.data("name") + ")" : "") + "](http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/" + path + "&debug&lang=" + locale + ")",
+                historyLink = "[Answer timeline](" + "http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/" + path + "&debug&lang=" + locale + "&activity=" + encodeURIComponent(JSON.stringify(Exercises.userActivityLog)).replace(/\)/g, "\\)") + ")",
+                localeMsg = "Locale: " + locale,
                 userHash = "User hash: " + crc32(user),
 
                 parts = [pathlink, historyLink,
-                        "    " + JSON.stringify(Exercises.guessLog), locale, userHash],
+                        "    " + JSON.stringify(Exercises.guessLog), localeMsg, userHash],
                 body = $.grep(parts, function(e) { return e != null; }).join("\n\n");
 
             return {

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -582,10 +582,11 @@ var Khan = (function() {
                         problemID,
                 pathlink = "[" + path + (exercise.data("name") !== exerciseId ? " (" + exercise.data("name") + ")" : "") + "](http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/" + path + "&debug)",
                 historyLink = "[Answer timeline](" + "http://sandcastle.khanacademy.org/media/castles/Khan:master/exercises/" + path + "&debug&activity=" + encodeURIComponent(JSON.stringify(Exercises.userActivityLog)).replace(/\)/g, "\\)") + ")",
+                locale = "Locale: " + icu.getLocale(),
                 userHash = "User hash: " + crc32(user),
 
                 parts = [pathlink, historyLink,
-                        "    " + JSON.stringify(Exercises.guessLog), userHash],
+                        "    " + JSON.stringify(Exercises.guessLog), locale, userHash],
                 body = $.grep(parts, function(e) { return e != null; }).join("\n\n");
 
             return {


### PR DESCRIPTION
This adds Locale as a line early on in the generated part of the body.

Would test on sandcastle but it's 500ing at the moment.  Works fine locally (forced the form to show and looked at the POST request after submit).  However, you have to test by removing the user hash generation from the modified function (calling crc32(user) crashes when local).
