### PR TITLE
Graphing inequalities 2 without choosing an answer

### DIFF
--- a/exercises/graphing_inequalities_2.html
+++ b/exercises/graphing_inequalities_2.html
@@ -185,7 +185,7 @@
                     <ul>
                         <li>
                             <label>
-                                <input id="yes" checked name="isSolution" type="radio">
+                                <input id="yes" name="isSolution" type="radio">
                                 <span>Yes</span>
                             </label>
                         </li>
@@ -206,7 +206,7 @@
                         $("input[name='isSolution']:checked").attr("id")]
                     </div>
                     <div class="validator-function">
-                        if (_.isEqual(guess, [[-5, 5], [5, 5], false, true])) {
+                        if (_.isEqual(guess.slice(0, 4), [[-5, 5], [5, 5], false, true]) || guess[4] === null) {
                             return "";
                         }
 


### PR DESCRIPTION
With a bit of zoom the point choice below the graph is not visible, thus it's easy to click through leaving the default "Yes" selected (be it right or wrong).

Removing the default checked state and making the validator function return an empty string when it should seems to be a good start. The exercise still gets marked wrong though, so I guess the empty string return is not functional at the moment. Further, it would be nice to be able to show an orange frame surrounding the choices if the user does not select anything.
