### PR TITLE
Partial bug fix for unsimplified fractions in sets not working correctly

### DIFF
--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1306,6 +1306,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
 
                     // If we have a check answer message
                     if (typeof correct === "string") {
+                        score.correct = false;
                         score.message = correct;
                     }
                 });


### PR DESCRIPTION
Here is a partial bug fix for this Trello issue: https://trello.com/c/2N458wGL/606-unsimplified-fractions-in-sets-doesn-t-work-correctly

I don't believe I completely fixed the bug, but I thought I'd post a pull request to get feedback first. Mainly I'm not sure how this effects (affects? Can never get the usage here!) other exercises. I only looked at the issue with `complete the squares 2`.

The bug occurs in the createValidator method for the `set` answer type. Specifically the logic in lines 1253-1312.

At least in the exercise `complete the square 2`, unsimplified fractions are getting through because, the set validator's score object's `correct` property defaults to true, but is not set to false when there is a message returned from the other validators.

In my fix, I'm assuming a message will only be returned when the answer is incorrect.

A few other notes:
- In my testing, this bug allows unsimplified answers through, but also allows partially correct answers through.
  - For example if the solution 3, 4, 2, 2 for the inputs, and I put in 3, 8/2, 200, 700, then my answer will be marked as correct. This is because the loop in the `set validator` essentially considers any score object with a message as correct.
- In my fixed version, the "Your answer is almost correct, but it needs to be simplified" can be somewhat misleading.
  - For example if the solution is 3, 4, 2, 2 for the inputs, and I put in 3, 8/2, 200, 700, I will receive the error message. This makes it seem like I just need to simplify my fractions, but in this case, 2 of the answers are completely wrong.
  - Wasn't sure how to deal with that though. 
