### PR TITLE
Fixes for the hyperbola intuition exercise

### DIFF
--- a/exercises/hyperbola_intuition.html
+++ b/exercises/hyperbola_intuition.html
@@ -20,7 +20,7 @@
 
                 <div class="question">
                     <p>The equation of a north-south opening hyperbola is :<br/>
-                        <code>\qquad \dfrac{(x - x_1)^2}{b^2} - \dfrac{(y - y_1)^2}{a^2} = 1</code>.
+                        <code>\qquad \dfrac{(y - y_1)^2}{a^2} - \dfrac{(x - x_1)^2}{b^2} = 1</code>.
                     </p>
                     <p>
                         Find the foci of the hyperbola below by moving the orange points to their correct positions.

--- a/exercises/hyperbola_intuition.html
+++ b/exercises/hyperbola_intuition.html
@@ -191,9 +191,9 @@
                     <var id="A, B, C">randFromArray([[3, 4, 5], [6, 8, 10], [9, 12, 15], [5, 12, 13]])</var>
                     <var id="A2">A * A</var>
                     <var id="B2">B * B</var>
-                    <var id="MAX_Y">18 - C</var>
-                    <var id="H">randRange(-5, 5)</var>
-                    <var id="K">randRange(-MAX_Y, MAX_Y)</var>
+                    <var id="MAX_X">18 - C</var>
+                    <var id="H">randRange(-MAX_X, MAX_X)</var>
+                    <var id="K">randRange(-5, 5)</var>
                 </div>
 
                 <div class="question">
@@ -258,12 +258,12 @@
                         $("#problemarea span.focus2-y-label").html("&lt;code&gt;" + coordY + "&lt;/code&gt;").tex();
                     };
 
