### PR TITLE
Add domain requirement to simplifying rational expressions 4 when needed

### DIFF
--- a/exercises/simplifying_rational_expressions_4.html
+++ b/exercises/simplifying_rational_expressions_4.html
@@ -56,6 +56,7 @@
             <var id="TERM_FACTOR">NUM_FACTORa.getGCD(DEN_FACTORa)</var>
             <var id="NUM_FACTOR2">NUM_FACTORa.divide(TERM_FACTOR)</var>
             <var id="DEN_FACTOR2">DEN_FACTORa.divide(TERM_FACTOR)</var>
+            <var id="ZERONOTSOL">TERM_FACTOR.variables[X]</var>
 
             <var id="NUMERATOR_SOL">FACTOR_SIGN ? TERM1.multiply(NUM_FACTOR2).multiply(-1) : TERM1.multiply(NUM_FACTOR2)</var>
             <var id="DENOMINATOR_SOL">TERM3.multiply(DEN_FACTOR2)</var>
@@ -75,40 +76,49 @@
                         <span class="sol" data-type="regex"><var>NUMERATOR_SOL.regex(true)</var></span>
                         <span class="sol" data-type="regex"><var>DENOMINATOR_SOL.regex(true)</var></span>
                         <span class="sol" data-type="number"><var>-A</var></span>
+                        <span class="sol" data-type="number" data-if="ZERONOTSOL"><var>0</var></span>
                     </div>
                     <div class="set-sol" data-type="multiple">
                         <span class="sol" data-type="regex"><var>NUMERATOR_SOL.multiply(-1).regex(true)</var></span>
                         <span class="sol" data-type="regex"><var>DENOMINATOR_SOL.multiply(-1).regex(true)</var></span>
                         <span class="sol" data-type="number"><var>-A</var></span>
+                        <span class="sol" data-type="number" data-if="ZERONOTSOL"><var>0</var></span>
+                    </div>
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NUMERATOR_SOL.regex(true)</var></span>
+                        <span class="sol" data-type="regex"><var>DENOMINATOR_SOL.regex(true)</var></span>
+                        <span class="sol" data-type="number" data-if="ZERONOTSOL"><var>0</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
+                    </div>
+                    <div class="set-sol" data-type="multiple">
+                        <span class="sol" data-type="regex"><var>NUMERATOR_SOL.multiply(-1).regex(true)</var></span>
+                        <span class="sol" data-type="regex"><var>DENOMINATOR_SOL.multiply(-1).regex(true)</var></span>
+                        <span class="sol" data-type="number" data-if="ZERONOTSOL"><var>0</var></span>
+                        <span class="sol" data-type="number"><var>-A</var></span>
                     </div>
 
                     <div class="input-format">
                         <div class="entry" data-type="multiple">
-                            <table>
-                                <tbody><tr>
-                                    <td>
-                                        <code><var>Y</var> = </code>
-                                    </td>
-                                    <td><table>
-                                        <tbody><tr>
-                                            <td class="soln-top">
-                                                <span class="sol short50">a</span>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="soln-bot">
-                                                <span class="sol short50" data-fallback="1">a</span>
-                                            </td>
-                                        </tr>
-                                    </tbody></table></td>
-                                    <td>
-                                        <code> \space <var>X</var> \neq </code><span class="sol soln-dom short32">a</span>
-                                    </td>
+                            <table><tbody>
+                                <tr>
+                                    <td class="soln-name" rowspan="2"><code><var>Y</var> = </code></td>
+                                    <td class="soln-top"><span class="sol short50">a</span></td>
+                                </tr>
+                                <tr>
+                                    <td class="soln-bot"><span class="sol short50" data-fallback="1">a</span></td>
+                                </tr>
+                                <tr>
+                                    <td><code><var>X</var> \neq </code></td>
+                                    <td><span class="sol short50">a</span></td>
+                                </tr>
+                                <tr data-if="ZERONOTSOL">
+                                    <td><code><var>X</var> \neq </code></td>
+                                    <td><span class="sol short50">a</span></td>
                                 </tr>
                             </tbody></table>
                         </div>
                     </div>
-                    <div class="example">a simplifed expression, like <code>x + 2</code></div>
+                    <div class="example">an expression, like <code>x + 2</code></div>
                 </div>
             </div>
         </div>
@@ -133,7 +143,11 @@
                 <p><code>\qquad <var>Y</var> = <span data-if="FACTOR_SIGN">-</span>
                     <span data-if="!DEN_FACTOR2.isOne()">\dfrac{<var>NUM_FACTOR2</var>}{<var>DEN_FACTOR2</var>} \cdot </span>
                     <span data-else-if="!NUM_FACTOR2.isOne()"><var>NUM_FACTOR2</var> \cdot </span>
-                    \dfrac{<var>NUMERATOR.divide(NUM_FACTOR)</var>}{<var>DENOMINATOR.divide(DEN_FACTOR)</var>}</code></p>
+                    \dfrac{<var>NUMERATOR.divide(NUM_FACTOR)</var>}{<var>DENOMINATOR.divide(DEN_FACTOR)</var>}</code>
+                </p>
+                <p data-if="ZERONOTSOL">
+                    Since we are dividing by <code><var>X</var></code>, we must remember that <code><var>X</var> \neq 0</code>.
+                </p>
             </div>
 
             <p>Next factor the numerator and denominator.</p>
@@ -161,7 +175,9 @@
                     <span data-else=""><span data-if="FACTOR_SIGN">-</span><var>NUM_FACTOR2</var>(<var>TERM1</var>)</span>}{
                     <span data-if="DEN_FACTOR2.isOne()"><var>TERM3</var></span>
                     <span data-else=""><var>DEN_FACTOR2</var>(<var>TERM3</var>)</span>}</code>,
-                <code><var>X</var> \neq <var>-A</var></code></p>
+                    <code><var>X</var> \neq <var>-A</var></code>
+                    <span data-if="ZERONOTSOL">, <code><var>X</var> \neq 0</code></span>
+                </p>
             </div>
 
         </div>

--- a/exercises/simplifying_rational_expressions_4.html
+++ b/exercises/simplifying_rational_expressions_4.html
@@ -67,7 +67,6 @@
 
                 <p class="problem">
                     Simplify the following expression and state the condition under which the simplification is valid.
-                    You can assume that <code><var>X</var> \neq 0</code>.
                 </p>
                 <p class="question"><code><var>Y</var> = \dfrac{<var>NUMERATOR</var>}{<var>DENOMINATOR</var>}</code></p>
 


### PR DESCRIPTION
In reference to this issue: https://github.com/Khan/khan-exercises/pull/117850
When we divide by x, then there is an additional answer box that requires students to note that z != 0.
Possibly not the most elegant way to do it, but it seems to work.
