### PR TITLE
Multiple question with a single custom item without answer

### DIFF
--- a/exercises/graphing_inequalities_2.html
+++ b/exercises/graphing_inequalities_2.html
@@ -185,7 +185,7 @@
                     <ul>
                         <li>
                             <label>
-                                <input id="yes" checked name="isSolution" type="radio">
+                                <input id="yes" name="isSolution" type="radio">
                                 <span>Yes</span>
                             </label>
                         </li>
@@ -206,7 +206,7 @@
                         $("input[name='isSolution']:checked").attr("id")]
                     </div>
                     <div class="validator-function">
-                        if (_.isEqual(guess, [[-5, 5], [5, 5], false, true])) {
+                        if (_.isEqual(guess.slice(0, 4), [[-5, 5], [5, 5], false, true]) || guess[4] === null) {
                             return "";
                         }
 

--- a/test/answer-types.js
+++ b/test/answer-types.js
@@ -839,6 +839,32 @@
         start();
     });
 
+    asyncTest("multiple with a single custom item", 9, function() {
+        setupSolutionArea();
+        var $problem = jQuery("#qunit-fixture .problem").append(
+            "<div class='solution' data-type='multiple'>" +
+                "<div class='instruction'>" +
+                    "<input type='text' id='custom-input'>" +
+                "</div>" +
+                "<div class='sol' data-type='custom'>" +
+                    "<div class='guess'>[$('#custom-input').val()]</div>" +
+                    "<div class='validator-function'>" +
+                        "return guess[0] == 'empty' ? '' : guess[0] == 5;" +
+                    "</div>" +
+                "</div>" +
+            "</div>"
+        );
+
+        var answerData = Khan.answerTypes.multiple.setup($("#solutionarea"),
+                $problem.children(".solution"));
+
+        testMultipleAnswer(answerData, ["5"], "right", "right answer is right");
+        testMultipleAnswer(answerData, ["empty"], "empty", "empty answer is empty");
+        testMultipleAnswer(answerData, ["1"], "wrong", "wrong answer is wrong");
+
+        start();
+    });
+
     asyncTest("set with no things", 15, function() {
         setupSolutionArea();
         var $problem = jQuery("#qunit-fixture .problem").append(

--- a/test/answer-types.js
+++ b/test/answer-types.js
@@ -1011,6 +1011,29 @@
         start();
     });
 
+    asyncTest("custom", 9, function() {
+        setupSolutionArea();
+        var $problem = jQuery("#qunit-fixture .problem").append(
+            "<div class='solution' data-type='custom'>" +
+                "<div class='instruction'>" +
+                    "<input type='text' id='custom-input'>" +
+                "</div>" +
+                "<div class='guess'>$('#custom-input').val()</div>" +
+                "<div class='validator-function'>" +
+                    "return guess == 'empty' ? '' : guess == 5;" +
+                "</div>" +
+            "</div>"
+        );
+
+        var answerData = Khan.answerTypes.custom.setup($("#solutionarea"),
+                $problem.children(".solution"));
+
+        testAnswer(answerData, "5", "right", "right answer is right");
+        testAnswer(answerData, "empty", "empty", "empty answer is empty");
+        testAnswer(answerData, "1", "wrong", "wrong answer is wrong");
+
+        start();
+    });
 
     asyncTest("prime factorization", 24, function() {
         setupSolutionArea();

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1221,9 +1221,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                         score.empty = score.empty && pass.empty;
                         score.correct = score.correct && pass.correct;
                         // TODO(eater): This just forwards one message
-                        if (!score.message && pass.message) {
-                            score.message = pass.message;
-                        }
+                        score.message = score.message || pass.message;
                     }
                 });
 
@@ -1879,7 +1877,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                     return {
                         empty: pass === "",
                         correct: pass === true,
-                        message: typeof pass === "string" ? pass : null,
+                        message: typeof pass === "string" && pass !== "" ? pass : null,
                         guess: guess
                     };
                 }

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1221,7 +1221,7 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                         score.empty = score.empty && pass.empty;
                         score.correct = score.correct && pass.correct;
                         // TODO(eater): This just forwards one message
-                        if (pass.message) {
+                        if (!score.message && pass.message) {
                             score.message = pass.message;
                         }
                     }

--- a/utils/answer-types.js
+++ b/utils/answer-types.js
@@ -1216,11 +1216,14 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                         // otherwise correct or not before forwarding on the
                         // message.
                         blockGradingMessage = pass.message;
+                        score.empty = false;
                     } else {
                         score.empty = score.empty && pass.empty;
                         score.correct = score.correct && pass.correct;
                         // TODO(eater): This just forwards one message
-                        score.message = score.message || pass.message;
+                        if (pass.message) {
+                            score.message = pass.message;
+                        }
                     }
                 });
 
@@ -1232,7 +1235,6 @@ Khan.answerTypes = $.extend(Khan.answerTypes, {
                         guess: guess
                     };
                 } else {
-                    score.empty = false;
                     return score;
                 }
             };


### PR DESCRIPTION
Second try at #161538.

When a multiple-type problem contains a single custom item, and the user clicks "check answer" without doing anything (thus the custom validator function likely returns an empty string) with the change KE says that there are parts of the problem left to answer rather than grading as incorrect.

For reference, the changed piece of code was introduced in https://github.com/Khan/khan-exercises/commit/d4288dbbad5400d9315454a271d1d4e5063d3dd9. There are couple of custom-in-multiple exercises, namely:
- basic_set_notation.html,
- ellipse_intuition.html,
- graphing_inequalities_2.html,
- graphing_points_2.html,
- graphing_systems_of_equations.html,
- graphing_systems_of_inequalities.html,
- hyperbola_intuition.html,
- parabola_intuition_3.html,
- unit_circle.html,
- visualizing_derivatives.html.

(Note: A few of these contain more than a single custom item -- see below.)

This is pretty minor, not sure if it's worth the time for reviewing, testing, etc. given the status of the legacy KE -- feel tree to close it altogether if that's the case. On the other hand, the multiple-kind exercise currently considers a guess (answer) empty (that is unanswered) only if all its parts are empty (rather than any one of its parts). This seems neither convenient nor consistent with the new framework. Should we change it?
