### PR TITLE
Remove mention of LCM from fraction exercises

### DIFF
--- a/exercises/adding_and_subtracting_fractions.html
+++ b/exercises/adding_and_subtracting_fractions.html
@@ -7,59 +7,59 @@
 </head>
 <body>
     <div class="exercise">
-    <div class="vars" data-ensure="D1 !== D2">
-        <var id="N1">randRange(1, 9)</var>
-        <var id="N2">randRange(1, 9)</var>
-        <var id="S1">randFromArray([-1, 1])</var>
-        <var id="S2">randFromArray([-1, 1])</var>
-        <var id="D1">randRangeExclude(2, 9, [N1])</var>
-        <var id="D2">randRangeExclude(2, 9, [N2])</var>
-        <var id="LCM">getLCM(D1, D2)</var>
-        <var id="F1">LCM / D1</var>
-        <var id="F2">LCM / D2</var>
-    </div>
+        <div class="vars" data-ensure="D1 !== D2">
+            <var id="S1">randFromArray([-1, 1])</var>
+            <var id="S2">randFromArray([-1, 1])</var>
+            <var id="D1">randFromArray(smallDenominators)</var>
+            <var id="D2">randFromArray(smallDenominators)</var>
+            <var id="N1">randRangeExclude(1, 9, [D1])</var>
+            <var id="N2">randRangeExclude(1, 9, [D2])</var>
+            <var id="LCM">getLCM(D1, D2)</var>
+            <var id="F1">LCM / D1</var>
+            <var id="F2">LCM / D2</var>
+        </div>
 
-    <div class="problems">
-        <div>
-            <div class="question">
-                <p><code><var>fraction(S1 * N1, D1)</var> + <var>fraction(S2 * N2, D2)</var> = {?}</code></p>
+        <div class="problems">
+            <div>
+                <div class="question">
+                    <p><code><var>fraction(S1 * N1, D1)</var> + <var>fraction(S2 * N2, D2)</var> = {?}</code></p>
+                </div>
+                <div class="solution" data-type="rational"><var>S1 * N1 / D1 + S2 * N2 / D2</var></div>
             </div>
-            <div class="solution" data-type="rational"><var>S1 * N1 / D1 + S2 * N2 / D2</var></div>
         </div>
-    </div>
 
-    <div class="hints">
-        <p><code>
-            \qquad =
-            <span data-if="S1 === -1">-</span>
-            \blue{\dfrac{<var>N1</var> \times <var>F1</var>}{<var>D1</var> \times <var>F1</var>}}
-            <span data-if="S2 === -1">-</span><span data-else>+</span>
-            \green{\dfrac{<var>N2</var> \times <var>F2</var>}{<var>D2</var> \times <var>F2</var>}}
-        </code></p>
+        <div class="hints">
+            <p><code>
+                \qquad =
+                <span data-if="S1 === -1">-</span>
+                \blue{\dfrac{<var>N1</var> \times <var>F1</var>}{<var>D1</var> \times <var>F1</var>}}
+                <span data-if="S2 === -1">-</span><span data-else>+</span>
+                \green{\dfrac{<var>N2</var> \times <var>F2</var>}{<var>D2</var> \times <var>F2</var>}}
+            </code></p>
 
-        <p><code>
-            \qquad =
-            <span data-if="S1 === -1">-</span>
-            \blue{\dfrac{<var>N1 * F1</var>}{<var>LCM</var>}}
-            <span data-if="S2 === -1">-</span><span data-else>+</span>
-            \green{\dfrac{<var>N2 * F2</var>}{<var>LCM</var>}}
-        </code></p>
+            <p><code>
+                \qquad =
+                <span data-if="S1 === -1">-</span>
+                \blue{\dfrac{<var>N1 * F1</var>}{<var>LCM</var>}}
+                <span data-if="S2 === -1">-</span><span data-else>+</span>
+                \green{\dfrac{<var>N2 * F2</var>}{<var>LCM</var>}}
+            </code></p>
 
