### PR TITLE
Updated khan-exercise to fix dependencies in 'congruency' utility

### DIFF
--- a/khan-exercise.js
+++ b/khan-exercise.js
@@ -210,7 +210,7 @@ var Khan = {
         "word-problems": ["math"],
         "interactive": ["graphie", "knumber", "kvector", "kpoint", "kline"],
         "mean-and-median": ["stat"],
-        "congruency": ["angles", "interactive"],
+        "congruency": ["angles", "interactive", "graphie-helpers"],
         "graphie": ["kpoint"],
         "graphie-3d": ["graphie", "kmatrix", "kvector"],
         "graphie-geometry": ["graphie", "kmatrix", "kvector", "kline"],


### PR DESCRIPTION
Found a discrepancy in utils/congruency.js.  The require() statements:

require("./angles.js");
require("./interactive.js");
require("./graphie-helpers.js");

did not match the dependencies in moduleDependencies from khan-exercises.js:

"congruency": ["angles", "interactive"],

Thus failing to populate Khan.modules with:

expressions
graphie-helpers
math-format

This bug shows in exercises/congruent_angles.html, when we compare Khan.modules to what moduleDependencies / resetModules would produce.

Found when doing unit tests in preparation for pushing:
https://github.com/pjmattingly/khan-exercises/tree/add_page_load

(end-to-end tests on exercises)
