### PR TITLE
Fix rational expression divide function bug

### DIFF
--- a/utils/rational-expressions.js
+++ b/utils/rational-expressions.js
@@ -231,7 +231,7 @@ $.extend(KhanUtil, {
 
         // Return a string showing how the term should be evaluated with a given value
         // e.g. 5x^2 evalated with 3 returns 5(3)^2
-        // If color is defined, the the value representing the variable is colored
+        // If color is defined, the value representing the variable is colored
         this.getEvaluateString = function(values, includeSign, color) {
             var s = '';
 

--- a/utils/rational-expressions.js
+++ b/utils/rational-expressions.js
@@ -231,7 +231,7 @@ $.extend(KhanUtil, {
 
         // Return a string showing how the term should be evaluated with a given value
         // e.g. 5x^2 evalated with 3 returns 5(3)^2
-        // If color is defined, the value representing the variable is colored
+        // If color is defined, the the value representing the variable is colored
         this.getEvaluateString = function(values, includeSign, color) {
             var s = '';
 
@@ -505,8 +505,8 @@ $.extend(KhanUtil, {
         // Assumes this expression can be factored to remove the one passed in
         this.divide = function(expression) {
             if (expression instanceof KhanUtil.RationalExpression) {
-                if (this.terms.length === 1) {
-                    return this.divideByTerm(expression.terms[0]);
+                if (expression.terms.length === 1) {
+                    return this.divide(expression.terms[0]);
                 }
 
                 var factors1 = this.factor();

--- a/utils/test/rational_expressions.html
+++ b/utils/test/rational_expressions.html
@@ -189,10 +189,14 @@
         start();
     });
 
-    asyncTest("divide expression", 3, function() {
+    asyncTest("divide expression", 7, function() {
         strictEqual(e4.divide(2).toString(), "x^2y^3 - 6x + 2", "expr by digit");
         strictEqual(e2.divide(t1).toString(), "-3x + 1", "expr by term digit");
         strictEqual(e4.divide(t2).toString(), "2xy^3 - 12 + 4x^-1", "expr by term");
+        strictEqual(e2.divide(new KhanUtil.RationalExpression([[2]])).toString(), "-6x + 2", "expr by one-term expr");
+        strictEqual(e2.divide(new KhanUtil.RationalExpression([[3, 'x'], -1])).toString(), "-4", "expr by expr");
+        strictEqual(e2.divide(new KhanUtil.RationalExpression([[-6, 'x'], 2])).toString(), "2", "expr by expr different factor");
+        strictEqual(e2.divide(new KhanUtil.RationalExpression([[3, 'x'], 1])), false, "expr by expr doesn't go");
         start();
     });
 


### PR DESCRIPTION
Remove call to non-existent divideByTerm function as mentioned by @mauk81 at https://github.com/Khan/khan-exercises/commit/48b8a46351910b2055d44c85036d2b65c1f8f946#commitcomment-4204795 and add more unit tests to cover more examples of division.