-        <p><code>
-            \qquad =
-            <span data-if="S1 === -1">-</span>
-            \dfrac{\blue{<var>N1 * F1</var>}
-            <span data-if="S2 === -1">-</span><span data-else>+</span>
-            \green{<var>N2 * F2</var>}}{<var>LCM</var>}
-        </code></p>
+            <p><code>
+                \qquad =
+                <span data-if="S1 === -1">-</span>
+                \dfrac{\blue{<var>N1 * F1</var>}
+                <span data-if="S2 === -1">-</span><span data-else>+</span>
+                \green{<var>N2 * F2</var>}}{<var>LCM</var>}
+            </code></p>
 
-        <p><code>\qquad = <var>fraction(S1 * F1 * N1 + S2 * F2 * N2, LCM)</var></code></p>
+            <p><code>\qquad = <var>fraction(S1 * F1 * N1 + S2 * F2 * N2, LCM)</var></code></p>
 
-        <div data-if="getGCD( F1 * N1 + F2 * N2, LCM ) !== 1">
-            <p>Simplify.</p>
-            <p><code>\qquad = <var>fractionReduce( F1 * N1 + F2 * N2, LCM )</var></code></p>
+            <div data-if="getGCD(F1 * N1 + F2 * N2, LCM) !== 1">
+                <p>Simplify.</p>
+                <p><code>\qquad = <var>fractionReduce(F1 * N1 + F2 * N2, LCM)</var></code></p>
+            </div>
         </div>
-    </div>
     </div>
 </body>
 </html>

--- a/exercises/adding_and_subtracting_fractions.html
+++ b/exercises/adding_and_subtracting_fractions.html
@@ -8,11 +8,13 @@
 <body>
     <div class="exercise">
     <div class="vars" data-ensure="D1 !== D2">
-        <var id="N1">randRangeNonZero( -9, 9 )</var>
-        <var id="N2">randRangeNonZero( -9, 9 )</var>
-        <var id="D1">randRangeExclude( 2, 9, [ N1, -N1 ] )</var>
-        <var id="D2">randRangeExclude( 2, 9, [ N2, -N2 ] )</var>
-        <var id="LCM">getLCM( D1, D2 )</var>
+        <var id="N1">randRange(1, 9)</var>
+        <var id="N2">randRange(1, 9)</var>
+        <var id="S1">randFromArray([-1, 1])</var>
+        <var id="S2">randFromArray([-1, 1])</var>
+        <var id="D1">randRangeExclude(2, 9, [N1])</var>
+        <var id="D2">randRangeExclude(2, 9, [N2])</var>
+        <var id="LCM">getLCM(D1, D2)</var>
         <var id="F1">LCM / D1</var>
         <var id="F2">LCM / D2</var>
     </div>
@@ -20,29 +22,42 @@
     <div class="problems">
         <div>
             <div class="question">
-                <p><code><var>fraction( N1, D1 )</var> + <var>fraction( N2, D2 )</var> = {?}</code></p>
+                <p><code><var>fraction(S1 * N1, D1)</var> + <var>fraction(S2 * N2, D2)</var> = {?}</code></p>
             </div>
-            <div class="solution" data-type="rational"><var>N1 / D1 + N2 / D2</var></div>
+            <div class="solution" data-type="rational"><var>S1 * N1 / D1 + S2 * N2 / D2</var></div>
         </div>
     </div>
 
     <div class="hints">
