### PR TITLE
Updated khan-exercise to remove moduleDependencies

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -194,36 +194,6 @@ var Khan = {
 
     imageBase: imageBase,
 
-    // Inter-util dependencies. This map is currently necessary so that we
-    // can expose only the appropriate $.fn["module-nameLoad"] hooks used
-    // by each problem. Dependencies on third-party files need not be
-    // listed here.
-    // TODO(alpert): Now that these deps are now encoded in require()
-    // lines, find a way to remove this map.
-    moduleDependencies: {
-        "math": ["knumber"],
-        "exponents": ["math", "math-format"],
-        "kinematics": ["math"],
-        "math-format": ["math", "expressions"],
-        "polynomials": ["math", "expressions"],
-        "stat": ["math"],
-        "word-problems": ["math"],
-        "interactive": ["graphie", "knumber", "kvector", "kpoint", "kline"],
-        "mean-and-median": ["stat"],
-        "congruency": ["angles", "interactive"],
-        "graphie": ["kpoint"],
-        "graphie-3d": ["graphie", "kmatrix", "kvector"],
-        "graphie-geometry": ["graphie", "kmatrix", "kvector", "kline"],
-        "graphie-helpers": ["math-format"],
-        "kmatrix": ["expressions"],
-        "chemistry": ["math-format"],
-        "kvector": ["knumber"],
-        "kpoint": ["kvector", "knumber"],
-        "kray": ["kpoint", "kvector"],
-        "kline": ["kpoint", "kvector"],
-        "constructions": ["kmatrix"]
-    },
-
     warnTimeout: function() {
         $(Exercises).trigger("warning", [$._("Your internet might be too " +
                 "slow to see an exercise. Refresh the page or " +
@@ -267,29 +237,27 @@ var Khan = {
         return mods;
     },
 
-    resetModules: function(exerciseId) {
-        var modules = Khan.getBaseModules().concat(
-                Khan.exerciseModulesMap[exerciseId]);
+    /**
+    * parses <script> items from the DOM (placed there via require()) for
+    * module names to populate Khan.modules
+    */
+    resetModules: function() {
         var moduleSet = {};
+        //check each <script> in the DOM loaded by require()
+        $.each($("script[src]"), function() {
+            //capture the module name of this form:
+            //../utils/<moduleName>.js
+            var moduleName = $(this).attr('src').
+                match(/^\.\.\/utils\/(.*)\.js$/);
 
-        $.each(modules, function(i, mod) {
-            useModule(mod);
+            //leave out "crc32"
+            //as does not belong in this list of modules and dependencies
+            if ( moduleName && moduleName[1] !== "crc32") {
+                moduleSet[moduleName[1]] = true;
+            }
         });
 
         Khan.modules = moduleSet;
-
-        function useModule(modNameOrObject) {
-            if (typeof modNameOrObject === "string") {
-                moduleSet[modNameOrObject] = true;
-                var deps = Khan.moduleDependencies[modNameOrObject] || [];
-
-                $.each(deps, function(i, mod) {
-                    useModule(mod);
-                });
-            } else if (modNameOrObject.name) {
-                moduleSet[modNameOrObject.name] = true;
-            }
-        }
     },
 
     loadLocalModeSiteWhenReady: function() {
@@ -1131,7 +1099,7 @@ function makeProblem(exerciseId, typeOverride, seedOverride) {
     debugLog("added inline styles");
 
     // Reset modules to only those required by the current exercise
-    Khan.resetModules(exerciseId);
+    Khan.resetModules();
 
     // Run the main method of any modules
     problem.runModules(problem, "Load");


### PR DESCRIPTION
Inspect <script> tags in the DOM to duplicate the functionality of resetModules, without having to maintain ModuleDependencies (as we depend on require() to traverse dependencies and fully populate the DOM with loaded modules).

Full Summary:

Can't we just use require() to find out what its loaded?

By the first time we call resetModules (and thus use moduleDependencies) require()'s data structures are not populated sufficiently to query them for the state of loaded modules.

Specifically "require.s.contexts._.defined" and require.defined() or require.specified()

http://stackoverflow.com/questions/11756483/require-js-access-all-loaded-modules/19043564#19043564      http://stackoverflow.com/questions/14851541/with-requirejs-is-it-possible-to-check-if-a-module-is-defined-without-attempting/14864434#14864434

Simple testing via Chrome's debugger and breakpoints just before the call to resetModules() confirms this.

I manually confirmed that the <script> tags present in the DOM contained references to all modules needed by the page are present (if not loaded) at this point.

See also my question on the forums:
https://groups.google.com/forum/#!topic/requirejs/90Y5D9sJhmw

Why don't we call resetModules() with an exerciseId anymore?

We don't need to use exerciseModulesMap as we lift the data-require modules included with require() directly from the DOM.  And thus the call to resetModules() does not require exerciseID as an argument in its calls and has been removed.

Test Plan:

See: https://github.com/pjmattingly/page_load

In short:
    We load the page with PhantomJS.
    We track each resource requested via onResourceRequested
    We similarly track their error or receipt via: onResourceError & onResourceReceived respectively
        see: http://phantomjs.org/api/webpage/
    Once we've accounted for each resource we use the onLoadFinished event handler to execute a callback to query the finished page for its variables

In its current state the ad hoc testing I've created isn't ready for integration into a testing suite, but was useful in validating these results.

This idea comes from an outline from the fine folks over at smumug.com and their own struggles with Phantom:
http://sorcery.smugmug.com/2013/12/17/using-phantomjs-at-scale/

So we simply encapsulate the proposed changes in a call back and then run it against the loaded page (specifically comparing to Khan.modules) to verify the results are identical.

(And since we already have underscore loaded on the page we can use its isEqual() function [http://underscorejs.org/#isEqual] to compare Khan.modules to our proposed changes, rather than any ad hoc object comparison solution)
(I automated the test with NodeUnit such that all exercises were compared to verify the modified code produced identical results)