-                    graph.func1 = addInteractiveFn(function(x) {
-                        return K + sqrt(A2 / B2 * (x - H) * (x - H) + A2);
+                    graph.func1 = addInteractiveFn(function(y) {
+                        return H + sqrt(A2 / B2 * (y - K) * (y - K) + A2);
                     }, { swapAxes: true });
 
-                    graph.func2 = addInteractiveFn(function(x) {
-                        return K - sqrt(A2 / B2 * (x - H) * (x - H) + A2);
+                    graph.func2 = addInteractiveFn(function(y) {
+                        return H - sqrt(A2 / B2 * (y - K) * (y - K) + A2);
                     }, { swapAxes: true });
 
                     doHyperbolaInteraction(graph.func1, graph.focus1, graph.focus2);
@@ -290,9 +290,9 @@
                                 return "";
                             }
 
-                            return guess[0][1] === H &amp;&amp; guess[1][1] === H &amp;&amp;
-                                (guess[0][0] === K - C &amp;&amp; guess[1][0] === K + C) ||
-                                (guess[0][0] === K + C &amp;&amp; guess[1][0] === K - C)
+                            return guess[0][1] === K &amp;&amp; guess[1][1] === K &amp;&amp;
+                                (guess[0][0] === H - C &amp;&amp; guess[1][0] === H + C) ||
+                                (guess[0][0] === H + C &amp;&amp; guess[1][0] === H - C)
                         </div>
                         <div class="show-guess">
                             graph.focus1.setCoord(guess[0]);
@@ -305,11 +305,11 @@
                         <table class="intuition-equation">
                             <tr>
                                 <td><code>x_1 = </code></td>
-                                <td><span class="sol short40" data-fallback="0"><var>K</var></span></td>
+                                <td><span class="sol short40" data-fallback="0"><var>H</var></span></td>
                             </tr>
                             <tr>
                                 <td><code>y_1 = </code></td>
-                                <td><span class="sol short40" data-fallback="0"><var>H</var></span></td>
+                                <td><span class="sol short40" data-fallback="0"><var>K</var></span></td>
                             </tr>
                             <tr>
                                 <td><code>a = </code></td>
@@ -329,15 +329,15 @@
                         There is only one way to arrange the two foci such that this is true.
                         <button onclick="javascript:
                             graph = KhanUtil.currentGraph.graph;
-                            graph.focus1.moveTo(graph.K + graph.C, graph.H);
-                            graph.focus2.moveTo(graph.K - graph.C, graph.H);
+                            graph.focus1.moveTo(graph.H + graph.C, graph.K);
+                            graph.focus2.moveTo(graph.H - graph.C, graph.K);
                         ">Show me</button>
                     </p>
-                    <p>One focus is <code>(<var>K - C</var>, <var>H</var>)</code> and the other is <code>(<var>K + C</var>, <var>H</var>)</code>.</p>
+                    <p>One focus is <code>(<var>H - C</var>, <var>K</var>)</code> and the other is <code>(<var>H + C</var>, <var>K</var>)</code>.</p>
                     <p><code>x_1</code> and <code>y_1</code> are the coordinates of the center of the hyperbola.</p>
                     <div>
                         <p>The center of a hyperbola is at the midpoint of its two foci.</p>
-                        <p><code>\left(\dfrac{<var>K - C</var> + <var>K + C</var>}{2}, \dfrac{<var>H</var> + <var>H</var>}{2}\right) = (<var>K</var>, <var>H</var>)</code></p>
+                        <p><code>\left(\dfrac{<var>H - C</var> + <var>H + C</var>}{2}, \dfrac{<var>K</var> + <var>K</var>}{2}\right) = (<var>H</var>, <var>K</var>)</code></p>
                     </div>
                     <p>The absolute value of the distance from one focus minus the distance to the other focus is equal to <code>2a</code></p>
                     <div>
@@ -359,7 +359,7 @@
                     </div>
                     <p>
                         So the equation of the hyperbola is
-                        <code>\dfrac{(x - <var>K</var>)^2}{<var>A</var>^2} - \dfrac{(y - <var>H</var>)^2}{<var>B</var>^2} = 1</code>.
+                        <code>\dfrac{(x - <var>H</var>)^2}{<var>A</var>^2} - \dfrac{(y - <var>K</var>)^2}{<var>B</var>^2} = 1</code>.
                     </p>
                 </div>
             </div>

--- a/exercises/hyperbola_intuition.html
+++ b/exercises/hyperbola_intuition.html
@@ -198,7 +198,7 @@
 
                 <div class="question">
                     <p>The equation of an east-west opening hyperbola is:<br/>
-                        <code>\qquad \dfrac{(x - x_1)^2}{b^2} - \dfrac{(y - y_1)^2}{a^2} = 1</code>.
+                        <code>\qquad \dfrac{(x - x_1)^2}{a^2} - \dfrac{(y - y_1)^2}{b^2} = 1</code>.
                     </p>
                     <p>
                         Find the foci of the hyperbola below by moving the orange points to their correct positions.
@@ -312,12 +312,12 @@
                                 <td><span class="sol short40" data-fallback="0"><var>H</var></span></td>
                             </tr>
                             <tr>
-                                <td><code>b = </code></td>
-                                <td><span class="sol short40"><var>B</var></span></td>
-                            </tr>
-                            <tr>
                                 <td><code>a = </code></td>
                                 <td><span class="sol short40"><var>A</var></span></td>
+                            </tr>
+                            <tr>
+                                <td><code>b = </code></td>
+                                <td><span class="sol short40"><var>B</var></span></td>
                             </tr>
                         </table>
                     </p>
@@ -359,7 +359,7 @@
                     </div>
                     <p>
                         So the equation of the hyperbola is
-                        <code>\dfrac{(x - <var>K</var>)^2}{<var>B</var>^2} - \dfrac{(y - <var>H</var>)^2}{<var>A</var>^2} = 1</code>.
+                        <code>\dfrac{(x - <var>K</var>)^2}{<var>A</var>^2} - \dfrac{(y - <var>H</var>)^2}{<var>B</var>^2} = 1</code>.
                     </p>
                 </div>
             </div>

--- a/exercises/hyperbola_intuition.html
+++ b/exercises/hyperbola_intuition.html
@@ -54,7 +54,7 @@
                     graph.H = H;
                     graph.K = K;
                     graph.C = C;
-                    
+
                     initAutoscaledGraph([[-20, 20], [-20, 20]], {});
                     addMouseLayer();
 
@@ -232,7 +232,7 @@
                     graph.H = H;
                     graph.K = K;
                     graph.C = C;
-                    
+
                     initAutoscaledGraph([[-20, 20], [-20, 20]], {});
                     addMouseLayer();
 
@@ -359,7 +359,7 @@
                     </div>
                     <p>
                         So the equation of the hyperbola is
-                        <code>\dfrac{(x - <var>H</var>)^2}{<var>B</var>^2} + \dfrac{(y - <var>K</var>)^2}{<var>A</var>^2} = 1</code>.
+                        <code>\dfrac{(x - <var>K</var>)^2}{<var>B</var>^2} - \dfrac{(y - <var>H</var>)^2}{<var>A</var>^2} = 1</code>.
                     </p>
                 </div>
             </div>

--- a/exercises/hyperbola_intuition.html
+++ b/exercises/hyperbola_intuition.html
@@ -2,7 +2,7 @@
 <html data-require="math math-format graphie interactive parabola-intuition">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Hyperbola and ellipse intuition</title>
+    <title>Hyperbola intuition</title>
     <script data-main="../local-only/main.js" src="../local-only/require.js"></script>
 </head>
 <body>
@@ -161,7 +161,7 @@
                         <p>The center of a hyperbola is at the midpoint of its two foci.</p>
                         <p><code>\left(\dfrac{<var>H</var> + <var>H</var>}{2}, \dfrac{<var>K+C</var> + <var>K-C</var>}{2}\right) = (<var>H</var>, <var>K</var>)</code></p>
                     </div>
-                    <p>The absolute value of the distance from one focus minus the distance to the other focus is equal to <code>2a</code></p>
+                    <p>The absolute value of the distance from one focus minus the distance to the other focus is equal to <code>2a</code>.</p>
                     <div>
                         <code>\qquad\begin{align*}
                             2a &amp;= <var>2 * A</var> \\
@@ -202,7 +202,7 @@
                     </p>
                     <p>
                         Find the foci of the hyperbola below by moving the orange points to their correct positions.
-                        Then use that information to find the values of <code>y_1</code>, <code>x_1</code>, <code>a</code> and <code>b</code>.
+                        Then use that information to find the values of <code>x_1</code>, <code>y_1</code>, <code>a</code> and <code>b</code>.
                     </p>
                 </div>
 
@@ -339,7 +339,7 @@
                         <p>The center of a hyperbola is at the midpoint of its two foci.</p>
                         <p><code>\left(\dfrac{<var>H - C</var> + <var>H + C</var>}{2}, \dfrac{<var>K</var> + <var>K</var>}{2}\right) = (<var>H</var>, <var>K</var>)</code></p>
                     </div>
-                    <p>The absolute value of the distance from one focus minus the distance to the other focus is equal to <code>2a</code></p>
+                    <p>The absolute value of the distance from one focus minus the distance to the other focus is equal to <code>2a</code>.</p>
                     <div>
                         <code>\qquad\begin{align*}
                             2a &amp;= <var>2 * A</var> \\


### PR DESCRIPTION
A few fixes:
- the title includes ellipse, but there are just two hyperbola problems in the file;
- the equation in the intro to the south-north case has signs flipped;
- the equation in the intro to the east-west case has axes swapped;
- the final hint in the east-west case gives an ellipse with center coordinates and axes swapped;

plus some minor readability improvements.

Some references:
- [Wiki](https://en.wikipedia.org/wiki/Hyperbola#Nomenclature_and_features), lists equations for both cases;
- [Mathworld](http://mathworld.wolfram.com/Hyperbola.html), derives the east-west case (equations 3-8);
- [EoM](https://www.encyclopediaofmath.org/index.php/Hyperbola), another one with the same notation for axes.

One possibility for testing is to copy the equation from the final hint to [Alpha](http://www.wolframalpha.com/input/?i=%28y%2B2%29^2%2F3^2+-+%28x-1%29^2%2F4^2%3D1). Clicking "Properties" gives foci, center etc.