-        <p>First, we need to find a common denominator. The least common multiple of <code><var>D1</var></code> and <code><var>D2</var></code> is the smallest possible common denominator.</p>
-        <p><code>\lcm(<var>D1</var>, <var>D2</var>) = <var>LCM</var></code></p>
-        <p>Now, we need to change both fractions to have a denominator of <code><var>LCM</var></code>.</p>
-        <p><code>\begin{align*}<var>fraction( N1, D1 )</var>\cdot <var>fraction( F1, F1 )</var> &amp;= <var>fraction( N1 * F1, LCM )</var>\\
-        <var>fraction( N2, D2 )</var>\cdot <var>fraction( F2, F2 )</var> &amp;= <var>fraction( N2 * F2, LCM )</var>\end{align*}</code></p>
-        <div>
-            <p>So, the problem becomes:</p>
-            <p><code><var>fraction( N1 * F1, LCM )</var> + <var>fraction( N2 * F2, LCM )</var> = {?}</code></p>
-        </div>
-        <div>
-            <p data-if="N2 > 0">Add the numerators.</p><p data-else="">Subtract the numerators.</p>
-            <p><code><var>fraction( F1 * N1 + F2 * N2, LCM)</var></code></p>
-        </div>
+        <p><code>
+            \qquad =
+            <span data-if="S1 === -1">-</span>
+            \blue{\dfrac{<var>N1</var> \times <var>F1</var>}{<var>D1</var> \times <var>F1</var>}}
+            <span data-if="S2 === -1">-</span><span data-else>+</span>
+            \green{\dfrac{<var>N2</var> \times <var>F2</var>}{<var>D2</var> \times <var>F2</var>}}
+        </code></p>
+
+        <p><code>
+            \qquad =
+            <span data-if="S1 === -1">-</span>
+            \blue{\dfrac{<var>N1 * F1</var>}{<var>LCM</var>}}
+            <span data-if="S2 === -1">-</span><span data-else>+</span>
+            \green{\dfrac{<var>N2 * F2</var>}{<var>LCM</var>}}
+        </code></p>
+
+        <p><code>
+            \qquad =
+            <span data-if="S1 === -1">-</span>
+            \dfrac{\blue{<var>N1 * F1</var>}
+            <span data-if="S2 === -1">-</span><span data-else>+</span>
+            \green{<var>N2 * F2</var>}}{<var>LCM</var>}
+        </code></p>
+
+        <p><code>\qquad = <var>fraction(S1 * F1 * N1 + S2 * F2 * N2, LCM)</var></code></p>
+
         <div data-if="getGCD( F1 * N1 + F2 * N2, LCM ) !== 1">
             <p>Simplify.</p>
-            <p><code><var>fractionReduce( F1 * N1 + F2 * N2, LCM )</var></code></p>
+            <p><code>\qquad = <var>fractionReduce( F1 * N1 + F2 * N2, LCM )</var></code></p>
         </div>
     </div>
     </div>

--- a/exercises/adding_and_subtracting_fractions.html
+++ b/exercises/adding_and_subtracting_fractions.html
@@ -54,11 +54,6 @@
             </code></p>
 
             <p><code>\qquad = <var>fraction(S1 * F1 * N1 + S2 * F2 * N2, LCM)</var></code></p>
-
-            <div data-if="getGCD(F1 * N1 + F2 * N2, LCM) !== 1">
-                <p>Simplify.</p>
-                <p><code>\qquad = <var>fractionReduce(F1 * N1 + F2 * N2, LCM)</var></code></p>
-            </div>
         </div>
     </div>
 </body>

--- a/exercises/adding_fractions.html
+++ b/exercises/adding_fractions.html
@@ -7,66 +7,46 @@
 </head>
 <body>
     <div class="exercise">
-    <div class="vars" data-ensure="SIMP_D1 !== SIMP_D2">
-        <var id="N1">randRange( 1, 9 )</var>
-        <var id="D1">randRange( N1 + 1, 13 )</var>
-        <var id="GCD1">getGCD( N1, D1 )</var>
-        <var id="SIMP_N1">N1 / GCD1</var>
-        <var id="SIMP_D1">D1 / GCD1</var>
+        <div class="problems">
+            <div>
+                <div class="vars">
+                    <var id="D1">randFromArray(smallDenominators)</var>
+                    <var id="D2">randFromArray(smallDenominators)</var>
+                    <var id="N1">randRangeExclude(1, 9, [D1])</var>
+                    <var id="N2">randRangeExclude(1, 9, [D2])</var>
+                    <var id="LCM">getLCM(D1, D2)</var>
+                    <var id="F1">LCM / D1</var>
+                    <var id="F2">LCM / D2</var>
+                </div>
 
-        <var id="N2">randRange( 1, 9 )</var>
-        <var id="D2">randRange( N2 + 1, 13 )</var>
-        <var id="GCD2">getGCD( N2, D2 )</var>
-        <var id="SIMP_N2">N2 / GCD2</var>
-        <var id="SIMP_D2">D2 / GCD2</var>
+                <p class="question"><code><var>fraction( N1, D1 )</var> + <var>fraction( N2, D2 )</var> = {?}</code></p>
+                <p class="solution" data-type="rational"><var>N1 / D1 + N2 / D2</var></p>
 
