### PR TITLE
Fix package.json formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,12 @@
         "url": "http://creativecommons.org/licenses/by-nc-sa/3.0/"
     }
     ],
-
     "repository": {
         "type": "git",
         "url": "http://github.com/Khan/khan-exercises/"
     },
-
     "devDependencies": {
-        "jison" : "0.4.13",
+        "jison": "0.4.13",
         "cheerio": "0.19.0",
         "uglify-js": "2.4.20",
         "jshint": "2.7.0"


### PR DESCRIPTION
# Change
Removed unnecessary white spaces from `package.json`. The spaces caused git to detect a change in `package.json` everytime `npm install` is run to get the dependencies, since `npm` corrects the JSON file itself. Just an annoying little bug.