### PR TITLE
Exercises: fix broken logo URL in header

### DIFF
--- a/exercises/khan-site.html
+++ b/exercises/khan-site.html
@@ -18,7 +18,7 @@
                 </span>
             </nav>
             <a href="http://khanacademy.org/" id="header-logo" data-tag="Header" title="Take me home!">
-                <img src="https://khan-academy.appspot.com/images/ka-simplified-logo-white.png">
+                <img src="http://api-explorer.khanacademy.org/static/img/ka-simplified-logo-white.png">
             </a>
         </div>
     </div>


### PR DESCRIPTION
Started building some exercises and noticed the header logo was 404ing.  Poked around a bit in Google and the appspot domain but couldn't find a white-lettered logo, so I found this one.

Side note:  is there a list somewhere of videos that do not have associated exercises?