-        <var id="LCM">getLCM( SIMP_D1, SIMP_D2 )</var>
-    </div>
+                <div class="hints">
+                    <p><code>
+                        \qquad = \blue{\dfrac{<var>N1</var> \times <var>F1</var>}{<var>D1</var> \times <var>F1</var>}} + 
+                        \green{\dfrac{<var>N2</var> \times <var>F2</var>}{<var>D2</var> \times <var>F2</var>}}
+                    </code></p>
 
-    <div class="problems">
-        <div id="add-fractions">
-            <p class="question"><code><var>fraction( N1, D1 )</var> + <var>fraction( N2, D2 )</var> = {?}</code></p>
-            <p class="solution" data-type="rational"><var>N1 / D1 + N2 / D2</var></p>
-        </div>
+                    <p><code>
+                        \qquad = \blue{\dfrac{<var>N1 * F1</var>}{<var>LCM</var>}} + 
+                        \green{\dfrac{<var>N2 * F2</var>}{<var>LCM</var>}}
+                    </code></p>
 
-        <div id="custom-8" data-type="add-fractions" data-weight="0">
-            <div class="vars">
-                <var id="N1">1</var>
-                <var id="D1">2</var>
-                <var id="GCD1">getGCD( N1, D1 )</var>
-                <var id="SIMP_N1">N1 / GCD1</var>
-                <var id="SIMP_D1">D1 / GCD1</var>
+                    <p><code>
+                        \qquad = \dfrac{\blue{<var>N1 * F1</var>} + 
+                        \green{<var>N2 * F2</var>}}{<var>LCM</var>}
+                    </code></p>
 
-                <var id="N2">1</var>
-                <var id="D2">4</var>
-                <var id="GCD2">getGCD( N2, D2 )</var>
-                <var id="SIMP_N2">N2 / GCD2</var>
-                <var id="SIMP_D2">D2 / GCD2</var>
+                    <p><code>\qquad = <var>fraction(F1 * N1 + F2 * N2, LCM)</var></code></p>
 
-                <var id="LCM">getLCM( SIMP_D1, SIMP_D2 )</var>
+                    <div data-if="getGCD(F1 * N1 + F2 * N2, LCM) !== 1">
+                        <p>Simplify.</p>
+                        <p><code>\qquad = <var>fractionReduce(F1 * N1 + F2 * N2, LCM)</var></code></p>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-
-    <div class="hints">
-        <div data-if="GCD1 !== 1 || GCD2 !== 1">
-            <p>Simplify each fraction.</p>
-            <p><code><var>fraction( SIMP_N1, SIMP_D1 )</var> + <var>fraction( SIMP_N2, SIMP_D2 )</var></code></p>
-        </div>
-        <p>Find a common denominator by finding the least common multiple of <code><var>SIMP_D1</var></code> and <code><var>SIMP_D2</var></code>.</p>
-        <p><code>\lcm(<var>SIMP_D1</var>, <var>SIMP_D2</var>) = <var>LCM</var></code></p>
-        <div>
-            <p>Change each fraction to an equivalent fraction with a denominator of <code><var>LCM</var></code>.</p>
-            <p><code><var>fraction( SIMP_N1, SIMP_D1 )</var> + <var>fraction( SIMP_N2, SIMP_D2 )</var></code></p>
-            <p><code>=<var>fraction( SIMP_N1, SIMP_D1 )</var> <span data-if="LCM !== SIMP_D1">\cdot <var>fraction( LCM / SIMP_D1, LCM / SIMP_D1 )</var></span> + <var>fraction( SIMP_N2, SIMP_D2 )</var> <span data-if="LCM !== SIMP_D2">\cdot <var>fraction( LCM / SIMP_D2, LCM / SIMP_D2 )</var></span></code></p>
-        </div>
-        <p><code>=<var>fraction( SIMP_N1 * LCM / SIMP_D1, LCM )</var> + <var>fraction( SIMP_N2 * LCM / SIMP_D2, LCM )</var></code></p>
-        <p><code>=<var>fraction( SIMP_N1 * LCM / SIMP_D1 + SIMP_N2 * LCM / SIMP_D2, LCM )</var></code></p>
-        <div data-if="getGCD( SIMP_N1 * LCM / SIMP_D1 + SIMP_N2 * LCM / SIMP_D2, LCM ) !== 1">
-            <p>Simplify.</p>
-            <p><code>=<var>fractionReduce( SIMP_N1 * LCM / SIMP_D1 + SIMP_N2 * LCM / SIMP_D2, LCM )</var></code></p>
-        </div>
-    </div>
     </div>
 </body>
 </html>

