### PR TITLE
Fix GH-98360, Fix similar triangles exercise not accepting correct answers

### DIFF
--- a/exercises/solving_similar_triangles_2.html
+++ b/exercises/solving_similar_triangles_2.html
@@ -79,7 +79,7 @@
                 <div class="hints" data-apply="appendContents">
                     <div>
                         <p><code>\overline{AB} : \overline{BC} = \dfrac{<var>SIDE_A</var>}{x}</code></p>
-                        <p><code>\overline{AD} : \overline{DE} = \dfrac{<var>SIDE_A</var> + <var>SIDE_B</var>}{<var>HEIGHT_B</var>} = 
+                        <p><code>\overline{AD} : \overline{DE} = \dfrac{<var>SIDE_A</var> + <var>SIDE_B</var>}{<var>HEIGHT_B</var>} =
                             <var>fraction(SIDE_A + SIDE_B, HEIGHT_B)</var></code></p>
                     </div>
 
@@ -92,13 +92,13 @@
                 </div>
             </div>
 
-            <div id="side-b" data-ensure="ANGLE > 20 && ANGLE < 50">
-                <div class="vars">
+            <div id="side-b">
+                <div class="vars" data-ensure="ANGLE > 20 && ANGLE < 50">
                     <var id="SIDE_A">randRange(1, 10)</var>
                     <var id="HEIGHT_A">randRange(1, SIDE_A)</var>
                     <var id="HEIGHT_B">HEIGHT_A + randRange(1, 10)</var>
                     <var id="SIDE_B">SIDE_A * (HEIGHT_B - HEIGHT_A) / HEIGHT_A</var>
-                    
+
                     <var id="LABELS">[SIDE_A, HEIGHT_A, "x", HEIGHT_B]</var>
                     <var id="ANGLE">atan(HEIGHT_A / SIDE_A) * 180 / PI</var>
                     <var id="TRI_A">new Triangle([0, 0],  [ANGLE, 90, 90 - ANGLE], 50 * (SIDE_A / (SIDE_A + SIDE_B)) * HEIGHT_A / HEIGHT_B, {})</var>
@@ -125,7 +125,7 @@
                     <p><code>
                         <span data-if="HEIGHT_A !== 1"><var>HEIGHT_A</var>(<var>SIDE_A</var> + x)</span>
                         <span data-else=""><var>SIDE_A</var> + x</span>
-                        = <var>HEIGHT_B * SIDE_A</var> 
+                        = <var>HEIGHT_B * SIDE_A</var>
                     </code></p>
 
                     <p data-if="HEIGHT_A !== 1"><code>
@@ -138,8 +138,8 @@
                 </div>
             </div>
 
-            <div id="height-b" data-ensure="ANGLE < 45">
-                <div class="vars">
+            <div id="height-b">
+                <div class="vars" data-ensure="ANGLE < 45">
                     <var id="SIDE_A">randRange(1, 10)</var>
                     <var id="SIDE_B">randRange(1, 10)</var>
                     <var id="HEIGHT_A">randRange(1, SIDE_A)</var>
@@ -173,7 +173,7 @@
                     </code></p>
 
                     <p data-ensure="SIDE_A !== 1"><code>
-                        x = <var>fraction(HEIGHT_A * (SIDE_A + SIDE_B), SIDE_A)</var> 
+                        x = <var>fraction(HEIGHT_A * (SIDE_A + SIDE_B), SIDE_A)</var>
                         <span data-if="getGCD(HEIGHT_A * (SIDE_A + SIDE_B), SIDE_A) !== 1">
                             = <var>fractionReduce(HEIGHT_A * (SIDE_A + SIDE_B), SIDE_A)</var>
                         </span>
@@ -234,7 +234,7 @@
             <p><code>\triangle ABC</code> and <code>\triangle ADE</code> both have a right angle and share <code>\angle BAC</code>.</p>
 
             <p>Therefore <code>\triangle ABC</code> and <code>\triangle ADE</code> are similar triangles.</p>
-            
+
             <p>
                 Therefore, the ratio <code>\overline{AB} : \overline{BC}</code>
                 is equal to the ratio <code>\overline{AD} : \overline{DE}</code>.


### PR DESCRIPTION
Here is a bug fix for GH-98360.

Similar triangles was not accepting correct answers in the case where `data-ensure` looped more than once. This affected problem types `height-b` and `side-b`. The ensure loops were placed on the `problem div` instead of on the `vars div`. This caused the solution var to get replaced on the first loop and therefore would not be updated on subsequent data-ensure loops.
