### PR TITLE
Don't always assume double arrows in graphInit()

### DIFF
--- a/utils/graphie.js
+++ b/utils/graphie.js
@@ -1107,7 +1107,7 @@ KhanUtil.createGraphie = function(el) {
         if (axes) {
 
             // this is a slight hack until <-> arrowheads work
-            if (axisArrows === "<->" || true) {
+            if (axisArrows === "<->" || axisArrows === true) {
                 this.style({
                     stroke: "#000000",
                     opacity: axisOpacity,


### PR DESCRIPTION
Summary: This if statement would always evaluate as true, which I'm pretty sure isn't what we want, though who knows what's out there that depends on this behavior :\

Test Plan:
1. Substate this into graphie-to-png
2. Run app.py in graphie-to-png
3. Go to http://localhost:5001/ and choose "1. Simple plot"
4. Change the `axisArrows: "<->"` line to `"->"` and `""` and regraph, seeing the correct axis arrows

Reviewers: aria, emily

Reviewed By: emily

Differential Revision: https://phabricator.khanacademy.org/D15861

(cherry picked from commit c992ca8ba0ec895da32d1db9c795f9cf6686a568)