--- a/exercises/adding_fractions.html
+++ b/exercises/adding_fractions.html
@@ -39,11 +39,6 @@
                     </code></p>
 
                     <p><code>\qquad = <var>fraction(F1 * N1 + F2 * N2, LCM)</var></code></p>
-
-                    <div data-if="getGCD(F1 * N1 + F2 * N2, LCM) !== 1">
-                        <p>Simplify.</p>
-                        <p><code>\qquad = <var>fractionReduce(F1 * N1 + F2 * N2, LCM)</var></code></p>
-                    </div>
                 </div>
             </div>
         </div>

--- a/exercises/adding_fractions.html
+++ b/exercises/adding_fractions.html
@@ -12,8 +12,8 @@
                 <div class="vars">
                     <var id="D1">randFromArray(smallDenominators)</var>
                     <var id="D2">randFromArray(smallDenominators)</var>
-                    <var id="N1">randRangeExclude(1, 9, [D1])</var>
-                    <var id="N2">randRangeExclude(1, 9, [D2])</var>
+                    <var id="N1">randRange(1, D1 - 1)</var>
+                    <var id="N2">randRange(1, D2 - 1)</var>
                     <var id="LCM">getLCM(D1, D2)</var>
                     <var id="F1">LCM / D1</var>
                     <var id="F2">LCM / D2</var>
@@ -23,20 +23,56 @@
                 <p class="solution" data-type="rational"><var>N1 / D1 + N2 / D2</var></p>
 
                 <div class="hints">
-                    <p><code>
-                        \qquad = \blue{\dfrac{<var>N1</var> \times <var>F1</var>}{<var>D1</var> \times <var>F1</var>}} + 
-                        \green{\dfrac{<var>N2</var> \times <var>F2</var>}{<var>D2</var> \times <var>F2</var>}}
-                    </code></p>
+                    <div class="graphie">
+                        init({ range: [[0, 2.4], [-1, 2]], scale: [200, 40] });
+                        rectchart([N1, D1 - N1], [BLUE, "#999"], 0);
+                        var chart2 = rectchart([N2, D2 - N2], [GREEN, "#999"], 0);
+                        chart2.translate(240, 0);
 
-                    <p><code>
-                        \qquad = \blue{\dfrac{<var>N1 * F1</var>}{<var>LCM</var>}} + 
-                        \green{\dfrac{<var>N2 * F2</var>}{<var>LCM</var>}}
-                    </code></p>
+                        label([0.5, 1], "\\blue{\\dfrac{" + N1 + "}{" + D1 + "}}", "above");
+                        label([1.7, 1], "\\green{\\dfrac{" + N2 + "}{" + D2 + "}}", "above");
+                        label([1.1, 1], "+", "above");
+                    </div>
 
