### PR TITLE
Updated moduleDependencies, "interactive" to reflect correct dependencies

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -208,7 +208,7 @@ var Khan = {
         "polynomials": ["math", "expressions"],
         "stat": ["math"],
         "word-problems": ["math"],
-        "interactive": ["graphie"],
+        "interactive": ["graphie", "knumber", "kvector", "kpoint", "kline"],
         "mean-and-median": ["stat"],
         "congruency": ["angles", "interactive"],
         "graphie": ["kpoint"],


### PR DESCRIPTION
Found that interactive.js had require() statements that did not match moduleDependencies:
    require("./graphie.js");
    var knumber = require("./knumber.js");
    var kvector = require("./kvector.js");
    var kpoint = require("./kpoint.js");
    var kline = require("./kline.js");
vs moduleDependencies:
    "interactive": ["graphie"]

Test Plan:
Used phantomjs (to load exercises containing the "interactive" module) and jquery (to compare the loaded page's <script> tags with Khan.modules to verify they were identical)

var module_name_reg = /^..\/utils\/(.*).js$/;
var modules = {};
$.each($('script'), function() {
    var src_tag = $(this).attr('src');

```
//if we have a src attribute in this <script>
if (src_tag) {
    var module_string = $(this).attr('src').match(module_name_reg);

    //if this tag contains a module of the form ../utils/<some module>.js
    //leave out "crc32" as does not belong in this list of modules and dependencies
    if ( module_string && module_string[1] !== 'crc32') {
        modules[module_string[1]] = true;
    }
}
```

});

return _.isEqual(modules, Khan.modules);

(note that the above code is a simplification of the entire process
 to load the page correctly as well as interrogate its variables.
 The changes proposed are so small that I have included them here only for reference)
