### PR TITLE
Fix for "not showing" bug

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1077,9 +1077,9 @@ window.Khan = (function() {
         var typeOverride = userExercise.problemType,
             seedOverride = userExercise.seed;
 
-        exerciseId = userExercise.exerciseModel.name;
-        exerciseName = userExercise.exerciseModel.displayName;
-        exerciseFile = userExercise.exerciseModel.fileName;
+        var exerciseId = userExercise.exerciseModel.name,
+            exerciseName = userExercise.exerciseModel.displayName,
+            exerciseFile = userExercise.exerciseModel.fileName;
 
         function finishRender() {
             // Get all problems of this exercise type...


### PR DESCRIPTION
I believe it's a pernicious scoping problem because:
- it occurs rarely
- when it does occur, the competing exercise never reaches
  `debugLog("loading and rendering " + exid)` on line 1113
- despite not reaching the above, it manages to set `typeOverride` on
  line 1077

That is, there are two, almost simultaneous renders (say A and B). A sets its local `var typeOverride` then A sets the global `exerciseId`, then B sets its local `var typeOverride`, then B sets the global `exerciseId`, then A calls `startLoadingExercise(exerciseId,...)` with the global `exerciseId`, which was the one set by B.

The only time the global `exerciseId` should be set is in `setUserExercise`.

The real solution is to change the variable names so that global and local variables are confused with each other.

If you're interested, I can write more at length about it, but this was the gist.
