### PR TITLE
Change equal sign to approx if MEAN is rounded

### DIFF
--- a/exercises/standard_deviation_of_a_population.html
+++ b/exercises/standard_deviation_of_a_population.html
@@ -17,7 +17,7 @@
                 return randRange(1, lifespan);
             } )</var>
             <var id="MEAN">roundTo(1, mean(DATA))</var>
-            <var id="MEAN_IS_ROUNDED">mean(DATA) == MEAN ? false : true</var>
+            <var id="MEAN_IS_ROUNDED">mean(DATA) !== MEAN</var>
             <var id="SQR_DEV">$.map(DATA, function( x ) { return roundTo(2, (x - MEAN) * (x - MEAN)); })</var>
             <var id="VARIANCE">roundTo(2, sum(SQR_DEV) / (DATA_POINTS - 1))</var>
             <var id="VARIANCE_POP">roundTo(2, sum(SQR_DEV) / DATA_POINTS)</var>

--- a/exercises/standard_deviation_of_a_population.html
+++ b/exercises/standard_deviation_of_a_population.html
@@ -17,6 +17,7 @@
                 return randRange(1, lifespan);
             } )</var>
             <var id="MEAN">roundTo(1, mean(DATA))</var>
+            <var id="MEAN_IS_ROUNDED">mean(DATA) == MEAN ? false : true</var>
             <var id="SQR_DEV">$.map(DATA, function( x ) { return roundTo(2, (x - MEAN) * (x - MEAN)); })</var>
             <var id="VARIANCE">roundTo(2, sum(SQR_DEV) / (DATA_POINTS - 1))</var>
             <var id="VARIANCE_POP">roundTo(2, sum(SQR_DEV) / DATA_POINTS)</var>
@@ -69,7 +70,7 @@
 
                     <p><code>
                         \blue{\mu} \quad = \quad
-                        \dfrac{<var>plus.apply(KhanUtil, DATA)</var>}{\green{<var>DATA_POINTS</var>}} \quad = \quad
+                        \dfrac{<var>plus.apply(KhanUtil, DATA)</var>}{\green{<var>DATA_POINTS</var>}} \quad <var>MEAN_IS_ROUNDED ? '\\approx' : '=' </var> \quad
                         \blue{<var>MEAN</var>\text{ <var>YEARS_OLD</var>}}
                     </code></p>
 


### PR DESCRIPTION
I think that this fixes issue #161493. 
In case the MEAN is rounded, \approx symbol should be used instead of "=".
