### PR TITLE
Add clues for common mistakes/misconceptions

### DIFF
--- a/exercises/clues_example.html
+++ b/exercises/clues_example.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html data-require="math math-format">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Clue Example</title>
+    <script src="../khan-exercise.js"></script>
+    <script type="text/javascript"></script>
+</head>
+<body>
+<div class="exercise">
+    <div class="problems">
+        <div id="misconceptions_marked_wrong">
+            <div class="vars"></div>
+            <p class="question">First round the following numbers, then add them: 34.5, 22.1, 30.6
+            	<br/><br/> Try entering in 87 (the answer you'd get if you added, then rounded; a misconception).
+            	<br/><br/> (Inspired by this <a href="https://github.com/Khan/khan-exercises/issues/113278">issue</a>)
+            	<br/><br/><br/><br/> Problem 1 of 3 (marked wrong)</p>
+            <p class="solution" data-type="expression" 
+            	data-clues='{"87":"Did you forget to round each number BEFORE adding?"}'>
+            	88</p>
+        </div>
+        <div id="common_mistakes">
+            <div class="vars"></div>
+            <p class="question">Express .03 as a fraction
+            	<br/><br/> Try entering in 3/10  (the answer you'd get if you made a common mistake).
+            	<br/><br/> (Inspired by this <a href="https://github.com/Khan/khan-exercises/issues/115239">issue</a>)
+            	<br/><br/><br/><br/> Problem 3 of 3 (marked wrong)</p>
+            <p class="solution" data-type="expression" data-same-form
+            	data-clues='{"3/10":"If 3/1 = 3 and 3/10 is .3, how would you express .03?"}'>
+            	3/100</p>
+        </div>
+        
+        <div id="misunderstanding_format_of_answer">
+            <p class="question"> How many times do you need to multiply 52.024 by ten to get 5202.4?</p>
+			<br/><br/> Try entering in 100  (the actual power of 10 rather than the exponent).
+            	<br/><br/> (Inspired by this <a href="https://github.com/Khan/khan-exercises/issues/115251">issue</a>)
+            	<br/><br/><br/><br/> Problem 3 of 3 (NOT marked wrong / considered empty answer / note that the button doesn't shake)</p>
+            <p class="solution" data-type="expression" 
+            	data-clues='{"100":["Yes, multiplying by 100 gets 5202.4, but the question asks how many times.", true]}'>
+            	2</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1974,6 +1974,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
             var options = {
                 form: solutionData.sameForm != null,
                 simplify: solutionData.simplify != null,
+                clues: solutionData.clues,
                 times: solutionData.times != null
             };
 
@@ -2147,6 +2148,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                     empty: false,
                     correct: false,
                     message: null,
+                    clues: options.clues,                    
                     guess: guess
                 };
                 // Don't bother parsing an empty input
@@ -2163,11 +2165,18 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                     return score;
                 }
 
+                var clue = _.find(options.clues, function(message, condition) {
+                	return guess == condition;
+                });
+
                 var result = KAS.compare(answer.expr, solution, options);
 
                 if (result.equal) {
                     // Correct answer
                     score.correct = true;
+                } else if (clue) {
+                	score.message = _.isArray(clue) ? clue[0] : clue;
+                	score.empty = _.isArray(clue) ? clue[1] : false;
                 } else if (result.message) {
                     // Nearly correct answer
                     score.message = result.message;


### PR DESCRIPTION
See this [sandcastle](http://sandcastle.kasandbox.org/media/castles/Merbs:clues/exercises/clues_example.html) and go through the three examples.

Provides a clue if the user's guess is a common mistake/misconception (arithmetic error, misunderstanding, wrong format). Gives the exercise-creator the ability to add `data-clues` property to solution in form `'{"guess":"message", "guess_2":"message_2"}'` with an option to pass an array as the value: `'{"guess":["message",
"count_as_empty"]}'`, where count_as_empty can be set to true to prevent the guess from being marked incorrect (a more lenient approach).

Only on the answer-type `expression`, for this commit. Just a proof of concept.
