### PR TITLE
Changing kline.equal() to strict collinearity check.

### DIFF
--- a/test/kline.js
+++ b/test/kline.js
@@ -39,4 +39,10 @@
         start();
     });
 
+    asyncTest('Two line segments that do not inersect and are not collinear, not equal', 1, function() {
+        var result = line.equal([[3, 4], [5, 11]], [[5, 6], [9, 5]]);
+        strictEqual(result, false);
+        start();
+    });
+
 })();

--- a/utils/kline.js
+++ b/utils/kline.js
@@ -24,23 +24,44 @@ var kline = KhanUtil.kline = {
         ];
     },
 
+    /**
+    * Tests if two lines are collinear.
+    * https://en.wikipedia.org/wiki/Collinearity
+    */
     equal: function(line1, line2, tolerance) {
-        // TODO (jack): A nicer implementation might just check collinearity of
-        // vectors using underscore magick
-        // Compare the directions of the lines
-        var v1 = kvector.subtract(line1[1],line1[0]);
-        var v2 = kvector.subtract(line2[1],line2[0]);
-        if (!kvector.collinear(v1, v2, tolerance)) {
-            return false;
+        var DEFAULT_TOLERANCE = 1e-9;
+
+        if (!tolerance) {
+            tolerance = DEFAULT_TOLERANCE;
         }
-        // If the start point is the same for the two lines, then they are the same
-        if (kpoint.equal(line1[0], line2[0])) {
-            return true;
-        }
-        // Make sure that the direction to get from line1 to
-        // line2 is the same as the direction of the lines
-        var line1ToLine2Vector = kvector.subtract(line2[0], line1[0]);
-        return kvector.collinear(v1, line1ToLine2Vector, tolerance);
+
+        /**
+        * line1's points are trivially collinear.
+        * So check against each point in line2.
+        * Form a triangle of the points (line1 and a single point from line2)
+        * iff the area of the triangle is zero, are the points collinear
+        * http://mathworld.wolfram.com/Collinear.html
+        */
+        var x1 = line1[0][0];
+        var y1 = line1[0][1];
+        var x2 = line1[1][0];
+        var y2 = line1[1][1];
+        return _.every(line2, function(dim) {
+            var x3 = dim[0];
+            var y3 = dim[1];
+            
+            //calculating area of triangle formed by the three points
+            //https://en.wikipedia.org/wiki/Shoelace_formula#Examples
+            //A = 1/2|x1*y2 + x2*y3 + x3*y1 - x2*y1 - x3*y2 - x1*y3|
+            var area = (1/2)*Math.abs(x1*y2 + x2*y3 + x3*y1 -
+                x2*y1 - x3*y2 - x1*y3);
+            
+            if (area === 0 || area < tolerance) {
+                return true;
+            } else {
+                return false;
+            }
+        });
     },
 
     intersect: function(px, py, rx, ry, qx, qy, sx, sy) {

--- a/utils/kline.js
+++ b/utils/kline.js
@@ -6,6 +6,7 @@ define(function(require) {
 
 var kpoint = require("./kpoint.js");
 var kvector = require("./kvector.js");
+var knumber = require("./knumber.js");
 
 var kline = KhanUtil.kline = {
 
@@ -29,12 +30,6 @@ var kline = KhanUtil.kline = {
     * https://en.wikipedia.org/wiki/Collinearity
     */
     equal: function(line1, line2, tolerance) {
-        var DEFAULT_TOLERANCE = 1e-9;
-
-        if (!tolerance) {
-            tolerance = DEFAULT_TOLERANCE;
-        }
-
         /**
         * line1's points are trivially collinear.
         * So check against each point in line2.
@@ -46,21 +41,17 @@ var kline = KhanUtil.kline = {
         var y1 = line1[0][1];
         var x2 = line1[1][0];
         var y2 = line1[1][1];
-        return _.every(line2, function(dim) {
-            var x3 = dim[0];
-            var y3 = dim[1];
+        return _.every(line2, function(point) {
+            var x3 = point[0];
+            var y3 = point[1];
             
             //calculating area of triangle formed by the three points
             //https://en.wikipedia.org/wiki/Shoelace_formula#Examples
             //A = 1/2|x1*y2 + x2*y3 + x3*y1 - x2*y1 - x3*y2 - x1*y3|
             var area = (1/2)*Math.abs(x1*y2 + x2*y3 + x3*y1 -
                 x2*y1 - x3*y2 - x1*y3);
-            
-            if (area === 0 || area < tolerance) {
-                return true;
-            } else {
-                return false;
-            }
+
+            return knumber.equal(area, 0, tolerance);
         });
     },
 


### PR DESCRIPTION
We can check for collinearity by forming a triangle of three of the points of the line segments under considerations.  Since line1's points are trivially collinear, we can test its points against each of line2's points one at a time.  If any of the points are not collinear then the line segments are not collinear.

Ref: http://mathworld.wolfram.com/Collinear.html

We do this by the "ShoeLace Formula", which calculates the area of a polygon defined by ordered pairs of points.  The triangle was the simplest and so is implemented here.

Why not use the formula for a 4 sided polygon and do it in one step?

Because the ordering of the pairs matters.
It appears that the formula assumes that the pairs of points will be given such that they define the perimeter of the figure.  We cannot give an unordered set of points and expect an accurate result.  Since ordering the points such that they would define a polygon would require some sort of sorting algorithm in addition, this was deemed needlessly complex and a simple loop with _.every() was used instead.

Ref: https://en.wikipedia.org/wiki/Shoelace_formula#Examples

Also this has the added benefit of extensibility, as to examine then N lines to verify collinearity would be a simple matter of:

equal: function(lines*) {
    ...
    _.every(_.flatten(arguments, true), function(dim) {
        ...

We can extract a list of lists from arguments, then compare them to line1 to verify if all such points are collinear, etc.

Added an extra test with semi-random values to verify.
