### PR TITLE
Add workspace (tex-pad?) to all exercises

### DIFF
--- a/css/khan-exercise.css
+++ b/css/khan-exercise.css
@@ -44,6 +44,18 @@ div.definition {
 }
 
 #workarea { margin-left: 30px; }
+#workspace { margin-left: 30px; }
+#workspace textarea, #workspace #workspace_display {
+	width: 48%;
+	height: 150px;
+}
+#workspace textarea {
+	resize: none; 
+	font: inherit;
+}
+#workspace #workspace_display {
+	float: right;
+}
 #hintsarea { margin-left: 50px; }
 #answer_area ul { list-style: none; }
 #answer_area li { padding: 7px 0; }

--- a/exercises/absolute_value_equations.html
+++ b/exercises/absolute_value_equations.html
@@ -41,6 +41,9 @@
                         <var>A</var>|x + <var>E</var>| + <var>B</var> =
                         <var>C</var>|x + <var>E</var>| + <var>D</var>
                     </code>
+                    <br><br>
+                     If you need to do some work on the page, but don't want to use scratchpad, try the workspace!
+ +                  It's on the bottom of the page, next to show scratchpad.
                 </p>
 
                 <div class="solution" data-type="multiple">

--- a/exercises/khan-exercise.html
+++ b/exercises/khan-exercise.html
@@ -21,6 +21,7 @@
         <div id="problemarea">
             <div id="scratchpad"><div></div></div>
             <div id="workarea" class="workarea"></div>
+            <div id="workspace"></div>
             <div id="hintsarea" class="hintsarea"></div>
         </div>
         <div id="answer_area_wrap"><div id="answer_area">

--- a/exercises/khan-site.html
+++ b/exercises/khan-site.html
@@ -44,6 +44,9 @@
                                             <li> <a href="" id="scratchpad-show" style="">Show scratchpad</a>
                                                 <span id="scratchpad-not-available" style="display: none;">Scratchpad not available</span>
                                             </li>
+                                            <li> <a href="" id="workspace-show" style="">Show workspace</a>
+                                                <span id="workspace-not-available" style="display: none;">Workspace not available</span>
+                                            </li>
                                             <li class="debug-mode"> <a href="?debug">Debug mode</a></li>
                                             <li> <a href="" id="problem-permalink">Problem permalink</a></li>
                                         </ul>

--- a/interface.js
+++ b/interface.js
@@ -46,6 +46,7 @@ var PerseusBridge = Exercises.PerseusBridge,
 $(Exercises)
     .bind("problemTemplateRendered", problemTemplateRendered)
     .bind("newProblem", newProblem)
+    .bind("showWorkspace", onWorkspaceShown)
     .bind("hintShown", onHintShown)
     .bind("readyForNextProblem", readyForNextProblem)
     .bind("warning", warning)
@@ -112,6 +113,17 @@ function problemTemplateRendered() {
         if (!localMode && userExercise.user) {
             window.localStorage["scratchpad:" + userExercise.user] =
                     Khan.scratchpad.isVisible();
+        }
+    });
+    
+    // Workspace toggle
+    $("#workspace-show").click(function(e) {
+        e.preventDefault();
+        Khan.workspace.toggle();
+
+        if (!localMode && userExercise.user) {
+            window.localStorage["workspace:" + userExercise.user] =
+                    Khan.workspace.isVisible();
         }
     });
 
@@ -408,6 +420,13 @@ function onHintShown(e, data) {
     }
 }
 
+function onWorkspaceShown(e, data) {
+	$("#workspace a").click(function(e) {
+        e.preventDefault();
+        Khan.workspace.texToggle();
+	});
+}
+
 function updateHintButtonText() {
     var $hintButton = $("#hint");
     var hintsLeft = numHints - hintsUsed;
@@ -676,6 +695,7 @@ function clearExistingProblem() {
             .show();
 
     Khan.scratchpad.clear();
+    Khan.workspace.clear();
 }
 
 })();

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -572,6 +572,90 @@ window.Khan = (function() {
 
             return actions;
         })(),
