### PR TITLE
Making sure drawBack draws a closed outline for faces that are in the background

### DIFF
--- a/utils/graphie-3d.js
+++ b/utils/graphie-3d.js
@@ -220,7 +220,7 @@ $.extend(KhanUtil, {
             face.drawBack = function() {
             	if (object.facesTransparent){
                 return graph.path(
-                    face.mappedVerts(),
+                    face.mappedVerts().concat(true),
                     { fill: null, stroke: "#666", opacity: 0.1 }
                 );
                 }


### PR DESCRIPTION
This is the cleaned-up version of  https://github.com/Khan/khan-exercises/pull/84085
(i.e. doesn't touch  `sketch.drawLines` )

BTW, the version which is on graphie-to-png,
http://graphie-to-png.khanacademy.org/static/js/khan-exercises/utils/graphie-3d.js
still has the bad code before the revert.