-                    <p><code>
-                        \qquad = \dfrac{\blue{<var>N1 * F1</var>} + 
-                        \green{<var>N2 * F2</var>}}{<var>LCM</var>}
-                    </code></p>
+                    <div class="graphie">
+                        init({ range: [[0, 3], [0, 2]], scale: [200, 40] });
+                        rectchart([N1 * F1, LCM - N1 * F1], [BLUE, "#999"], 0);
+                        var chart2 = rectchart([N2 * F2, LCM - N2 * F2], [GREEN, "#999"], 0);
+                        chart2.translate(240, 0);
+
+                        label([0.5, 1], "\\blue{\\dfrac{" + N1 + " \\times " + F1 + "}{" + D1 + " \\times " + F1 + "}}", "above");
+                        label([1.7, 1], "\\green{\\dfrac{" + N2 + " \\times " + F2 + "}{" + D2 + " \\times " + F2 + "}}", "above");
+                        label([1.1, 1], "+", "above");
+                    </div>
+
+                    <div class="graphie">
+                        init({ range: [[0, 3], [0, 1.5]], scale: [200, 40] });
+
+                        label([0.5, 0], "\\blue{\\dfrac{" + (N1 * F1) + "}{" + LCM  + "}}", "above");
+                        label([1.7, 0], "\\green{\\dfrac{" + (N2 * F2) + "}{" + LCM + "}}", "above");
+                        label([1.1, 0], "+", "above");
+                    </div>
+
+                    <div>
+                        <div class="graphie">
+                            init({ range: [[0, 3], [0, 2]], scale: [200, 40] });
+
+                            if (N1 / D1 + N2 / D2 &gt; 1) {
+                                var part1 = LCM - N1 * F1;
+                                var part2 = N2 * F2 - part1;
+
+                                rectchart([N1 * F1, part1], [BLUE, GREEN], 0);
+                                var chart2 = rectchart([part2, LCM - part2], [GREEN, "#999"], 0);
+                                chart2.translate(240, 0);
+                            } else {
+                                rectchart([N1 * F1, N2 * F2, LCM - N1 * F1 - N2 * F2], [BLUE, GREEN, "#999"], 0);
+                            }
+                        </div>
+                        <p><code>
+                            \qquad = \dfrac{\blue{<var>N1 * F1</var>} + 
+                            \green{<var>N2 * F2</var>}}{<var>LCM</var>}
+                        </code></p>
+                    </div>
 
                     <p><code>\qquad = <var>fraction(F1 * N1 + F2 * N2, LCM)</var></code></p>
                 </div>

--- a/exercises/adding_fractions.html
+++ b/exercises/adding_fractions.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-require="math math-format">
+<html data-require="math math-format graphie graphie-helpers">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Adding fractions</title>

--- a/exercises/subtracting_fractions.html
+++ b/exercises/subtracting_fractions.html
@@ -38,11 +38,6 @@
                     </code></p>
 
                     <p><code>\qquad = <var>fraction(F1 * N1 - F2 * N2, LCM)</var></code></p>
-
-                    <div data-if="getGCD(F1 * N1 - F2 * N2, LCM) !== 1">
-                        <p>Simplify.</p>
-                        <p><code>\qquad = <var>fractionReduce(F1 * N1 + F2 * N2, LCM)</var></code></p>
-                    </div>
                 </div>
             </div>
         </div>

--- a/exercises/subtracting_fractions.html
+++ b/exercises/subtracting_fractions.html
@@ -7,48 +7,45 @@
 </head>
 <body>
     <div class="exercise">
-    <div class="vars" data-ensure="N1/D1 - N2/D2 > 0 && SIMP_D1 !== SIMP_D2">
-        <var id="D1">randRange( 2, 10 )</var>
-        <var id="N1">randRange( 1, D1 - 1 )</var>
-        <var id="GCD1">getGCD( N1, D1 )</var>
-        <var id="SIMP_N1">N1 / GCD1</var>
-        <var id="SIMP_D1">D1 / GCD1</var>
+        <div class="problems">
+            <div>
+                <div class="vars" data-ensure="N1/D1 > N2/D2">
+                    <var id="D1">randFromArray(smallDenominators)</var>
+                    <var id="D2">randFromArray(smallDenominators)</var>
+                    <var id="N1">randRangeExclude(1, 9, [D1])</var>
+                    <var id="N2">randRangeExclude(1, 9, [D2])</var>
+                    <var id="LCM">getLCM(D1, D2)</var>
+                    <var id="F1">LCM / D1</var>
+                    <var id="F2">LCM / D2</var>
+                </div>
+                <p class="question"><code><var>fraction(N1, D1)</var> - <var>fraction(N2, D2)</var> = {?}</code></p>
+                <p class="solution" data-type="rational"><var>N1 / D1 - N2 / D2</var></p>
 
-        <var id="D2">randRange( 2, 10 )</var>
-        <var id="N2">randRange( 1, D2 - 1 )</var>
-        <var id="GCD2">getGCD( N2, D2 )</var>
-        <var id="SIMP_N2">N2 / GCD2</var>
-        <var id="SIMP_D2">D2 / GCD2</var>
+                <div class="hints">
+                    <p><code>
+                        \qquad = \blue{\dfrac{<var>N1</var> \times <var>F1</var>}{<var>D1</var> \times <var>F1</var>}} - 
+                        \green{\dfrac{<var>N2</var> \times <var>F2</var>}{<var>D2</var> \times <var>F2</var>}}
+                    </code></p>
 
