### PR TITLE
Going Bagless: changing out problemBag

### DIFF
--- a/exercises/permutations_1.html
+++ b/exercises/permutations_1.html
@@ -8,7 +8,7 @@
 <body>
     <div class="exercise">
         <div class="problems">
-            <div id="letters" data-weight="0.6">
+            <div id="letters" data-weight="3">
                 <div class="vars" data-ensure="WORD != PERM">
                     <var id="INDEX">randRange(0,11)</var>
                     <var id="WORD">["CLAW", "OPAL", "APE", "RULES", "ANGER", "SLIME", "FEAT", "FANCY", "SONG", "DEN", "TIGER", "IRON"][INDEX]</var>
@@ -42,7 +42,7 @@
                 </div>
             </div>
 
-            <div id="reindeer" data-weight="0.4">
+            <div id="reindeer" data-weight="2">
                 <div class="vars">
                     <var id="NUM_NAMES">randRange(4,5)</var>
                     <var id="NAMES">_.map(randRangeUnique(0,8,NUM_NAMES), function(n){

--- a/exercises/permutations_and_combinations_2.html
+++ b/exercises/permutations_and_combinations_2.html
@@ -34,7 +34,7 @@
 <body>
     <div class="exercise">
         <div class="problems">
-            <div id="letters" data-weight="0.4">
+            <div id="letters" data-weight="2">
                 <div class="vars" data-ensure="PERM !== WORD">
                     <var id="INDEX">randRange(0,7)</var>
                     <var id="WORD">["HATTER", "PRIOR", "BUMMED", "SASSY", "CANNON", "PLOP", "ERROR", "THAT"][INDEX]</var>
@@ -92,7 +92,7 @@
                 </div>
             </div>
 
-            <div id="reindeer" data-weight="0.2">
+            <div id="reindeer" data-weight="1">
                 <div class="vars" data-ensure="PAIR[0] != PAIR[1]">
                     <var id="NAMES">shuffle(["Bloopin", "Gloopin", "Prancer", "Lancer", "Quentin", "Balthazar", "Ezekiel", "Jebediah", "Rudy"],
                         randRange(4,5))</var>
@@ -165,7 +165,7 @@
                     </div>
                 </div>
             </div>
-            <div id="divisible" data-weight="0.4">
+            <div id="divisible" data-weight="2">
                 <div class="vars" data-ensure="getGCD(FAC1,FAC2) === 1">
                     <var id="FAC1">randRange(2,10)</var>
                     <var id="FAC2">randRange(2,10)</var>

--- a/exercises/pythagorean_theorem_2.html
+++ b/exercises/pythagorean_theorem_2.html
@@ -91,7 +91,7 @@
             </div>
         </div>
 
-        <div id="45-45-90-find-leg" data-weight="0.5">
+        <div id="45-45-90-find-leg">
             <div class="vars">
                 <var id="AB">2 * randRange( 2, 6 )</var>
             </div>
@@ -145,7 +145,7 @@
             </div>
         </div>
 
-        <div id="45-45-90-find-leg-2" data-weight="0.5">
+        <div id="45-45-90-find-leg-2">
             <div class="vars">
                 <var id="AB">2 * randRange( 2, 6 )</var>
             </div>
@@ -203,7 +203,7 @@
             </div>
         </div>
 
-        <div id="30-60-90-find-hypotenuse-given-short-leg">
+        <div id="30-60-90-find-hypotenuse-given-short-leg" data-weight="2">
             <div class="vars">
                 <var id="BC">randRange( 2, 6 )</var>
                 <var id="BCr, BCrs">randFromArray([ [1, ""], [3, "\\sqrt{3}"] ])</var>
@@ -263,7 +263,7 @@
             </div>
         </div>
 
-        <div id="30-60-90-find-hypotenuse-given-long-leg">
+        <div id="30-60-90-find-hypotenuse-given-long-leg" data-weight="2">
             <div class="vars">
                 <var id="AC">3 * randRange( 2, 6 )</var>
                 <var id="ACr, ACrs, ABs, AB">randFromArray([
@@ -328,7 +328,7 @@
             </div>
         </div>
 
-        <div id="30-60-90-find-short-leg-given-hypotenuse">
+        <div id="30-60-90-find-short-leg-given-hypotenuse" data-weight="2">
             <div class="vars">
                 <var id="BC">randRange( 2, 6 )</var>
                 <var id="BCr, BCrs">randFromArray([ [1, ""], [3, "\\sqrt{3}"] ])</var>
@@ -386,7 +386,7 @@
             </div>
         </div>
 
-        <div id="30-60-90-find-long-leg-given-hypotenuse">
+        <div id="30-60-90-find-long-leg-given-hypotenuse" data-weight="2">
             <div class="vars">
                 <var id="AC">3 * randRange( 2, 6 )</var>
                 <var id="ACr, ACrs, ABs, AB">randFromArray([

--- a/exercises/recognizing_fractions_0.5.html
+++ b/exercises/recognizing_fractions_0.5.html
@@ -59,41 +59,6 @@
                     <p>So your answer should be <code>\dfrac{\color{#e00}{<var>NUM_1</var>}}{\color{#000}{\text{<var>DEN_1</var>}}}</code>.</p>
                 </div>
             </div>
-
-            <div id="custom-1" data-type="pie-chart" data-weight="0">
-                <div class="vars">
-                    <var id="NUM_1">1</var>
-                    <var id="DEN_1">2</var>
-                </div>
-            </div>
-
-            <div id="custom-2" data-type="pie-chart" data-weight="0">
-                <div class="vars">
-                    <var id="NUM_1">1</var>
-                    <var id="DEN_1">4</var>
-                </div>
-            </div>
-
-            <div id="custom-6" data-type="pie-chart" data-weight="0">
-                <div class="vars">
-                    <var id="NUM_1">2</var>
-                    <var id="DEN_1">4</var>
-                </div>
-            </div>
-
-            <div id="custom-3" data-type="pie-chart" data-weight="0">
-                <div class="vars">
-                    <var id="NUM_1">1</var>
-                    <var id="DEN_1">5</var>
-                </div>
-            </div>
-
-            <div id="custom-4" data-type="pie-chart" data-weight="0">
-                <div class="vars">
-                    <var id="NUM_1">2</var>
-                    <var id="DEN_1">5</var>
-                </div>
-            </div>
         </div>
     </div>
 </body>

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1136,20 +1136,15 @@ window.Khan = (function() {
             }
 
         // Otherwise create a random problem from weights
-        } else if (typeof exerciseId !== "undefined") {
+        } else {
         	var typeIndex = [];
         	$.each(problems, function(index) {
+        		if ($(this).data("weight") === 0) return;
         		var weight = $(this).data("weight") || 1;
-        		_.times(weight, function(){typeIndex.push(index);});
+        		_.times(weight, function(){ typeIndex.push(index); });
         	});
         	problem = problems.eq(Math.floor(Math.random() * typeIndex.length));
-        	
-        	// var weightSum = typeIndex.length, jostler = weightSum % 3 ? 3 : 1;
-        	// problem = problems.eq(typeIndex[(jostler * problemNum) % weightSum]);
-
-        // No valid problem was found, bail out
-        } else {
-            return;
+        	id = $(problem).attr("id");
         }
 
         problemID = id;

--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -1137,14 +1137,15 @@ window.Khan = (function() {
 
         // Otherwise create a random problem from weights
         } else {
-        	var typeIndex = [];
-        	$.each(problems, function(index) {
-        		if ($(this).data("weight") === 0) return;
-        		var weight = $(this).data("weight") || 1;
-        		_.times(weight, function(){ typeIndex.push(index); });
-        	});
-        	problem = problems.eq(Math.floor(Math.random() * typeIndex.length));
-        	id = $(problem).attr("id");
+            var typeIndex = [];
+            $.each(problems, function(index) {
+                if ($(this).data("weight") === 0) return;
+                var weight = $(this).data("weight") || 1;
+                _.times(weight, function(){ typeIndex.push(index); });
+            });
+            id = Math.floor(Math.random() * typeIndex.length);
+            problem = problems.eq(id);
+            id = $(problem).attr("id") || "" + id;
         }
 
         problemID = id;


### PR DESCRIPTION
The problemBag is confusing (with respect to multiple problems being loaded), because it seems as though it is reloaded each time, making each draw random (with replacement) rather than shuffled (without replacement). If it’s not really important to be precise with the weighting (that of of 10 draws, something with probability .30 is chosen exactly three times), then the following suffices:

```
    problem = problems.eq(Math.floor(Math.random() * typeIndex.length));
```

To make the exercises compatible:
- Changed all exercises with `data-weight` equal to some decimal to the corresponding integer.
- Deleted some exercises with `data-weight=“0”` (https://github.com/Khan/khan-exercises/commit/ece572aa0a283b5de3149750aeaf0306bf1b16e0#commitcomment-4769554)
- Some exercises with `data-weight=“0”` used it as a template to reduce redundancy. Since this is clever, I added the one line necessary to allow it.
