### PR TITLE
Small fix to graphie-3d -- make sure a closed path is drawn

### DIFF
--- a/utils/graphie-3d.js
+++ b/utils/graphie-3d.js
@@ -211,7 +211,7 @@ $.extend(KhanUtil, {
             face.drawBack = function() {
             	if (object.facesTransparent){
                 return graph.path(
-                    face.mappedVerts(),
+                    face.mappedVerts().concat(true),
                     { fill: null, stroke: "#666", opacity: 0.1 }
                 );
                 }
@@ -267,7 +267,7 @@ $.extend(KhanUtil, {
             // draw the sketch's lines
             sketch.drawLines= function() {
                 return graph.path(
-                    sketch.mappedVerts(),
+                    sketch.mappedVerts().concat(true),
                     { fill: null, stroke: "#666", opacity: sketch.opacityValue }
                 );
             };


### PR DESCRIPTION
Small fix to graphie-3d -- make sure path is drawn:

```
path( [v1,v2,v3] )
```

should be 

```
path( [v1,v2,v3,true] ) 
```

to draw a closed path.