-        <var id="LCM">getLCM( SIMP_D1, SIMP_D2 )</var>
-    </div>
+                    <p><code>
+                        \qquad = \blue{\dfrac{<var>N1 * F1</var>}{<var>LCM</var>}} -
+                        \green{\dfrac{<var>N2 * F2</var>}{<var>LCM</var>}}
+                    </code></p>
 
-    <div class="problems">
-        <div>
-            <p class="question"><code><var>fraction( N1, D1 )</var> - <var>fraction( N2, D2 )</var> = {?}</code></p>
-            <p class="solution" data-type="rational"><var>N1 / D1 - N2 / D2</var></p>
-        </div>
-    </div>
+                    <p><code>
+                        \qquad = \dfrac{\blue{<var>N1 * F1</var>} - 
+                        \green{<var>N2 * F2</var>}}{<var>LCM</var>}
+                    </code></p>
 
-    <div class="hints">
-        <div data-if="GCD1 !== 1 || GCD2 !== 1">
-            <p>Simplify each fraction.</p>
-            <p><code><var>fraction( SIMP_N1, SIMP_D1 )</var> - <var>fraction( SIMP_N2, SIMP_D2 )</var></code></p>
+                    <p><code>\qquad = <var>fraction(F1 * N1 - F2 * N2, LCM)</var></code></p>
+
+                    <div data-if="getGCD(F1 * N1 - F2 * N2, LCM) !== 1">
+                        <p>Simplify.</p>
+                        <p><code>\qquad = <var>fractionReduce(F1 * N1 + F2 * N2, LCM)</var></code></p>
+                    </div>
+                </div>
+            </div>
         </div>
-        <p>Find a common denominator by finding the least common multiple of <code><var>SIMP_D1</var></code> and <code><var>SIMP_D2</var></code>.</p>
-        <p><code>\lcm(<var>SIMP_D1</var>, <var>SIMP_D2</var>) = <var>LCM</var></code></p>
-        <div>
-            <p>Change each fraction to an equivalent fraction with a denominator of <code><var>LCM</var></code>.</p>
-            <p><code><var>fraction( SIMP_N1, SIMP_D1 )</var> - <var>fraction( SIMP_N2, SIMP_D2 )</var></code></p>
-            <p><code>=<var>fraction( SIMP_N1, SIMP_D1 )</var> <span data-if="LCM !== SIMP_D1">\cdot <var>fraction( LCM / SIMP_D1, LCM / SIMP_D1 )</var></span> - <var>fraction( SIMP_N2, SIMP_D2 )</var> <span data-if="LCM !== SIMP_D2">\cdot <var>fraction( LCM / SIMP_D2, LCM / SIMP_D2 )</var></span></code></p>
-        </div>
-        <p><code>=<var>fraction( SIMP_N1 * LCM / SIMP_D1, LCM )</var> - <var>fraction( SIMP_N2 * LCM / SIMP_D2, LCM )</var></code></p>
-        <p><code>=<var>fraction( SIMP_N1 * LCM / SIMP_D1 - SIMP_N2 * LCM / SIMP_D2, LCM )</var></code></p>
-        <div data-if="getGCD( SIMP_N1 * LCM / SIMP_D1 - SIMP_N2 * LCM / SIMP_D2, LCM ) !== 1">
-            <p>Simplify.</p>
-            <p><code>=<var>fractionReduce( SIMP_N1 * LCM / SIMP_D1 - SIMP_N2 * LCM / SIMP_D2, LCM )</var></code></p>
-        </div>
-    </div>
     </div>
 </body>
 </html>

--- a/utils/math.js
+++ b/utils/math.js
@@ -120,6 +120,9 @@ $.extend(KhanUtil, {
     primes: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
         47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97],
 
+    denominators: [2, 3, 4, 5, 6, 8, 10, 12, 100],
+    smallDenominators: [2, 3, 4, 5, 6, 8, 10, 12],
+
     getPrime: function() {
         return KhanUtil.primes[KhanUtil.rand(KhanUtil.primes.length)];
     },


### PR DESCRIPTION
Also change denominators to those suggested by common core (add these to math.util).
For: https://trello.com/c/X4Gwu72V/439-fractions-exercises
