### PR TITLE
Fix for not-showing-bug

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1114,7 +1114,7 @@ window.Khan = (function() {
             $(Exercises).trigger("clearExistingProblem");
 
             // Generate a new problem
-            makeProblem(typeOverride, seedOverride);
+            makeProblem(typeOverride, seedOverride, exerciseId);
         }
 
         // Use a separate variable here because if exerciseID changes, we still
@@ -1184,7 +1184,7 @@ window.Khan = (function() {
                  $.trim(guess.join("").replace(/,/g, "")) === "");
     }
 
-    function makeProblem(id, seed) {
+    function makeProblem(id, seed, exerciseId) {
         debugLog("start of makeProblem");
 
         // Enable scratchpad (unless the exercise explicitly disables it later)
@@ -1208,7 +1208,9 @@ window.Khan = (function() {
         }
 
         if (typeof id !== "undefined") {
-            var problems = exercises.children(".problems").children();
+            var problems = exercises.filter(function() {
+                return exerciseId == null || $.data(this, "rootName") === exerciseId;
+            }).children(".problems").children();
 
             problem = /^\d+$/.test(id) ?
                 // Access a problem by number
@@ -1337,10 +1339,8 @@ window.Khan = (function() {
 
         debugLog("added inline styles");
 
-        // Get the filename of the currently shown exercise, then reset modules
-        // to only those required by the current exercise
-        var exerciseId = exercise.data("name");
-        Khan.resetModules(exerciseId);
+        // Reset modules to only those required by the current exercise
+        Khan.resetModules(exercise.data("name"));
 
         // Run the main method of any modules
         problem.runModules(problem, "Load");
@@ -1430,7 +1430,7 @@ window.Khan = (function() {
             // Making the problem failed, let's try again
             debugLog("validator was falsey");
             problem.remove();
-            makeProblem(id, randomSeed);
+            makeProblem(id, randomSeed, exerciseId);
             return;
         }
 


### PR DESCRIPTION
Fix for two different bugs: the first is similar to a previous bug (https://github.com/Khan/khan-exercises/pull/122815), and the second allows a more graceful fail for the not-showing-bug where the problem's type is `undefined`.  

For the first one, the variable `exercises` may contains multiple exercises with the same `id`, which causes problems when a core problem is expanded. For example, in issue https://github.com/Khan/khan-exercises/issues/129114, there is the id `multiple` in both divisibility_0.5 and comparing_fractions_2, so when it looks for the `original`, it sometimes can’t find it. The most straightfoward way to resolve the problem is to simply pass `exerciseId` in as a parameter to `makeProblem`.

For the second, if the `problem` is still null after checking for an `exerciseType` and the `problemBag`, try to fail gracefully  by creating a problem from the exerciseId. This presumes that `problems` contains problems with the `exerciseId`, but that is likely since all `undefined` not-showing-bugs contain an exercise which is loaded.

Also,
- Have all instances of `makeProblem` call with `exerciseId`
- Change variable name `id` to `exerciseType` for clarity
- Fix regular expression for inputs like “divisibility_0.5”, which used to be read as “5” because of the period (only caused errors in localMode).

Loose ends:
- makeProblem on line 1502 (“Hook out for exercise test runner”). I don't understand it.
- when not in localMode, problemBag is only called when `nextUserExercise` doesn’t contain a type. When does that happen? When/where/how does `readyForNextProblem` in interface.js get it's data?