+        
+        workspace: (function() {
+            var disabled = false, isTex = false, wasVisible, workspace;
+
+            var actions = {
+                disable: function() {
+                    wasVisible = actions.isVisible();
+                    actions.hide();
+
+                    $("#workspace-show").hide();
+                    $("#workspace-not-available").show();
+                    disabled = true;
+                },
+
+                enable: function() {
+                    if (wasVisible) {
+                        actions.show();
+                        wasVisible = false;
+                    }
+
+                    $("#workspace-show").show();
+                    $("#workspace-not-available").hide();
+                    disabled = false;
+                },
+
+                isVisible: function() {
+                    return workspace ? $("#workspace").is(":visible"): false;
+                },
+
+                show: function() {
+                    if (actions.isVisible()) {
+                        return;
+                    }
+
+                    var makeVisible = function() {
+                        $("#workspace").show();
+                        $("#workspace-show").text($._("Hide workspace"));
+
+                        // If workspace has never been created or if it's empty
+                        // because it was removed from the DOM, recreate a new
+                        // workspace.
+                        if (!workspace || !$("#workspace").children().length) {
+                            workspace = new MakeWorkspace(
+                                $("#workspace"));
+                        }
+                        $(Exercises).trigger("showWorkspace");
+                        $("#workspace-tex-toggle").text(isTex ? "Switch to non-tex" : "Switch to tex");
+                    };
+
+                    loadModule("workspace").then(makeVisible);
+                },
+
+                hide: function() {
+                    if (!actions.isVisible()) {
+                        return;
+                    }
+
+                    $("#workspace").hide();
+                    $("#workspace-show").text($._("Show workspace"));
+                },
+                
+                texToggle: function() {
+                	isTex = !isTex;
+                	$("#workspace-tex-toggle").text(isTex ? "Switch to non-tex" : "Switch to tex");
+                	$("#workspace_input").trigger("propertychange");
+                },
+                
+                isTex: function() {
+                	return isTex;
+                },
+
+                toggle: function() {
+                    actions.isVisible() ? actions.hide() : actions.show();
+                },
+
+                clear: function() {
+                    $('#workspace_input').val('');
+                    $('#workspace_display').empty();
+                },
+
+            };
+
+            return actions;
+        })(),
 
         getSeedInfo: function() {
             return {
@@ -1099,6 +1183,11 @@ window.Khan = (function() {
                 if (typeof lastScratchpad !== "undefined" && JSON.parse(lastScratchpad)) {
                     Khan.scratchpad.show();
                 }
+                
+                var lastWorkspace = window.localStorage["workspace:" + user];
+                if (typeof lastWorkspace !== "undefined" && JSON.parse(lastWorkspace)) {
+                    Khan.workspace.show();
+                }
             }
 
             $(Exercises).trigger("clearExistingProblem");
@@ -1179,6 +1268,8 @@ window.Khan = (function() {
 
         // Enable scratchpad (unless the exercise explicitly disables it later)
         Khan.scratchpad.enable();
+        
+        Khan.workspace.enable();
 
         // Allow passing in a random seed
         if (typeof seed !== "undefined") {

--- a/utils/workspace.js
+++ b/utils/workspace.js
@@ -1,0 +1,102 @@
+function MakeWorkspace(workspace, options) {
+    var defaults = {
+    	functions: "f g h",
+    };
+    
+    options = _.extend(defaults, options);
+    var message = '"Type in something here and it will be parsed it on the right."'
+    var $input = $('<textarea id="workspace_input" placeholder='+message+'/>');
+    var $tex = $('<div id="workspace_display" class="tex"/>');
+    var $texToggle = $('<a href="#" id="workspace-tex-toggle"/>');
+    
+	
+    $(workspace).append($input, $tex, $texToggle);
+	
+    var lastParsedTex = [];
+    
+    var update = function() {
+        isTex = Khan.workspace.isTex();
+        if(isTex && $input.val()) {
+        	$tex.empty().append($("<code>").text($input.val())).tex();
+        } else {
+        	var inputLines = $input.val().split(/\r|\r\n|\n/);
+        	var parsedText = "";
+        	_.each(inputLines, function(inputLine, i) {
+        		var result = KAS.parse(inputLine, options);
+        		if(result.parsed) {
+        			lastParsedTex[i] = result.expr.tex();
+        		}
+        		parsedText += lastParsedTex[i] +" \\\\ ";
+        	});
+        	$tex.empty().append($("<code>").text(parsedText)).tex()
+        }	
+    };
+        
+    // Define event handlers
+    $input.on("input propertychange", update);
+
+    $input.on("keydown", function(event) {
+        var input = $input[0];
+
+        var start = input.selectionStart;
+        var end = input.selectionEnd;
+        var supported = start !== undefined;
+
+        if (supported && event.which === 8 /* backspace */) {
+            var val = input.value;
+            if (start === end && val.slice(start - 1, start + 1) === "()") {
+                // "f(|)" + backspace -> "f|" (| is the cursor position)
+                event.preventDefault();
+                input.value = val.slice(0, start - 1) + val.slice(start + 1);
+                input.selectionStart = start - 1;
+                input.selectionEnd = end - 1;
+                update();
+            }
+        }
+    });
+
+    $input.on("keypress", function(event) {
+        var input = $input[0];
+
+        var start = input.selectionStart;
+        var end = input.selectionEnd;
+        var supported = start !== undefined;
+
+        if (supported && event.which === 40 /* left paren */) {
+            var val = input.value;
+            event.preventDefault();
+
+            if (start === end) {
+                // "f|" + "(" -> "f(|)"
+                var insertMatched = _.any([" ", ")", ""], function(c) {
+                    return val.charAt(start) === c;
+                });
+
+                input.value = val.slice(0, start) +
+                        (insertMatched ? "()" : "(") + val.slice(end);
+            } else {
+                // "f|x+y|" + "(" -> "f(|x+y|)"
+                input.value = val.slice(0, start) +
+                        "(" + val.slice(start, end) + ")" + val.slice(end);
+            }
+
+            input.selectionStart = start + 1;
+            input.selectionEnd = end + 1;
+            update();
+
+        } else if (supported && event.which === 41 /* right paren */) {
+            var val = input.value;
+            if (start === end && val.charAt(start) === ")") {
+                // f(|) + ")" -> "f()|"
+                event.preventDefault();
+                input.selectionStart = start + 1;
+                input.selectionEnd = end + 1;
+                update();
+            }
+        }
+        
+        this.update = update;
+        
+        return this;
+    });
+}


### PR DESCRIPTION
tldr: A instantly parsing textarea. Go to this [sandcastle](http://sandcastle.kasandbox.org/media/castles/Merbs:texpad/exercises/absolute_value_equations.html) and click on "Show workspace" at the bottom of the page.

This is just a proof of concept as an alternative to the scratchpad. It adds the link "Show workspace" at the bottom of the page alongside "Show scratchpad". When clicked, it produces textarea that takes up half the width of the screen, which upon input, parses that input and displays the parsed tex on the other half of the screen. Atm, it defaults to the pseudo-tex that the `expression` answer-type reads in and feeds to KAS. It also provides a "Switch to tex" option, which is far less limited, but you need to know tex, and end each line with `\\`. The provided version has multiline support in the pseudo-tex format (adds the `\\` for you). There are definitely issues (for example, KAS can parse `1=1` but can't parse `1=1=1` or `3|x|`), but they can be fixed if you (collective) think this is worth pursuing.

As a rationale, 
- this is how I do my maths
- an algorithm can possibly read in their input, watch as they reduce line by line, and unobtrusively alert them if they made an error (forgot to distribute a -1, added incorrectly, etc.), with some time delay (or after they submit an answer).
- data aggregation (per problem) could look for common mistakes, which couldn't be derived from the user's guess alone. 
